### PR TITLE
EICNET-431: Adapt discussion content type (save button)

### DIFF
--- a/config/sync/node.type.discussion.yml
+++ b/config/sync/node.type.discussion.yml
@@ -14,5 +14,5 @@ type: discussion
 description: "The content type \"Discussion\" is designed to host a discussion that the author wants to launch. The discussion can start from a question or a more elaborate topic.\r\nOnce created and published, the discussion will occur through comments posted on the \"Discussion\" page "
 help: ''
 new_revision: true
-preview_mode: 2
+preview_mode: 1
 display_submitted: true


### PR DESCRIPTION
### Changes

- Make save button available from the start when creating a new discussion.

### Tests

- Try to create a new discussion content type and check if the save button is available from the start.