### PR TITLE
EICNET-766: Show fallback icon for group teaser, updates storybook example

### DIFF
--- a/lib/themes/eic_community/patterns/compositions/group/group.teaser.html.twig
+++ b/lib/themes/eic_community/patterns/compositions/group/group.teaser.html.twig
@@ -1,11 +1,24 @@
 {% set title_element = title_element|default('h2') %}
 
 <div class="ecl-teaser ecl-teaser--group {{ highlight.is_active ? 'ecl-teaser--is-highlighted' }} {{ extra_classes }}">
-  {% if image is not empty %}
     <figure class="ecl-teaser__image-wrapper">
-      <img class="ecl-teaser__image" src="{{ image.src }}" alt="{{ image.alt }}" />
+      {% if image is not empty %}
+        <img class="ecl-teaser__image" src="{{ image.src }}" alt="{{ image.alt }}" />
+      {% else %}
+        {% if icon_file_path %}
+          <div class="ecl-teaser__image-fallback-wrapper">
+            {% include '@ecl-twig/ec-component-icon/ecl-icon.html.twig' with {
+              icon: {
+                size: '3xl',
+                path: icon_file_path,
+                type: 'custom',
+                name: 'group_circle',
+              },
+            } only %}
+          </div>
+        {% endif %}
+      {% endif %}
     </figure>
-  {% endif %}
   <div class="ecl-teaser__main-wrapper">
     {% if type is not empty %}
       <div class="ecl-teaser__meta-header">

--- a/lib/themes/eic_community/sass/components/_icon.scss
+++ b/lib/themes/eic_community/sass/components/_icon.scss
@@ -1,0 +1,5 @@
+.ecl-icon {
+  &--3xl {
+    width: $ecl-icon-2-xl * 1.5;
+  }
+}

--- a/lib/themes/eic_community/sass/compositions/_teaser.scss
+++ b/lib/themes/eic_community/sass/compositions/_teaser.scss
@@ -198,6 +198,14 @@
     }
   }
 
+  &__image-fallback-wrapper {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    color: map-get($ecl-colors, 'white');
+  }
+
   &__main-wrapper {
     flex-grow: 1;
     display: flex;

--- a/lib/themes/eic_community/sass/eic_community.screen.scss
+++ b/lib/themes/eic_community/sass/eic_community.screen.scss
@@ -87,6 +87,7 @@
 @import "./components/global";
 @import "./components/grid";
 @import "./components/hero";
+@import "./components/icon";
 @import "./components/inline-actions";
 @import "./components/inline-stats";
 @import "./components/investment";

--- a/lib/themes/eic_community/styleguide/bundles/group.stories.js
+++ b/lib/themes/eic_community/styleguide/bundles/group.stories.js
@@ -487,7 +487,9 @@ export const OverviewPublic = () =>
       {
         content: TeaserTemplate(teaser.group),
       },
-      10
+      10,
+      () => ({ content: TeaserTemplate(without(teaser.group, 'image')) }),
+      [0]
     ),
     pagination: pagination,
   });


### PR DESCRIPTION
This PR updates the group teaser component and will show the group icon as fallback image.
Storybook has been updated and the example can be found at: `Storybook > Group > Group Overview Public`.