### PR TITLE
EICNET-765: Hide features field from group creation form.

### DIFF
--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -9,7 +9,7 @@ use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\eic_groups\Hooks\EntityOperations;
-use Drupal\eic_groups\Hooks\FormAlter;
+use Drupal\eic_groups\Hooks\FormOperations;
 
 /**
  * Implements hook_theme().
@@ -29,7 +29,7 @@ function eic_groups_theme($existing, $type, $theme, $path) {
  * Implements hook_form_FORM_ID_alter().
  */
 function eic_groups_form_group_group_add_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  \Drupal::classResolver(FormAlter::class)
+  \Drupal::classResolver(FormOperations::class)
     ->groupGroupAddForm($form, $form_state);
 }
 

--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -7,7 +7,9 @@
 
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\eic_groups\Hooks\EntityOperations;
+use Drupal\eic_groups\Hooks\FormAlter;
 
 /**
  * Implements hook_theme().
@@ -21,6 +23,14 @@ function eic_groups_theme($existing, $type, $theme, $path) {
       ],
     ],
   ];
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function eic_groups_form_group_group_add_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  \Drupal::classResolver(FormAlter::class)
+    ->groupGroupAddForm($form, $form_state);
 }
 
 /**

--- a/lib/modules/eic_groups/src/Hooks/FormAlter.php
+++ b/lib/modules/eic_groups/src/Hooks/FormAlter.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Drupal\eic_groups\Hooks;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\eic_groups\EICGroupsHelperInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class FormAlter.
+ *
+ * Implementations for entity hooks.
+ */
+class FormAlter implements ContainerInjectionInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The EIC Groups helper service.
+   *
+   * @var \Drupal\eic_groups\EICGroupsHelperInterface
+   */
+  protected $eicGroupsHelper;
+
+  /**
+   * Constructs a new EntityOperations object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\eic_groups\EICGroupsHelperInterface $eic_groups_helper
+   *   The EIC Groups helper service.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, EICGroupsHelperInterface $eic_groups_helper) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->eicGroupsHelper = $eic_groups_helper;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('eic_groups.helper')
+    );
+  }
+
+  /**
+   * Implements hook_form_FORM_ID_alter().
+   */
+  public function groupGroupAddForm(&$form, FormStateInterface $form_state) {
+    // We don't want the features field to be accessible during the group
+    // creation process.
+    $form['features']['#access'] = FALSE;
+  }
+
+}

--- a/lib/modules/eic_groups/src/Hooks/FormOperations.php
+++ b/lib/modules/eic_groups/src/Hooks/FormOperations.php
@@ -14,7 +14,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * Implementations for entity hooks.
  */
-class FormAlter implements ContainerInjectionInterface {
+class FormOperations implements ContainerInjectionInterface {
 
   use StringTranslationTrait;
 


### PR DESCRIPTION
Test:

- Features field should not be visible when creating a new group
- It should be visible when editing an existing group