### PR TITLE
EICNET-721: Refactor eic_groups module to use group PURL service

### DIFF
--- a/config/sync/context.context.group_group_homepage.yml
+++ b/config/sync/context.context.group_group_homepage.yml
@@ -71,7 +71,7 @@ reactions:
         region: page_header
         weight: '0'
         context_mapping:
-          group: '@group.group_route_context:group'
+          group: '@group_purl.context_provider:group'
         custom_id: eic_group_header
         theme: eic_community
         css_class: ''

--- a/config/sync/context.context.group_wiki_overview.yml
+++ b/config/sync/context.context.group_wiki_overview.yml
@@ -45,12 +45,12 @@ reactions:
         region: page_header
         weight: '0'
         context_mapping:
-          group: '@group.group_route_context:group'
+          group: '@group_purl.context_provider:group'
         custom_id: eic_group_header
         theme: eic_community
         css_class: ''
         unique: 0
-        context_id: group_wiki
+        context_id: group_wiki_overview
         uuid: 04974156-0f3e-411b-a62d-f961cff1e0c9
       365c1731-6e0c-49b4-90f0-9d8bbdb1a924:
         id: system_breadcrumb_block

--- a/config/sync/context.context.group_wiki_page.yml
+++ b/config/sync/context.context.group_wiki_page.yml
@@ -45,7 +45,7 @@ reactions:
         region: page_header
         weight: '0'
         context_mapping:
-          group: '@group.group_route_context:group'
+          group: '@group_purl.context_provider:group'
         custom_id: eic_group_header
         theme: eic_community
         css_class: ''

--- a/config/sync/language.content_settings.node.book.yml
+++ b/config/sync/language.content_settings.node.book.yml
@@ -1,0 +1,11 @@
+uuid: 00cbe2cb-7dd6-4b20-869e-a7dd03600ede
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.book
+id: node.book
+target_entity_type_id: node
+target_bundle: book
+default_langcode: site_default
+language_alterable: false

--- a/config/sync/language.content_settings.node.wiki_page.yml
+++ b/config/sync/language.content_settings.node.wiki_page.yml
@@ -1,0 +1,11 @@
+uuid: 169f604c-de4a-4187-b9f0-f9a26a5e4e6d
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.wiki_page
+id: node.wiki_page
+target_entity_type_id: node
+target_bundle: wiki_page
+default_langcode: site_default
+language_alterable: false

--- a/config/sync/node.type.book.yml
+++ b/config/sync/node.type.book.yml
@@ -5,6 +5,30 @@ dependencies:
   enforced:
     module:
       - book
+  module:
+    - menu_ui
+    - purl
+    - scheduler
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - main
+    parent: 'main:'
+  purl:
+    keep_context: 1
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: false
+    publish_past_date: error
+    publish_past_date_created: false
+    publish_required: false
+    publish_revision: false
+    publish_touch: false
+    show_message_after_update: true
+    unpublish_enable: false
+    unpublish_required: false
+    unpublish_revision: false
 _core:
   default_config_hash: 2gWGA-X4ERc4McStS7cMEG3ZBpDEqfNRDPTjB1v674Y
 name: 'Book page'

--- a/config/sync/node.type.wiki_page.yml
+++ b/config/sync/node.type.wiki_page.yml
@@ -4,11 +4,28 @@ status: true
 dependencies:
   module:
     - menu_ui
+    - purl
+    - scheduler
 third_party_settings:
   menu_ui:
     available_menus:
       - main
     parent: 'main:'
+  purl:
+    keep_context: 1
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: false
+    publish_past_date: error
+    publish_past_date_created: false
+    publish_required: false
+    publish_revision: false
+    publish_touch: false
+    show_message_after_update: true
+    unpublish_enable: false
+    unpublish_required: false
+    unpublish_revision: false
 name: 'Wiki Page'
 type: wiki_page
 description: ''

--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
@@ -6,7 +6,7 @@ use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
-use Drupal\eic_groups\EICGroupsHelperInterface;
+use Drupal\group_purl\Context\GroupPurlContext;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -31,11 +31,11 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
   protected $routeMatch;
 
   /**
-   * The EIC Groups helper service.
+   * The group purl context.
    *
-   * @var \Drupal\eic_groups\EICGroupsHelperInterface
+   * @var \Drupal\group_purl\Context\GroupPurlContext
    */
-  protected $eicGroupsHelper;
+  protected $groupPurlContext;
 
   /**
    * Constructs a new EICGroupHeaderBlock instance.
@@ -51,13 +51,13 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
    *   The plugin implementation definition.
    * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
    *   The current route match.
-   * @param \Drupal\eic_groups\EICGroupsHelperInterface $eic_groups_helper
-   *   The EIC Groups helper service.
+   * @param \Drupal\group_purl\Context\GroupPurlContext $group_purl_context
+   *   The group purl context.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, RouteMatchInterface $route_match, EICGroupsHelperInterface $eic_groups_helper) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, RouteMatchInterface $route_match, GroupPurlContext $group_purl_context) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->routeMatch = $route_match;
-    $this->eicGroupsHelper = $eic_groups_helper;
+    $this->groupPurlContext = $group_purl_context;
   }
 
   /**
@@ -69,7 +69,7 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
       $plugin_id,
       $plugin_definition,
       $container->get('current_route_match'),
-      $container->get('eic_groups.helper')
+      $container->get('group_purl.context_provider')
     );
   }
 
@@ -81,9 +81,7 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
 
     // Do nothing if no group was found in the context or in the current route.
     if ((!$group = $this->getContextValue('group')) || !$group->id()) {
-      if (!$group = $this->eicGroupsHelper->getGroupFromRoute()) {
-        return $build;
-      }
+      return $build;
     }
 
     // The content of this is block is shown depending on the current user's

--- a/lib/modules/eic_groups/src/Plugin/Block/GroupWikiBookNavigationBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/GroupWikiBookNavigationBlock.php
@@ -5,15 +5,9 @@ namespace Drupal\eic_groups\Plugin\Block;
 use Drupal\book\BookManagerInterface;
 use Drupal\book\Plugin\Block\BookNavigationBlock;
 use Drupal\Core\Database\Connection;
-use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Routing\RouteMatchInterface;
-use Drupal\eic_groups\EICGroupsHelperInterface;
-use Drupal\group\Entity\Group;
-use Drupal\group\Entity\GroupContent;
-use Drupal\group\Entity\GroupInterface;
-use Drupal\node\NodeInterface;
+use Drupal\group_purl\Context\GroupPurlContext;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -36,11 +30,11 @@ class GroupWikiBookNavigationBlock extends BookNavigationBlock {
   protected $database;
 
   /**
-   * The EIC Groups helper service.
+   * The group purl context.
    *
-   * @var \Drupal\eic_groups\EICGroupsHelperInterface
+   * @var \Drupal\group_purl\Context\GroupPurlContext
    */
-  protected $eicGroupsHelper;
+  protected $groupPurlContext;
 
   /**
    * Constructs a new BookNavigationBlock instance.
@@ -59,13 +53,13 @@ class GroupWikiBookNavigationBlock extends BookNavigationBlock {
    *   The node storage.
    * @param \Drupal\Core\Database\Connection $database
    *   The database service.
-   * @param \Drupal\eic_groups\EICGroupsHelperInterface $eic_groups_helper
-   *   The EIC Groups helper service.
+   * @param \Drupal\group_purl\Context\GroupPurlContext $group_purl_context
+   *   The group purl context.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, RequestStack $request_stack, BookManagerInterface $book_manager, EntityStorageInterface $node_storage, Connection $database, EICGroupsHelperInterface $eic_groups_helper) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, RequestStack $request_stack, BookManagerInterface $book_manager, EntityStorageInterface $node_storage, Connection $database, GroupPurlContext $group_purl_context) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $request_stack, $book_manager, $node_storage);
     $this->database = $database;
-    $this->eicGroupsHelper = $eic_groups_helper;
+    $this->groupPurlContext = $group_purl_context;
   }
 
   /**
@@ -80,7 +74,7 @@ class GroupWikiBookNavigationBlock extends BookNavigationBlock {
       $container->get('book.manager'),
       $container->get('entity_type.manager')->getStorage('node'),
       $container->get('database'),
-      $container->get('eic_groups.helper')
+      $container->get('group_purl.context_provider')
     );
   }
 
@@ -102,7 +96,7 @@ class GroupWikiBookNavigationBlock extends BookNavigationBlock {
    * {@inheritdoc}
    */
   public function build() {
-    if (!$this->eicGroupsHelper->getGroupFromRoute()) {
+    if (!$this->groupPurlContext->getGroupFromRoute()) {
       return [];
     }
 


### PR DESCRIPTION
### Changes

- Re-factor eic_groups to use group_purl.context_provider service in order to retrieve the group from the url;
- Enable PURL in CTypes wiki_page and book; Update eic_group_header block in contexts.