### PR TITLE
EICNET-559: Fix theme namespaces

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/content/node--page.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--page.inc
@@ -5,7 +5,7 @@
  * Prepares variables for node page template.
  */
 
-use Drupal\oe_theme\ValueObject\ImageValueObject;
+use Drupal\eic_community\ValueObject\ImageValueObject;
 
 /**
  * Implements hook_preprocess_node() for page node.

--- a/lib/themes/eic_community/templates/compositions/ec-component-navigation/local-tasks.html.twig
+++ b/lib/themes/eic_community/templates/compositions/ec-component-navigation/local-tasks.html.twig
@@ -1,0 +1,58 @@
+{#
+  Parameters:
+    - "title" (string) (default: 'Navigation'): for screen readers
+    - "links" (array) (default: []): collection of @ecl-twig/link
+    - "variant" (string) (default: 'primary'): type of local tasks
+    - "extra_classes" (string) (default: '')
+    - "extra_attributes" (array) (default: []): format: [
+        {
+          "name" (string) (default: ''),
+          "value" (string) (default: '')
+        },
+        ...
+      ]
+#}
+
+{# Internal properties #}
+
+{% set _title = title|default('Navigation') %}
+{% set _links = links|default([]) %}
+{% set _variant = variant|default('primary') %}
+{% set _css_class = 'ecl-navigation-list' %}
+{% set _extra_attributes = '' %}
+
+{# Internal logic - Process properties #}
+
+{% if _variant == 'primary' %}
+  {% set _list_class = ' ecl-u-pb-m ecl-u-type-bold' %}
+  {% set _list_item_class = ' ecl-u-pa-m' %}
+{% endif %}
+{% if _variant == 'secondary' %}
+  {% set _list_class = ' ecl-u-pb-s ecl-u-type-s' %}
+  {% set _list_item_class = ' ecl-u-pa-s' %}
+{% endif %}
+{% if extra_classes is not empty %}
+  {% set _css_class = _css_class ~ ' ' ~ extra_classes %}
+{% endif %}
+
+{% if extra_attributes is not empty %}
+  {% for attr in extra_attributes %}
+    {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value ~ '"' %}
+  {% endfor %}
+{% endif %}
+
+{# Print the result #}
+
+{% if _links is not empty %}
+  <nav class="{{ _css_class }}"{{ _extra_attributes|raw }}>
+    <h2 hidden>{{ _title }}</h2>
+    <ul class="ecl-navigation-list ecl-unordered-list--no-bullet ecl-u-border-bottom ecl-u-border-color-grey-25{{ _list_class }}">
+      {% for _link in _links %}
+        {% set _active_class = _link.is_active == true ? ' ecl-navigation-list__item--active ecl-u-border-bottom ecl-u-border-color-blue' : '' %}
+        <li class="ecl-navigation-list__item ecl-unordered-list__item ecl-u-d-inline{{ _list_item_class }}{{ _active_class }}">
+          {% include '@ecl-twig/link' with _link only %}
+        </li>
+      {% endfor %}
+    </ul>
+  </nav>
+{% endif %}

--- a/lib/themes/eic_community/templates/navigation/menu-local-tasks.html.twig
+++ b/lib/themes/eic_community/templates/navigation/menu-local-tasks.html.twig
@@ -8,6 +8,18 @@
 #}
 <div class="ecl-section-wrapper ecl-section-wrapper--has-compact-layout">
   <div class="ecl-container">
-    {% include "@oe_theme/navigation/menu-local-tasks.html.twig" %}
+    {% if primary %}
+      {% include '@eic_community/compositions/ec-component-navigation/local-tasks.html.twig' with {
+        title: 'Primary tabs'|t,
+        links: primary_links
+      } %}
+    {% endif %}
+    {% if secondary %}
+      {% include '@eic_community/compositions/ec-component-navigation/local-tasks.html.twig' with {
+        title: 'Secondary tabs'|t,
+        links: secondary_links,
+        variant: 'secondary'
+      } %}
+    {% endif %}
   </div>
 </div>


### PR DESCRIPTION
- Fix namespace used in hook eic_community_preprocess_node__page();
- Fix wrong namespace in template menu-local-tasks and add missing composition.