### PR TITLE
Make sure we skip the npm build too when appropriate.

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -35,7 +35,7 @@ COLOR_RED="\e[91m"
 BG_COLOR_DEFAULT="\e[49m"
 BG_COLOR_GREEN="\e[42m"
 DRUSH_CMD="../vendor/bin/drush"
-THEME_PATH="themes/custom/eic_community"
+THEME_PATH="web/themes/custom/eic_community"
 DEFAULT_CONTENT_MODULES="eic_default_content default_content hal serialization"
 
 # Define list of arguments expected in the input


### PR DESCRIPTION
I had trouble running the deploy script in mu local Lando setup, because the PHP service that runs the deploy script does not have npm available. When we do it like this, at least it answers to the existing skip build option as a workaround.