### PR TITLE
EICNET-772: Adjusts wiki navigation.

### DIFF
--- a/lib/themes/eic_community/.storybook/preview-head.html
+++ b/lib/themes/eic_community/.storybook/preview-head.html
@@ -26,6 +26,7 @@
 <script src="scripts/components/drupal.navigation-list.js"></script>
 <script src="scripts/compositions/drupal.collapsible-options.js"></script>
 <script src="scripts/compositions/drupal.comment-attachments.js"></script>
+<script src="scripts/compositions/drupal.editorial-article.js"></script>
 <script src="scripts/compositions/drupal.featured-list.js"></script>
 <script src="scripts/compositions/drupal.featured-content-collection.js"></script>
 <script src="scripts/compositions/drupal.featured-content-sections.js"></script>

--- a/lib/themes/eic_community/js/components/drupal.navigation-list.js
+++ b/lib/themes/eic_community/js/components/drupal.navigation-list.js
@@ -133,12 +133,59 @@
           collapsed: true,
         });
       }
+
+      collapseParentElement(navigationList);
     });
 
     if (readSession('collapsed')) {
       navigationList.setAttribute('aria-collapsed', 'true');
+      collapseParentElement(navigationList);
     }
 
     navigationListToggle.classList.add('ecl-navigation-list__toggle--is-ready');
   }
+
+  function collapseParentElement(navigationList) {
+    const parentSelector = navigationList.getAttribute('data-navigation-list-parent-selector');
+
+    if (!parentSelector || !document.querySelector(parentSelector)) {
+      return;
+    }
+
+    // Don't query the parent element everytime.
+    if (!navigationList.parentSelector) {
+      navigationList.parentSelector = getParent(
+        navigationList,
+        document.querySelector(parentSelector)
+      );
+    }
+
+    if (!navigationList.parentSelector) {
+      return;
+    }
+
+    if (navigationList.getAttribute('aria-collapsed') === 'true') {
+      navigationList.parentSelector.setAttribute('aria-collapsed', 'true');
+    } else {
+      navigationList.parentSelector.removeAttribute('aria-collapsed');
+    }
+  }
+
+  /**
+   * Returns the Parent element from the given HTMLElement context.
+   *
+   * @param {HTMLElement} context Use the parent element from the defined context.
+   * @param {HTMLElement} target The element that should exist as parent from the context.
+   */
+  const getParent = (context, target) => {
+    let node = context;
+
+    if (node !== null) {
+      do {
+        if (node === target) {
+          return node;
+        }
+      } while ((node = node.parentNode));
+    }
+  };
 })(ECL, Drupal);

--- a/lib/themes/eic_community/js/compositions/drupal.editorial-article.js
+++ b/lib/themes/eic_community/js/compositions/drupal.editorial-article.js
@@ -1,0 +1,61 @@
+/**
+ * @file
+ * Implements the logic for the editorial article HTMLElements.
+ */
+(function (Drupal) {
+  Drupal.behaviors.editorialArticle = {
+    attach: function () {
+      const editorialArticle = document.querySelectorAll(
+        '.ecl-editorial-article:not(.ecl-editorial-article--is-ready)'
+      );
+
+      if (!editorialArticle.length) {
+        return;
+      }
+
+      for (let i = 0; i < editorialArticle.length; i++) {
+        defineEditorialArticle(editorialArticle[i]);
+      }
+    },
+  };
+
+  /**
+   * Implements the collapse logic for the current editorial article element.
+   *
+   * @param {HTMLElement} editorialArticle
+   */
+  function defineEditorialArticle(editorialArticle) {
+    if (!editorialArticle.classList.contains('ecl-editorial-article--is-collapsible')) {
+      return;
+    }
+
+    window.addEventListener('resize', () => {
+      editorialArticle.throttle && clearTimeout(editorialArticle.throttle);
+
+      editorialArticle.throttle = setTimeout(
+        () => defineEditorialArticleMinHeight(editorialArticle),
+        200
+      );
+    });
+
+    defineEditorialArticleMinHeight(editorialArticle);
+
+    editorialArticle.classList.add('ecl-editorial-article--is-ready');
+  }
+
+  function defineEditorialArticleMinHeight(editorialArticle) {
+    if (!editorialArticle) {
+      return;
+    }
+
+    const editorialArticleAside = editorialArticle.querySelector('.ecl-editorial-article__aside');
+
+    if (!editorialArticleAside) {
+      return;
+    }
+
+    if (editorialArticle.style) {
+      editorialArticle.style.minHeight = `${editorialArticleAside.firstElementChild.offsetHeight}px`;
+    }
+  }
+})(Drupal);

--- a/lib/themes/eic_community/patterns/components/navigation-list/navigation-list.html.twig
+++ b/lib/themes/eic_community/patterns/components/navigation-list/navigation-list.html.twig
@@ -1,4 +1,6 @@
-<div class="ecl-navigation-list">
+{% import "@theme/patterns/core/snippets.twig" as snippets %}
+
+<div class="ecl-navigation-list" {{ snippets.attr(extra_attributes) }}>
   <div class="ecl-navigation-list__controls">
     {% if collapse is not empty %}
       {% include "@ecl-twig/ec-component-button/ecl-button.html.twig" with {
@@ -7,7 +9,7 @@
           name: 'download',
           type: 'custom',
           path: icon_file_path,
-          size: 's',
+          size: 'xs',
         },
         type: 'button',
         variant: 'secondary',

--- a/lib/themes/eic_community/patterns/compositions/editorial-article.html.twig
+++ b/lib/themes/eic_community/patterns/compositions/editorial-article.html.twig
@@ -5,9 +5,18 @@
 {% endif %}
 
 <section class="ecl-section-wrapper">
-  <div class="ecl-editorial-article">
+  <div class="ecl-editorial-article {{ extra_classes }}">
     <div class="ecl-container">
       <div class="ecl-editorial-article__wrapper">
+        <section class="ecl-editorial-article__header">
+          {% if actions is not empty %}
+            {% include "@theme/patterns/components/inline-actions.html.twig" with actions|default({})|merge({
+              items: actions.items ? actions.items|map(i => i|merge({
+                extra_classes: i.extra_classes|default('') ~ ' ecl-link--button ecl-link--button-primary'
+              }))
+            }) %}
+          {% endif %}
+        </section>
         <section class="ecl-editorial-article__content">
           {% block content %}
             {{ content }}

--- a/lib/themes/eic_community/patterns/compositions/group/group.full--wiki.html.twig
+++ b/lib/themes/eic_community/patterns/compositions/group/group.full--wiki.html.twig
@@ -1,55 +1,79 @@
+{% set layout = {
+  extra_classes: 'ecl-base-layout--is-fluid'
+ } %}
+
 {% extends "@theme/patterns/compositions/group/group.full.html.twig" %}
 
-{% block content %}
-  {% if items is empty %}
-    <div class="ecl-section-wrapper">
-      <div class="ecl-container">
-        {% embed "@theme/patterns/components/well.html.twig" with {
-          extra_classes: 'ecl-well--is-centered ecl-well--is-grey',
-        } %}
-          {% block content %}
-            {% set label = no_items.label|default('No wiki pages (yet).') %}
-            {% set title_element = no_items.title_element|default('h2') %}
+{% set contents %}
+  {% embed "@theme/patterns/compositions/editorial-article.html.twig" with {
+    extra_classes: 'ecl-editorial-article--is-collapsible ecl-editorial-article--has-reversed-layout',
+    actions: actions,
+  } %}
+    {% block content %}
+      {% if items is empty %}
+        <div class="ecl-section-wrapper">
+          <div class="ecl-container">
+            {% embed "@theme/patterns/components/well.html.twig" with {
+              extra_classes: 'ecl-well--is-centered ecl-well--is-grey',
+            } %}
+              {% block content %}
+                {% set label = no_items.label|default('No wiki pages (yet).') %}
+                {% set title_element = no_items.title_element|default('h2') %}
 
-            <{{ title_element }}>{{ label }}</{{ title_element}}>
+                <{{ title_element }}>{{ label }}</{{ title_element}}>
 
-            {% if no_items.link and no_items.link.path %}
-              {% include "@ecl-twig/ec-component-link/ecl-link.html.twig" with {
-                link: no_items.link|merge({
-                  icon_position: 'after',
-                  type: 'standalone',
-                }),
-                extra_classes: 'ecl-link--button ecl-link--button-primary',
-              } only %}
-            {% endif %}
+                {% if no_items.link and no_items.link.path %}
+                  {% include "@ecl-twig/ec-component-link/ecl-link.html.twig" with {
+                    link: no_items.link|merge({
+                      icon_position: 'after',
+                      type: 'standalone',
+                    }),
+                    extra_classes: 'ecl-link--button ecl-link--button-primary',
+                  } only %}
+                {% endif %}
+              {% endblock %}
+            {% endembed %}
+          </div>
+        </div>
+      {% else %}
+        {{ content }}
+      {% endif %}
+    {% endblock %}
+
+    {%- block sidebar -%}
+      {% if items is not empty %}
+        {% embed "@theme/patterns/components/navigation-list/navigation-list.html.twig" with {
+          extra_attributes: [
+            {
+              name: 'data-navigation-list-parent-selector',
+              value: '.ecl-editorial-article',
+
+            }
+          ],
+          icon_file_path: common.icon_file_path,
+          items: items,
+          collapse: {
+            label: 'Subjects',
+          }
+        }  %}
+
+          {% block before %}
+            {{ new_wiki }}
           {% endblock %}
+
+          {% block after %}
+            {{ contributors}}
+          {% endblock %}
+
         {% endembed %}
-      </div>
-    </div>
-  {% else %}
-    {{ content }}
-  {% endif %}
+
+      {% endif %}
+    {%- endblock -%}
+  {% endembed %}
+{% endset %}
+
+{% block sidebar %}{% endblock %}
+
+{% block content %}
+  {{ contents }}
 {% endblock %}
-
-{%- block sidebar -%}
-  {% if items is not empty %}
-    {% embed "@theme/patterns/components/navigation-list/navigation-list.html.twig" with {
-      icon_file_path: common.icon_file_path,
-      items: items,
-      collapse: {
-        label: 'Subjects',
-      }
-    }  %}
-
-      {% block before %}
-        {{ new_wiki }}
-      {% endblock %}
-
-      {% block after %}
-        {{ contributors}}
-      {% endblock %}
-
-    {% endembed %}
-
-  {% endif %}
-{%- endblock -%}

--- a/lib/themes/eic_community/patterns/layout/base.html.twig
+++ b/lib/themes/eic_community/patterns/layout/base.html.twig
@@ -64,7 +64,7 @@
       {{ page.page_header }}
     {% endblock %}
 
-    <div class="ecl-base-layout{{ output_sidebar ? ' ecl-base-layout--contain' }}">
+    <div class="ecl-base-layout{{ output_sidebar ? ' ecl-base-layout--contain' }} {{ layout ? layout.extra_classes }}">
       {% if output_content_before %}
         <div class="ecl-base-layout__content-before">
           {{ output_content_before }}

--- a/lib/themes/eic_community/sass/components/_navigation-list.scss
+++ b/lib/themes/eic_community/sass/components/_navigation-list.scss
@@ -1,7 +1,8 @@
 .ecl-navigation-list {
   $node: &;
   padding: map-get($ecl-spacing, 'xs');
-  border: ecl-border();
+  outline: ecl-border();
+  outline-offset: -1px;
 
   &,
   &__main-before,
@@ -27,6 +28,7 @@
 
   &--is-ready[aria-collapsed="true"] {
     display: inline-block;
+    padding: map-get($ecl-spacing, '2xs');
   }
 
   &__items,

--- a/lib/themes/eic_community/sass/compositions/_base-layout.scss
+++ b/lib/themes/eic_community/sass/compositions/_base-layout.scss
@@ -72,6 +72,12 @@
     @include ecl-media-breakpoint-up('lg') {
       width: 21%;
       min-width: map-get($ecl-width, 'form-m');
+
+      #{$node}--is-fluid & {
+        width: auto;
+        min-width: 0;
+      }
+
       margin: 0 map-get($ecl-spacing, '3xl') 0 0;
     }
   }

--- a/lib/themes/eic_community/sass/compositions/_editorial-article.scss
+++ b/lib/themes/eic_community/sass/compositions/_editorial-article.scss
@@ -1,14 +1,45 @@
 .ecl-editorial-article {
+  $node: &;
+
   &__wrapper {
+    display: flex;
+    flex-direction: column;
+
     @include ecl-media-breakpoint-up('md') {
-      display: flex;
       align-items: stretch;
+      flex-direction: row;
+
+      #{$node}--is-collapsible & {
+        @include ecl-media-breakpoint-up('md') {
+          flex-wrap: wrap;
+        }
+      }
+    }
+  }
+
+  &__header,
+  &__content {
+    #{$node}--is-ready#{$node}--is-collapsible & {
+      @include ecl-media-breakpoint-up('md') {
+        margin-left: calc(100% / #{$ecl-grid-columns} * 4);
+      }
+    }
+
+    #{$node}--is-ready#{$node}--is-collapsible[aria-collapsed="true"] & {
+      @include ecl-media-breakpoint-up('md') {
+        margin-left: 0;
+      }
     }
   }
 
   &__content {
     font-size: ecl-typography('font-size');
     line-height: ecl-typography('line-height');
+    margin-top: ecl-layout('gutter');
+
+    &:first-child {
+      margin-top: 0;
+    }
 
     @include ecl-media-breakpoint-up('md') {
       flex-grow: 1;
@@ -51,11 +82,37 @@
     position: relative;
     margin-top: ecl-layout('gutter');
 
+    #{$node}--is-collapsible & {
+      margin-top: 0;
+      margin-bottom: ecl-layout('gutter');
+      order: -1;
+    }
+
     @include ecl-media-breakpoint-up('md') {
       box-sizing: border-box;
       margin: 0;
       padding-left: ecl-layout('gutter');
       width: calc(100% / #{$ecl-grid-columns} * 4);
+
+      #{$node}--has-reversed-layout & {
+        @include ecl-media-breakpoint-up('md') {
+          padding-left: 0;
+          order: -1;
+          padding-right: ecl-layout('gutter');
+        }
+      }
+
+      #{$node}--is-ready#{$node}--is-collapsible & {
+        height: 0;
+        margin: 0;
+      }
+
+      #{$node}--is-ready#{$node}--is-collapsible[aria-collapsed="true"] & {
+        height: auto;
+        width: auto;
+      }
+
+
       flex-shrink: 0;
     }
   }
@@ -64,6 +121,11 @@
     @include ecl-media-breakpoint-up('md') {
       position: sticky;
       top: ecl-layout('gutter');
+
+      #{$node}--is-collapsible#{$node}--is-ready & {
+        position: relative;
+        top: auto;
+      }
     }
   }
 

--- a/lib/themes/eic_community/snippets/index.js
+++ b/lib/themes/eic_community/snippets/index.js
@@ -68,8 +68,6 @@ export const mockItems = (payload, amount = 10, assigner, assignees = []) => {
     // Inserts additional properties within the selected item index.
     if (Array.isArray(assignees) && typeof assigner === 'function' && assignees.includes(i)) {
       output[i] = assigner();
-
-      console.log(assigner());
     }
   }
 

--- a/lib/themes/eic_community/styleguide/bundles/group.stories.js
+++ b/lib/themes/eic_community/styleguide/bundles/group.stories.js
@@ -455,6 +455,22 @@ export const GroupWikiPrivate = () =>
             },
           ],
         }),
+        actions: {
+          items: [
+            {
+              link: {
+                label: 'Add page on same level',
+                path: '?path=current',
+              },
+            },
+            {
+              link: {
+                label: 'Add child page',
+                path: '?path=new',
+              },
+            },
+          ],
+        },
         items: wiki.items,
         content: WysiwygTemplate(),
         no_items: {

--- a/lib/themes/eic_community/styleguide/components/navigation-list.docs.mdx
+++ b/lib/themes/eic_community/styleguide/components/navigation-list.docs.mdx
@@ -8,6 +8,20 @@ Displays a vertical collapsible navigation list that can also be completely coll
 {% include "@theme/patterns/components/navigation-list.html.twig" %}
 ```
 
+The component can also apply the collapsed state to a parent container in order to implement within the layout.
+You can do this by defining the parent-selector data attribute within the component data structure:
+
+```
+  {% include "@theme/patterns/components/navigation-list.html.twig" with {
+    extra_attributes: {
+      name: 'data-navigation-list-parent-selector',
+      value: '.selector',
+    }
+  } %}
+```
+
+This will apply the aria-collapsed state also on the parent element `.selector`.
+
 ## Block parameters:
 
 | Key    | Type   | Description                                        | Mandatory |

--- a/lib/themes/eic_community/styleguide/compositions/editorial-article.stories.js
+++ b/lib/themes/eic_community/styleguide/compositions/editorial-article.stories.js
@@ -21,6 +21,24 @@ export const WithSidebar = () =>
     sidebar: editableField('Area for the editorial article sidebar.'),
   });
 
+export const WithSidebarReverseed = () =>
+  EditorialArticleTemplate({
+    content: wysiwyg({
+      icon_file_path: common.icon_file_path,
+    }),
+    extra_classes: 'ecl-editorial-article--has-reversed-layout',
+    sidebar: editableField('Area for the editorial article sidebar.'),
+  });
+
+export const Collapsible = () =>
+  EditorialArticleTemplate({
+    content: wysiwyg({
+      icon_file_path: common.icon_file_path,
+    }),
+    extra_classes: 'ecl-editorial-article--is-collapsible',
+    sidebar: editableField('Area for the editorial article sidebar.'),
+  });
+
 export default {
   title: 'Compositions / Editorial Article',
   parameters: {


### PR DESCRIPTION
This PR implements the collapse feature for the editorial-article component. The Wiki page used this component where the sidebar could be collapsed with the navigation-list component. The editorial-article component will now collapse the sidebar within the `Storybook > Group > Group Wiki Private` example. This will place the navigation list button next to the other buttons of the wiki page.

