### PR TITLE
EICNET-611: Remove access permission from Group members overview

### DIFF
--- a/config/sync/views.view.group_overviews.yml
+++ b/config/sync/views.view.group_overviews.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - search_api.index.global
   module:
-    - group
     - profile
     - search_api
 id: group_overviews
@@ -409,9 +408,8 @@ display:
         groups:
           1: AND
       access:
-        type: group_permission
-        options:
-          group_permission: 'view group_membership content'
+        type: none
+        options: {  }
       sorts:
         user_field_full_name:
           id: user_field_full_name
@@ -442,10 +440,8 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
-        - route.group
         - url
         - url.query_args
-        - user.group_permissions
         - 'user.node_grants:view'
       tags:
         - 'config:search_api.index.global'


### PR DESCRIPTION
- Update Group members overview: remove required access permission (this is temporary until Peristent group URLs have been implemented).