### PR TITLE
EICNET-732 Fix group wiki page redirection

### DIFF
--- a/lib/modules/eic_groups/eic_groups.services.yml
+++ b/lib/modules/eic_groups/eic_groups.services.yml
@@ -7,3 +7,8 @@ services:
   eic_groups.helper:
     class: Drupal\eic_groups\EICGroupsHelper
     arguments: ['@current_route_match']
+  eic_groups.book_page_redirect_subscriber:
+    class: Drupal\eic_groups\EventSubscriber\BookPageRedirectSubscriber
+    arguments: ['@group_purl.context_provider', '@book.manager']
+    tags:
+      - { name: event_subscriber }

--- a/lib/modules/eic_groups/src/EventSubscriber/BookPageRedirectSubscriber.php
+++ b/lib/modules/eic_groups/src/EventSubscriber/BookPageRedirectSubscriber.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Drupal\eic_groups\EventSubscriber;
+
+use Drupal\book\BookManagerInterface;
+use Drupal\Core\Cache\CacheableRedirectResponse;
+use Drupal\group_purl\Context\GroupPurlContext;
+use Drupal\node\Entity\Node;
+use Drupal\node\NodeInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Provides an Event Subscriber for kernel events.
+ */
+class BookPageRedirectSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The group entity from the group purl context.
+   *
+   * @var \Drupal\group\Entity\GroupInterface
+   */
+  protected $group;
+
+  /**
+   * The book manager.
+   *
+   * @var \Drupal\book\BookManagerInterface
+   */
+  protected $bookManager;
+
+  /**
+   * Constructs a new BookPageRedirectSubscriber instance.
+   *
+   * @param \Drupal\group_purl\Context\GroupPurlContext $group_purl_context
+   *   The group purl context.
+   * @param \Drupal\book\BookManagerInterface $book_manager
+   *   The book manager.
+   */
+  public function __construct(GroupPurlContext $group_purl_context, BookManagerInterface $book_manager) {
+    $this->group = $group_purl_context->getGroupFromRoute();
+    $this->bookManager = $book_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      KernelEvents::REQUEST => [
+        ['redirectBookPage'],
+      ]
+    ];
+  }
+
+  /**
+   * Redirect requests from book node detail pages to the 1st level wiki page.
+   *
+   * @param RequestEvent $event
+   *   The event object.
+   *
+   * @return void
+   */
+  public function redirectBookPage(RequestEvent $event) {
+    $request = $event->getRequest();
+
+    // This is necessary because this also gets called on
+    // node sub-tabs such as "edit", "revisions", etc.  This
+    // prevents those pages from redirected.
+    if ($request->attributes->get('_route') !== 'entity.node.canonical') {
+      return;
+    }
+
+    $node = \Drupal::request()->attributes->get('node');
+
+    if (!($node instanceof NodeInterface)) {
+      return;
+    }
+
+    // Only redirect book pages in the context of group.
+    if ($node->getType() !== 'book' || is_null($this->group)) {
+      return;
+    }
+
+    $data = $this->bookManager->bookTreeAllData($node->book['bid'], $node->book, 2);
+    $book_data = reset($data);
+    if (!empty($book_data['below'])) {
+      $wiki_page_nid = reset($book_data['below'])['link']['nid'];
+      $wiki_page = Node::load($wiki_page_nid);
+      $redirect_response = new CacheableRedirectResponse($wiki_page->toUrl()->toString());
+      $redirect_response->addCacheableDependency($wiki_page);
+      $redirect_response->send();
+    }
+  }
+
+}


### PR DESCRIPTION
### Improvements

- Create event subscriber to redirect book pages to the 1st level wiki page of the current group and refactor EntityOperations class.

### Tests

- Create a new group a publish it;
- Go to the book page of the group (you can find it in /admin/content). You should see the message "No wiki pages (yet)".
- Create a new wiki page from the book page (click on the link to add a new wiki page);
- If you try to navigate to the book page you should be redirected to the 1st level wiki page;