### PR TITLE
EICNET-310: Create block for homepage USP section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "php": ">=7.2",
         "composer/installers": "^1.5",
         "cweagans/composer-patches": "^1.0",
+        "drupal/block_content_permissions": "^1.10",
         "drupal/core": "^8.7",
         "drupal/core-composer-scaffold": "^8.8",
         "drupal/flag": "^4.0@beta",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5a9ce65162a1789f6eb38c499dc929d2",
+    "content-hash": "96903d6536685024c03676cdc0719f29",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2016,6 +2016,58 @@
             ],
             "abandoned": "roave/better-reflection",
             "time": "2020-10-27T21:46:55+00:00"
+        },
+        {
+            "name": "drupal/block_content_permissions",
+            "version": "1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/block_content_permissions.git",
+                "reference": "8.x-1.10"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/block_content_permissions-8.x-1.10.zip",
+                "reference": "8.x-1.10",
+                "shasum": "03cfd1ff8edb05ea0f953916b23ef7b3aed82ab4"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9"
+            },
+            "suggest": {
+                "drupal/block_region_permissions": "Block Region Permissions adds permissions for administering 'blocks' based on each theme's regions."
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.10",
+                    "datestamp": "1593975004",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                },
+                "patches_applied": {
+                    "2920739 - Allow accessing the \"Custom block library\" page without \"Administer blocks\" permission": "https://www.drupal.org/files/issues/2020-07-27/block_content_permissions-access_listing_page-2920739-38.patch"
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Joshua Roberson",
+                    "homepage": "https://www.drupal.org/u/joshuaroberson",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "Block Content Permissions adds permissions for administering 'block content types' and 'block content'.",
+            "homepage": "https://www.drupal.org/project/block_content_permissions",
+            "support": {
+                "source": "https://git.drupalcode.org/project/block_content_permissions",
+                "issues": "https://www.drupal.org/project/issues/block_content_permissions"
+            }
         },
         {
             "name": "drupal/core",

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -1,5 +1,8 @@
 {
   "patches": {
+    "drupal/block_content_permissions": {
+      "2920739 - Allow accessing the \"Custom block library\" page without \"Administer blocks\" permission": "https://www.drupal.org/files/issues/2020-07-27/block_content_permissions-access_listing_page-2920739-38.patch"
+    },
     "drupal/group": {
       "2881769 - group/{group}/node/create uses the permissions of group/{group}/node/add": "https://www.drupal.org/files/issues/2020-10-01/2881769-22.patch"
     }

--- a/config/sync/block_content.type.tiles_reference.yml
+++ b/config/sync/block_content.type.tiles_reference.yml
@@ -1,0 +1,10 @@
+uuid: 591c9496-4be9-4d7c-8ec4-966fb9d14f18
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: HC8NR3ddqsP6oH84mM2A_DkTKQEguUIFsv0SE8dk_BE
+id: tiles_reference
+label: 'Tiles reference'
+revision: 0
+description: ''

--- a/config/sync/core.entity_form_display.block_content.tiles_reference.default.yml
+++ b/config/sync/core.entity_form_display.block_content.tiles_reference.default.yml
@@ -1,0 +1,53 @@
+uuid: 9826c596-181e-4325-bf9d-1d09d4105c5a
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.tiles_reference
+    - field.field.block_content.tiles_reference.field_body
+    - field.field.block_content.tiles_reference.field_tiles_ref
+    - field.field.block_content.tiles_reference.field_title
+  module:
+    - text
+_core:
+  default_config_hash: gf3lGjvTzQ13dj7K_jKmXV9ZnfuPn058Hgy-FymhKGg
+id: block_content.tiles_reference.default
+targetEntityType: block_content
+bundle: tiles_reference
+mode: default
+content:
+  field_body:
+    weight: 27
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
+    region: content
+  field_tiles_ref:
+    weight: 28
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+  field_title:
+    weight: 26
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  info:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/config/sync/core.entity_view_display.block_content.tiles_reference.default.yml
+++ b/config/sync/core.entity_view_display.block_content.tiles_reference.default.yml
@@ -1,0 +1,43 @@
+uuid: e9b96479-10c7-42cc-9002-4474b429b8e6
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.tiles_reference
+    - field.field.block_content.tiles_reference.field_body
+    - field.field.block_content.tiles_reference.field_tiles_ref
+    - field.field.block_content.tiles_reference.field_title
+  module:
+    - text
+_core:
+  default_config_hash: GKv9zNYfUVAEOvd0poR0o0OAImSRyfj1QUVTDatFMs4
+id: block_content.tiles_reference.default
+targetEntityType: block_content
+bundle: tiles_reference
+mode: default
+content:
+  field_body:
+    weight: 1
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  field_tiles_ref:
+    weight: 2
+    label: hidden
+    settings:
+      view_mode: teaser
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+  field_title:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden: {  }

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -2,6 +2,7 @@ module:
   big_pipe: 0
   block: 0
   block_content: 0
+  block_content_permissions: 0
   breakpoint: 0
   config: 0
   contextual: 0
@@ -9,6 +10,8 @@ module:
   dblog: 0
   dynamic_page_cache: 0
   editor: 0
+  eic_block_type_tiles_reference: 0
+  eic_block_types: 0
   eic_blocks: 0
   eic_content: 0
   eic_content_story: 0

--- a/config/sync/field.field.block_content.tiles_reference.field_body.yml
+++ b/config/sync/field.field.block_content.tiles_reference.field_body.yml
@@ -1,0 +1,23 @@
+uuid: eff7f827-dcd2-4052-b99b-4af167f9dd1b
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.tiles_reference
+    - field.storage.block_content.field_body
+  module:
+    - text
+_core:
+  default_config_hash: vJhg2nkI1YtnYJP7vVdH1hkfwdqbZNKhHQD9mX49ZSc
+id: block_content.tiles_reference.field_body
+field_name: field_body
+entity_type: block_content
+bundle: tiles_reference
+label: Description
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/config/sync/field.field.block_content.tiles_reference.field_tiles_ref.yml
+++ b/config/sync/field.field.block_content.tiles_reference.field_tiles_ref.yml
@@ -1,0 +1,30 @@
+uuid: 31a79279-4e14-4a42-8dda-b2c73dbce725
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.tiles_reference
+    - field.storage.block_content.field_tiles_ref
+    - node.type.page
+_core:
+  default_config_hash: FrvtRJAmyOGPIRg1choNQbtiM2gewLfhMNH9ngkTM7M
+id: block_content.tiles_reference.field_tiles_ref
+field_name: field_tiles_ref
+entity_type: block_content
+bundle: tiles_reference
+label: Tiles
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      page: page
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.block_content.tiles_reference.field_title.yml
+++ b/config/sync/field.field.block_content.tiles_reference.field_title.yml
@@ -1,0 +1,21 @@
+uuid: 310e8ab8-0c8a-4c62-9abc-5c6e334289b2
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.tiles_reference
+    - field.storage.block_content.field_title
+_core:
+  default_config_hash: t1G7QzbCNV540RA1KtA2mrRQo8d2MEmqqmBdnFyi4Bg
+id: block_content.tiles_reference.field_title
+field_name: field_title
+entity_type: block_content
+bundle: tiles_reference
+label: Title
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.block_content.field_body.yml
+++ b/config/sync/field.storage.block_content.field_body.yml
@@ -1,0 +1,21 @@
+uuid: 27343333-c2e0-486f-8330-f397078c8553
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - text
+_core:
+  default_config_hash: oUTCiY1XbG52tFSENhaL1bA43IYeVketjCiUajheonw
+id: block_content.field_body
+field_name: field_body
+entity_type: block_content
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.block_content.field_tiles_ref.yml
+++ b/config/sync/field.storage.block_content.field_tiles_ref.yml
@@ -1,0 +1,22 @@
+uuid: 27d98678-6077-44a6-9558-a57962873824
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - node
+_core:
+  default_config_hash: G1vcnU_cKIBV87LG6Avg73hNXwijuYpioipmiVZeBG8
+id: block_content.field_tiles_ref
+field_name: field_tiles_ref
+entity_type: block_content
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.block_content.field_title.yml
+++ b/config/sync/field.storage.block_content.field_title.yml
@@ -1,0 +1,23 @@
+uuid: a8f02792-f553-40f1-95b6-89798527d1ed
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+_core:
+  default_config_hash: yegE14uuLFTlGV6vjedwDtDpSFKBNfc1nfMJGxFTTPQ
+id: block_content.field_title
+field_name: field_title
+entity_type: block_content
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/lib/modules/eic_block_types/config/install/field.storage.block_content.field_body.yml
+++ b/lib/modules/eic_block_types/config/install/field.storage.block_content.field_body.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - text
+id: block_content.field_body
+field_name: field_body
+entity_type: block_content
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/lib/modules/eic_block_types/config/install/field.storage.block_content.field_title.yml
+++ b/lib/modules/eic_block_types/config/install/field.storage.block_content.field_title.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+id: block_content.field_title
+field_name: field_title
+entity_type: block_content
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/lib/modules/eic_block_types/eic_block_types.info.yml
+++ b/lib/modules/eic_block_types/eic_block_types.info.yml
@@ -1,0 +1,6 @@
+name: EIC Block content
+type: module
+description: Provides block types for EIC Community Platform.
+package: European Innovation Council
+core: 8.x
+core_version_requirement: ^8 || ^9

--- a/lib/modules/eic_block_types/eic_block_types.module
+++ b/lib/modules/eic_block_types/eic_block_types.module
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * @file
+ * Primary module hooks for EIC Block content module.
+ *
+ * @DCG
+ * This file is no longer required in Drupal 8.
+ * @see https://www.drupal.org/node/2217931
+ */

--- a/lib/modules/eic_block_types/modules/eic_block_type_tiles_reference/config/install/block_content.type.tiles_reference.yml
+++ b/lib/modules/eic_block_types/modules/eic_block_type_tiles_reference/config/install/block_content.type.tiles_reference.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: tiles_reference
+label: 'Tiles reference'
+revision: 0
+description: ''

--- a/lib/modules/eic_block_types/modules/eic_block_type_tiles_reference/config/install/core.entity_form_display.block_content.tiles_reference.default.yml
+++ b/lib/modules/eic_block_types/modules/eic_block_type_tiles_reference/config/install/core.entity_form_display.block_content.tiles_reference.default.yml
@@ -1,0 +1,50 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.tiles_reference
+    - field.field.block_content.tiles_reference.field_body
+    - field.field.block_content.tiles_reference.field_tiles_ref
+    - field.field.block_content.tiles_reference.field_title
+  module:
+    - text
+id: block_content.tiles_reference.default
+targetEntityType: block_content
+bundle: tiles_reference
+mode: default
+content:
+  field_body:
+    weight: 27
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
+    region: content
+  field_tiles_ref:
+    weight: 28
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+  field_title:
+    weight: 26
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  info:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/lib/modules/eic_block_types/modules/eic_block_type_tiles_reference/config/install/core.entity_view_display.block_content.tiles_reference.default.yml
+++ b/lib/modules/eic_block_types/modules/eic_block_type_tiles_reference/config/install/core.entity_view_display.block_content.tiles_reference.default.yml
@@ -1,0 +1,40 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.tiles_reference
+    - field.field.block_content.tiles_reference.field_body
+    - field.field.block_content.tiles_reference.field_tiles_ref
+    - field.field.block_content.tiles_reference.field_title
+  module:
+    - text
+id: block_content.tiles_reference.default
+targetEntityType: block_content
+bundle: tiles_reference
+mode: default
+content:
+  field_body:
+    weight: 1
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  field_tiles_ref:
+    weight: 2
+    label: hidden
+    settings:
+      view_mode: teaser
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+  field_title:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden: {  }

--- a/lib/modules/eic_block_types/modules/eic_block_type_tiles_reference/config/install/field.field.block_content.tiles_reference.field_body.yml
+++ b/lib/modules/eic_block_types/modules/eic_block_type_tiles_reference/config/install/field.field.block_content.tiles_reference.field_body.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.tiles_reference
+    - field.storage.block_content.field_body
+  module:
+    - text
+id: block_content.tiles_reference.field_body
+field_name: field_body
+entity_type: block_content
+bundle: tiles_reference
+label: Description
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/lib/modules/eic_block_types/modules/eic_block_type_tiles_reference/config/install/field.field.block_content.tiles_reference.field_tiles_ref.yml
+++ b/lib/modules/eic_block_types/modules/eic_block_type_tiles_reference/config/install/field.field.block_content.tiles_reference.field_tiles_ref.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.tiles_reference
+    - field.storage.block_content.field_tiles_ref
+    - node.type.page
+id: block_content.tiles_reference.field_tiles_ref
+field_name: field_tiles_ref
+entity_type: block_content
+bundle: tiles_reference
+label: Tiles
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      page: page
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/lib/modules/eic_block_types/modules/eic_block_type_tiles_reference/config/install/field.field.block_content.tiles_reference.field_title.yml
+++ b/lib/modules/eic_block_types/modules/eic_block_type_tiles_reference/config/install/field.field.block_content.tiles_reference.field_title.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.tiles_reference
+    - field.storage.block_content.field_title
+id: block_content.tiles_reference.field_title
+field_name: field_title
+entity_type: block_content
+bundle: tiles_reference
+label: Title
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/lib/modules/eic_block_types/modules/eic_block_type_tiles_reference/config/install/field.storage.block_content.field_tiles_ref.yml
+++ b/lib/modules/eic_block_types/modules/eic_block_type_tiles_reference/config/install/field.storage.block_content.field_tiles_ref.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - node
+id: block_content.field_tiles_ref
+field_name: field_tiles_ref
+entity_type: block_content
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/lib/modules/eic_block_types/modules/eic_block_type_tiles_reference/eic_block_type_tiles_reference.info.yml
+++ b/lib/modules/eic_block_types/modules/eic_block_type_tiles_reference/eic_block_type_tiles_reference.info.yml
@@ -1,0 +1,8 @@
+name: EIC Block content tiles reference
+type: module
+description: Provides a block type to show Tiles of content pages.
+package: European Innovation Council
+core: 8.x
+core_version_requirement: ^8 || ^9
+dependencies:
+  - eic_block_types:eic_block_types

--- a/lib/modules/eic_block_types/modules/eic_block_type_tiles_reference/eic_block_type_tiles_reference.module
+++ b/lib/modules/eic_block_types/modules/eic_block_type_tiles_reference/eic_block_type_tiles_reference.module
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * @file
+ * Primary module hooks for EIC Block content tiles reference module.
+ *
+ * @DCG
+ * This file is no longer required in Drupal 8.
+ * @see https://www.drupal.org/node/2217931
+ */


### PR DESCRIPTION
### Notes

- Implementation of block type "Tiles reference";
- Install contrib module block_content_permissions.

### Installation procedures

- composer install
- Re-install platform

### Tests

- Go to -> /admin/content/block-content and add a new custom block;
- You should be able to see the expected fields to be filled in according to its definition in confluence;

### To do

- This block needs to be placed in the homepage. Although, we still need to define the approach for the homepage blocks.