### PR TITLE
EICNET-384: Add field_related_groups to News content type

### DIFF
--- a/config/sync/core.entity_form_display.node.news.default.yml
+++ b/config/sync/core.entity_form_display.node.news.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.node.news.field_image_caption
     - field.field.node.news.field_introduction
     - field.field.node.news.field_news_paragraphs
+    - field.field.node.news.field_related_groups
     - field.field.node.news.field_related_stories
     - field.field.node.news.field_video
     - field.field.node.news.field_vocab_geo
@@ -110,6 +111,16 @@ content:
       form_display_mode: default
       default_paragraph_type: ''
     third_party_settings: {  }
+    region: content
+  field_related_groups:
+    weight: 32
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
     region: content
   field_related_stories:
     weight: 11

--- a/config/sync/core.entity_view_display.node.news.default.yml
+++ b/config/sync/core.entity_view_display.node.news.default.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.news.field_image_caption
     - field.field.node.news.field_introduction
     - field.field.node.news.field_news_paragraphs
+    - field.field.node.news.field_related_groups
     - field.field.node.news.field_related_stories
     - field.field.node.news.field_video
     - field.field.node.news.field_vocab_geo
@@ -107,6 +108,14 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
+    region: content
+  field_related_groups:
+    weight: 102
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
     region: content
   field_related_stories:
     weight: 12

--- a/config/sync/core.entity_view_display.node.news.teaser.yml
+++ b/config/sync/core.entity_view_display.node.news.teaser.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.news.field_image_caption
     - field.field.node.news.field_introduction
     - field.field.node.news.field_news_paragraphs
+    - field.field.node.news.field_related_groups
     - field.field.node.news.field_related_stories
     - field.field.node.news.field_video
     - field.field.node.news.field_vocab_geo
@@ -75,6 +76,7 @@ hidden:
   field_image: true
   field_image_caption: true
   field_news_paragraphs: true
+  field_related_groups: true
   field_related_stories: true
   field_video: true
   field_vocab_geo: true

--- a/config/sync/field.field.node.news.field_related_groups.yml
+++ b/config/sync/field.field.node.news.field_related_groups.yml
@@ -1,0 +1,28 @@
+uuid: a104ccea-134b-469e-a9cf-874672b4f20c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_related_groups
+    - group.type.group
+    - node.type.news
+id: node.news.field_related_groups
+field_name: field_related_groups
+entity_type: node
+bundle: news
+label: 'Related groups'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:group'
+  handler_settings:
+    target_bundles:
+      group: group
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.storage.node.field_related_groups.yml
+++ b/config/sync/field.storage.node.field_related_groups.yml
@@ -1,0 +1,20 @@
+uuid: de05f04e-f467-4afd-a7f1-3e631b6a181c
+langcode: en
+status: true
+dependencies:
+  module:
+    - group
+    - node
+id: node.field_related_groups
+field_name: field_related_groups
+entity_type: node
+type: entity_reference
+settings:
+  target_type: group
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
Currently added the field_related_groups as an autocomplete field instead of using Entity Browser and without private and restricted groups filtered out. Ludovic said the implementation Entity Browser part or something similar should be discussed more first and will be implemented later.