### PR TITLE
EICNET-175: Apply patch to Group module to fix permissions checking.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
             }
         },
         "composer-exit-on-patch-failure": true,
+        "patches-file": "composer.patches.json",
         "enable-patching": true,
         "drupal-scaffold": {
             "locations": {

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -1,0 +1,7 @@
+{
+  "patches": {
+    "drupal/group": {
+      "2881769 - group/{group}/node/create uses the permissions of group/{group}/node/add": "https://www.drupal.org/files/issues/2020-10-01/2881769-22.patch"
+    }
+  }
+}


### PR DESCRIPTION
Patch for https://drupal.org/node/2881769.

This adds a separate patches file.