### PR TITLE
EICNET-700: Make facts figures for homepage more compact.

### DIFF
--- a/lib/themes/eic_community/data/fact-figures.data.js
+++ b/lib/themes/eic_community/data/fact-figures.data.js
@@ -1,7 +1,7 @@
 import common from '@theme/data/common.data';
 
 export default {
-  column: 3,
+  column: 4,
   display_icons: true,
   icon_file_path: common.icon_file_path,
   items: [
@@ -32,24 +32,6 @@ export default {
       icon: {
         type: 'custom',
         name: 'group',
-      },
-    },
-    {
-      title: 'Projects',
-      description: 'Enim ullamco Lorem deserunt cillum adipisicing aliqua fugiat aute.',
-      value: 22,
-      icon: {
-        type: 'custom',
-        name: 'documents',
-      },
-    },
-    {
-      title: 'Challenges',
-      description: 'Incididunt mollit est deserunt eu laboris pariatur duis eiusmod.',
-      value: 16,
-      icon: {
-        type: 'custom',
-        name: 'objectif',
       },
     },
     {

--- a/lib/themes/eic_community/patterns/pages/homepage/homepage.public.html.twig
+++ b/lib/themes/eic_community/patterns/pages/homepage/homepage.public.html.twig
@@ -61,6 +61,7 @@
   {% include "@theme/patterns/compositions/fact-figures-wrapper.html.twig" with fact_figures|default({})|merge({
     compact: true,
     extra_classes: 'ecl-section-wrapper ecl-section-wrapper--is-blue',
+    column: 4,
   })  only %}
 
 {% endblock %}

--- a/lib/themes/eic_community/sass/compositions/_fact-figures-wrapper.scss
+++ b/lib/themes/eic_community/sass/compositions/_fact-figures-wrapper.scss
@@ -1,6 +1,7 @@
 .ecl-fact-figures-wrapper {
   & .ecl-fact-figures {
     $node: &;
+
     padding: 0;
     background-color: transparent;
 
@@ -9,7 +10,7 @@
     &__items {
       padding: 0;
       margin-top: #{0 - ecl-layout('gutter--lg', 'description') * 2};
-      margin-left: #{0 - ecl-layout('gutter')};
+      margin-right: #{0 - ecl-layout('gutter')};
 
       @include ecl-media-breakpoint-up('md') {
         display: flex;
@@ -24,7 +25,7 @@
       &,
       &:first-of-type {
         padding: 0;
-        padding-left: ecl-layout('gutter');
+        padding-right: ecl-layout('gutter');
         margin-top: #{ecl-layout('gutter--lg', 'description') * 2};
         flex-basis: inherit;
 
@@ -37,25 +38,33 @@
 
   &--has-compact-layout .ecl-fact-figures {
     &__item {
-      position: relative;
+      &,
+      &:first-of-type {
+        position: relative;
+        display: flex;
+        flex-wrap: wrap;
+        box-sizing: border-box;
+        flex-direction: row;
+        align-items: center;
+        padding-left: calc(#{map-get($ecl-media, '3xs')} + #{ecl-box-model('padding')});
+      }
     }
 
     &__icon {
       position: absolute;
-      top: 0;
-      left: ecl-layout('gutter');
+      top: #{0 - map-get($ecl-spacing, 'xs')};
+      left: 0;
       width: map-get($ecl-media, '3xs');
       height: map-get($ecl-media, '3xs');
     }
 
-    &__value,
-    &__title,
-    &__description {
-      margin-left: calc(#{map-get($ecl-media, '3xs')} + #{ecl-box-model('padding')});
+    &__value {
+      margin-right: map-get($ecl-spacing, 's');
     }
 
     &__title {
       margin-top: 0;
+      font-weight: inherit;
       @include ecl-responsive-font('label');
     }
   }


### PR DESCRIPTION
This PR adjusts the homepage example within storybook that shows a compact version of the facts and figures component. 4 items are displayed within this example. The typography also some minor changes to match with the latest design.