### PR TITLE
EICNET-720: Fix namespaces in paragraph preprocess includes

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/paragraphs/paragraph--banner.inc
+++ b/lib/themes/eic_community/includes/preprocess/paragraphs/paragraph--banner.inc
@@ -5,7 +5,7 @@
  * Prepares variables for paragraph banner template.
  */
 
-use Drupal\oe_theme\ValueObject\ImageValueObject;
+use Drupal\eic_community\ValueObject\ImageValueObject;
 
 /**
  * Implements hook_preprocess_paragraph() for banner paragraph.

--- a/lib/themes/eic_community/includes/preprocess/paragraphs/paragraph--full-media-content.inc
+++ b/lib/themes/eic_community/includes/preprocess/paragraphs/paragraph--full-media-content.inc
@@ -5,7 +5,7 @@
  * Prepares variables for paragraph full media content template.
  */
 
-use Drupal\oe_theme\ValueObject\ImageValueObject;
+use Drupal\eic_community\ValueObject\ImageValueObject;
 
 /**
  * Implements hook_preprocess_paragraph() for full_media_content paragraph.

--- a/lib/themes/eic_community/includes/preprocess/paragraphs/paragraph--text-and-media-content.inc
+++ b/lib/themes/eic_community/includes/preprocess/paragraphs/paragraph--text-and-media-content.inc
@@ -5,7 +5,7 @@
  * Prepares variables for paragraph text and media content template.
  */
 
-use Drupal\oe_theme\ValueObject\ImageValueObject;
+use Drupal\eic_community\ValueObject\ImageValueObject;
 
 /**
  * Implements hook_preprocess_paragraph() for text_and_media_content paragraph.


### PR DESCRIPTION
Replace old usage of oe_theme ImageValueObject class with the new one provided by eic_community theme.