### PR TITLE
EICNET-727: Fix form submissions.

### DIFF
--- a/lib/themes/eic_community/templates/form/input--submit.html.twig
+++ b/lib/themes/eic_community/templates/form/input--submit.html.twig
@@ -8,7 +8,7 @@
 #}
 {% set extraAttributes = [] %}
 {% for name,value in attributes.toArray %}
-  {% set extraAttributes = extraAttributes|merge([{'name': name, 'value': value|join(' ')}]) %}
+  {% set extraAttributes = extraAttributes|merge([{'name': name ~ '=' ~ value|join(' ')|e('html_attr')}]) %}
 {% endfor %}
 
 {% include '@ecl-twig/button' with {


### PR DESCRIPTION
With the change, you iterate over a simple array of attribute names (keys) and attribute values. Without, you iterate over the Attribute object directly, which produces a series of AttributeString objects, which eventually results in doubly escaped attribute values.