### PR TITLE
EICNET-764: Limit group operation links

### DIFF
--- a/lib/modules/eic_groups/src/EICGroupsHelper.php
+++ b/lib/modules/eic_groups/src/EICGroupsHelper.php
@@ -90,7 +90,7 @@ class EICGroupsHelper implements EICGroupsHelperInterface {
   /**
    * {@inheritdoc}
    */
-  public function getGroupOperationLinks(GroupInterface $group, CacheableMetadata $cacheable_metadata = NULL) {
+  public function getGroupOperationLinks(GroupInterface $group, $limit_entities = [], CacheableMetadata $cacheable_metadata = NULL) {
     $operation_links = [];
 
     if (!is_null($cacheable_metadata)) {
@@ -98,6 +98,10 @@ class EICGroupsHelper implements EICGroupsHelperInterface {
       // cacheable metadata.
       foreach ($group->getGroupType()->getInstalledContentPlugins() as $plugin) {
         /** @var \Drupal\group\Plugin\GroupContentEnablerInterface $plugin */
+        if (!empty($limit_entities) && !in_array($plugin->getEntityTypeId(), $limit_entities)) {
+          continue;
+        }
+
         $operation_links += $plugin->getGroupOperations($group);
         $cacheable_metadata = $cacheable_metadata->merge($plugin->getGroupOperationsCacheableMetadata());
       }
@@ -107,6 +111,10 @@ class EICGroupsHelper implements EICGroupsHelperInterface {
       // merging cacheable metadata.
       foreach ($group->getGroupType()->getInstalledContentPlugins() as $plugin) {
         /** @var \Drupal\group\Plugin\GroupContentEnablerInterface $plugin */
+        if (!empty($limit_entities) && !in_array($plugin->getEntityTypeId(), $limit_entities)) {
+          continue;
+        }
+
         $operation_links += $plugin->getGroupOperations($group);
       }
     }

--- a/lib/modules/eic_groups/src/EICGroupsHelperInterface.php
+++ b/lib/modules/eic_groups/src/EICGroupsHelperInterface.php
@@ -35,6 +35,8 @@ interface EICGroupsHelperInterface {
    *
    * @param \Drupal\group\Entity\GroupInterface $group
    *   The Group entity.
+   * @param array $limit_entities
+   *   Array of entities types to limit operation links.
    * @param \Drupal\Core\Cache\CacheableMetadata $cacheable_metadata
    *   An optional cacheable metadata object.
    *
@@ -45,6 +47,6 @@ interface EICGroupsHelperInterface {
    *   - url: An instance of \Drupal\Core\Url for the operation URL.
    *   - weight: The weight of the operation.
    */
-  public function getGroupOperationLinks(GroupInterface $group, CacheableMetadata $cacheable_metadata = NULL);
+  public function getGroupOperationLinks(GroupInterface $group, array $limit_entities = [], CacheableMetadata $cacheable_metadata = NULL);
 
 }

--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
@@ -7,7 +7,6 @@ use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\eic_groups\EICGroupsHelperInterface;
-use Drupal\group_purl\Context\GroupPurlContext;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -32,13 +31,6 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
   protected $routeMatch;
 
   /**
-   * The group purl context.
-   *
-   * @var \Drupal\group_purl\Context\GroupPurlContext
-   */
-  protected $groupPurlContext;
-
-  /**
    * The EIC groups helper service.
    *
    * @var \Drupal\eic_groups\EICGroupsHelperInterface
@@ -59,15 +51,12 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
    *   The plugin implementation definition.
    * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
    *   The current route match.
-   * @param \Drupal\group_purl\Context\GroupPurlContext $group_purl_context
-   *   The group purl context.
    * @param \Drupal\eic_groups\EICGroupsHelperInterface $eic_groups_helper
    *   The EIC groups helper service.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, RouteMatchInterface $route_match, GroupPurlContext $group_purl_context, EICGroupsHelperInterface $eic_groups_helper) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, RouteMatchInterface $route_match, EICGroupsHelperInterface $eic_groups_helper) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->routeMatch = $route_match;
-    $this->groupPurlContext = $group_purl_context;
     $this->eicGroupsHelper = $eic_groups_helper;
   }
 
@@ -80,7 +69,6 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
       $plugin_id,
       $plugin_definition,
       $container->get('current_route_match'),
-      $container->get('group_purl.context_provider'),
       $container->get('eic_groups.helper')
     );
   }

--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
@@ -107,6 +107,13 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
       'url.path',
     ]);
 
+    $operation_links = $this->eicGroupsHelper->getGroupOperationLinks($group, ['node'], $cacheable_metadata);
+
+    // Removes operation link of wiki page group content.
+    if (isset($operation_links['gnode-create-wiki_page'])) {
+      unset($operation_links['gnode-create-wiki_page']);
+    }
+
     $build['content'] = [
       '#theme' => 'eic_group_header_block',
       '#group' => $group,
@@ -115,7 +122,7 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
         'bundle' => $group->bundle(),
         'title' => $group->label(),
         'description' => $group->get('field_body')->value,
-        'operation_links' => $this->eicGroupsHelper->getGroupOperationLinks($group, $cacheable_metadata),
+        'operation_links' => $operation_links,
       ],
     ];
 


### PR DESCRIPTION
### Improvements

- Limit group operation links to nodes and remove "Wiki page".
- Update method **::getGroupOperationLinks** from EICGroupsHelper service in order to limit the results for specific entities;