### PR TITLE
EICNET-740: "Back to groups" button uses a language parameter

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/blocks/block--eic-group-header-block.inc
+++ b/lib/themes/eic_community/includes/preprocess/blocks/block--eic-group-header-block.inc
@@ -5,6 +5,7 @@
  * Contains implementation for hook_preprocess_block() for eic_group_header.
  */
 
+use Drupal\Core\Url;
 use Drupal\eic_community\ValueObject\ImageValueObject;
 
 /**
@@ -23,4 +24,8 @@ function eic_community_preprocess_eic_group_header_block(array &$variables) {
       'alt' => $image_item->getAlt(),
     ];
   }
+
+  // Adds url to navigate back to the list of groups.
+  $back_url = Url::fromRoute('view.global_overviews.page_1');
+  $variables['back_url'] = $back_url->getInternalPath();
 }

--- a/lib/themes/eic_community/templates/blocks/eic-group-header-block.html.twig
+++ b/lib/themes/eic_community/templates/blocks/eic-group-header-block.html.twig
@@ -20,7 +20,7 @@
   image: group_values.image|default({}),
   parent: {
     link: {
-      path: '/' ~ current_language_id|to_internal_language_id ~ '/groups',
+      path: back_url,
       label: 'All groups'|t,
     }
   }


### PR DESCRIPTION
### Fixes

- Show correct link to go back to the list of groups in group header block.

### Tests

- Create a new group;
- Navigate to the group detail page and click on "All groups" link;
- Check if you were correctly redirected back to the list of groups.