### PR TITLE
EICNET-658: Create the global search page

### DIFF
--- a/config/sync/context.context.search.yml
+++ b/config/sync/context.context.search.yml
@@ -1,0 +1,125 @@
+uuid: b482d527-78c7-4520-875f-9bd1606a1abb
+langcode: en
+status: true
+dependencies: {  }
+name: search
+label: Search
+group: null
+description: 'Context used when viewing global search results.'
+requireAllConditions: false
+disabled: false
+conditions:
+  view_inclusion:
+    id: view_inclusion
+    negate: null
+    uuid: ab244b04-6e16-4d7e-807b-a253b4f116b5
+    view_inclusion:
+      view-global_overviews-search: view-global_overviews-search
+    context_mapping: {  }
+reactions:
+  blocks:
+    blocks:
+      b27ac8cb-7cf7-4536-9488-68ff624b35d7:
+        id: 'facets_summary_block:search_summary'
+        label: 'Search summary'
+        provider: facets_summary
+        label_display: '0'
+        region: content
+        weight: '-3'
+        context_mapping: {  }
+        custom_id: facets_summary_block_search_summary
+        theme: eic_community
+        css_class: ''
+        unique: 0
+        context_id: search
+        uuid: b27ac8cb-7cf7-4536-9488-68ff624b35d7
+      44e147ec-0f73-4eff-bffc-3e113fd0f09c:
+        id: system_main_block
+        label: 'Main page content'
+        provider: system
+        label_display: '0'
+        region: content
+        weight: '-1'
+        context_mapping: {  }
+        custom_id: system_main_block
+        theme: eic_community
+        css_class: ''
+        unique: 0
+        context_id: search
+        uuid: 44e147ec-0f73-4eff-bffc-3e113fd0f09c
+      8da47f9d-3e3c-4c86-92be-3b1d8e618b2d:
+        id: 'views_exposed_filter_block:global_overviews-search'
+        label: ''
+        provider: views
+        label_display: '0'
+        views_label: ''
+        region: sidebar
+        weight: '-3'
+        context_mapping: {  }
+        custom_id: views_exposed_filter_block_global_overviews_search
+        theme: eic_community
+        css_class: ''
+        unique: 0
+        context_id: search
+        uuid: 8da47f9d-3e3c-4c86-92be-3b1d8e618b2d
+      6a376cc5-5dfb-47ba-bfe6-e6f63307476f:
+        id: 'facet_block:search_content_type'
+        label: 'Content type'
+        provider: facets
+        label_display: '0'
+        region: sidebar
+        weight: '-2'
+        context_mapping: {  }
+        custom_id: facet_block_search_content_type
+        theme: eic_community
+        css_class: ''
+        unique: 0
+        context_id: search
+        uuid: 6a376cc5-5dfb-47ba-bfe6-e6f63307476f
+      89cce8b1-efeb-49c5-be09-927fa77f1f1e:
+        id: 'search_api_sorts_block:views_page:global_overviews__search'
+        label: 'Sort by (View Global Overviews, display Search)'
+        provider: search_api_sorts
+        label_display: '0'
+        region: content
+        weight: '-2'
+        context_mapping: {  }
+        custom_id: search_api_sorts_block_views_page_global_overviews__search
+        theme: eic_community
+        css_class: ''
+        unique: 0
+        context_id: search
+        uuid: 89cce8b1-efeb-49c5-be09-927fa77f1f1e
+      37406cf7-7478-4cc0-8331-d8b895615cb9:
+        id: 'facet_block:search_topics'
+        label: Topics
+        provider: facets
+        label_display: '0'
+        region: sidebar
+        weight: '-1'
+        context_mapping: {  }
+        custom_id: facet_block_search_topics
+        theme: eic_community
+        css_class: ''
+        unique: 0
+        context_id: search
+        uuid: 37406cf7-7478-4cc0-8331-d8b895615cb9
+      7946f50b-1860-4054-8d67-6449fc026b7e:
+        id: 'facet_block:search_regions_countries'
+        label: 'Regions & Countries'
+        provider: facets
+        label_display: '0'
+        region: sidebar
+        weight: '0'
+        context_mapping: {  }
+        custom_id: facet_block_search_regions_countries
+        theme: eic_community
+        css_class: ''
+        unique: 0
+        context_id: search
+        uuid: 7946f50b-1860-4054-8d67-6449fc026b7e
+    id: blocks
+    saved: false
+    uuid: b2e2c0ac-50de-49b1-b2e3-f957728678f0
+    include_default_blocks: 0
+weight: 0

--- a/config/sync/facets.facet.search_content_type.yml
+++ b/config/sync/facets.facet.search_content_type.yml
@@ -1,0 +1,68 @@
+uuid: c73d88e5-45a8-40ba-9966-d1bb53487068
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.index.global
+    - views.view.global_overviews
+  module:
+    - search_api
+id: search_content_type
+name: 'Content type'
+url_alias: content_type
+weight: 0
+min_count: 1
+show_only_one_result: false
+field_identifier: content_type
+facet_source_id: 'search_api:views_page__global_overviews__search'
+widget:
+  type: checkbox
+  config:
+    show_numbers: true
+    soft_limit: 0
+    soft_limit_settings:
+      show_less_label: 'Show less'
+      show_more_label: 'Show more'
+    show_reset_link: false
+    reset_text: 'Show all'
+    hide_reset_when_no_selection: false
+query_operator: or
+use_hierarchy: false
+expand_hierarchy: false
+enable_parent_when_child_gets_disabled: true
+hard_limit: 0
+exclude: false
+only_visible_when_facet_source_is_visible: true
+processor_configs:
+  active_widget_order:
+    processor_id: active_widget_order
+    weights:
+      sort: 20
+    settings:
+      sort: DESC
+  count_widget_order:
+    processor_id: count_widget_order
+    weights:
+      sort: 30
+    settings:
+      sort: DESC
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: 40
+    settings:
+      sort: ASC
+  list_item:
+    processor_id: list_item
+    weights:
+      build: 5
+    settings: {  }
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }
+empty_behavior:
+  behavior: none
+show_title: true

--- a/config/sync/facets.facet.search_regions_countries.yml
+++ b/config/sync/facets.facet.search_regions_countries.yml
@@ -1,0 +1,68 @@
+uuid: ee346b24-80c6-4185-a695-eb17fe714a54
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.index.global
+    - views.view.global_overviews
+  module:
+    - search_api
+id: search_regions_countries
+name: 'Regions & Countries'
+url_alias: regions_countries
+weight: 0
+min_count: 1
+show_only_one_result: false
+field_identifier: aggregated_field_vocab_geo
+facet_source_id: 'search_api:views_page__global_overviews__search'
+widget:
+  type: checkbox
+  config:
+    show_numbers: true
+    soft_limit: 0
+    soft_limit_settings:
+      show_less_label: 'Show less'
+      show_more_label: 'Show more'
+    show_reset_link: false
+    reset_text: 'Show all'
+    hide_reset_when_no_selection: false
+query_operator: or
+use_hierarchy: true
+expand_hierarchy: true
+enable_parent_when_child_gets_disabled: true
+hard_limit: 0
+exclude: false
+only_visible_when_facet_source_is_visible: true
+processor_configs:
+  active_widget_order:
+    processor_id: active_widget_order
+    weights:
+      sort: 20
+    settings:
+      sort: DESC
+  count_widget_order:
+    processor_id: count_widget_order
+    weights:
+      sort: 30
+    settings:
+      sort: DESC
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: 40
+    settings:
+      sort: ASC
+  translate_entity_aggregated_fields:
+    processor_id: translate_entity_aggregated_fields
+    weights:
+      build: 5
+    settings: {  }
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }
+empty_behavior:
+  behavior: none
+show_title: true

--- a/config/sync/facets.facet.search_topics.yml
+++ b/config/sync/facets.facet.search_topics.yml
@@ -1,0 +1,68 @@
+uuid: f067d437-617c-4af5-b618-a067c502105c
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.index.global
+    - views.view.global_overviews
+  module:
+    - search_api
+id: search_topics
+name: Topics
+url_alias: topics
+weight: 0
+min_count: 1
+show_only_one_result: false
+field_identifier: aggregated_field_vocab_topics
+facet_source_id: 'search_api:views_page__global_overviews__search'
+widget:
+  type: checkbox
+  config:
+    show_numbers: true
+    soft_limit: 0
+    soft_limit_settings:
+      show_less_label: 'Show less'
+      show_more_label: 'Show more'
+    show_reset_link: false
+    reset_text: 'Show all'
+    hide_reset_when_no_selection: false
+query_operator: or
+use_hierarchy: true
+expand_hierarchy: true
+enable_parent_when_child_gets_disabled: true
+hard_limit: 0
+exclude: false
+only_visible_when_facet_source_is_visible: true
+processor_configs:
+  active_widget_order:
+    processor_id: active_widget_order
+    weights:
+      sort: 20
+    settings:
+      sort: DESC
+  count_widget_order:
+    processor_id: count_widget_order
+    weights:
+      sort: 30
+    settings:
+      sort: DESC
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: 40
+    settings:
+      sort: ASC
+  translate_entity_aggregated_fields:
+    processor_id: translate_entity_aggregated_fields
+    weights:
+      build: 5
+    settings: {  }
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }
+empty_behavior:
+  behavior: none
+show_title: true

--- a/config/sync/facets.facet_source.search_api__views_page__global_overviews__search.yml
+++ b/config/sync/facets.facet_source.search_api__views_page__global_overviews__search.yml
@@ -1,0 +1,9 @@
+uuid: 0c8e985f-f039-4e4a-99ca-d65eb962498b
+langcode: en
+status: true
+dependencies: {  }
+id: search_api__views_page__global_overviews__search
+name: 'search_api:views_page__global_overviews__search'
+filter_key: null
+url_processor: query_string
+breadcrumb: {  }

--- a/config/sync/facets_summary.facets_summary.search_summary.yml
+++ b/config/sync/facets_summary.facets_summary.search_summary.yml
@@ -1,0 +1,51 @@
+uuid: 831a383d-0f54-43e6-9f4b-db1c1ffc8e37
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.index.global
+    - views.view.global_overviews
+  module:
+    - search_api
+id: search_summary
+name: 'Search summary'
+facets:
+  search_content_type:
+    checked: true
+    label: 'Content type'
+    separator: ', '
+    weight: 0
+    show_count: false
+  search_regions_countries:
+    checked: true
+    label: 'Regions & Countries'
+    separator: ', '
+    weight: 0
+    show_count: false
+  search_topics:
+    checked: true
+    label: Topics
+    separator: ', '
+    weight: 0
+    show_count: false
+facet_source_id: 'search_api:views_page__global_overviews__search'
+processor_configs:
+  hide_when_not_rendered:
+    processor_id: hide_when_not_rendered
+    weights:
+      build: '45'
+    settings: {  }
+  reset_facets:
+    processor_id: reset_facets
+    weights:
+      build: '30'
+    settings:
+      link_text: 'Clear all'
+  show_text_when_empty:
+    processor_id: show_text_when_empty
+    weights:
+      build: '10'
+    settings:
+      text:
+        value: 'No results found.'
+        format: plain_text

--- a/config/sync/search_api.index.global.yml
+++ b/config/sync/search_api.index.global.yml
@@ -73,6 +73,33 @@ name: Global
 description: ''
 read_only: false
 field_settings:
+  aggregated_created:
+    label: '[Aggregated] Created on'
+    property_path: aggregated_field
+    type: date
+    configuration:
+      type: union
+      fields:
+        - 'entity:group/created'
+        - 'entity:node/created'
+  aggregated_field_vocab_geo:
+    label: '[Aggregated] Regions & Countries'
+    property_path: aggregated_field
+    type: integer
+    configuration:
+      type: union
+      fields:
+        - 'entity:group/field_vocab_geo'
+        - 'entity:node/field_vocab_geo'
+  aggregated_field_vocab_topics:
+    label: '[Aggregated] Topics'
+    property_path: aggregated_field
+    type: integer
+    configuration:
+      type: union
+      fields:
+        - 'entity:group/field_vocab_topics'
+        - 'entity:node/field_vocab_topics'
   content__group_content__entity_id_gid:
     label: 'Reverse reference: Group content using Content » Parent group'
     datasource_id: 'entity:node'
@@ -226,6 +253,14 @@ field_settings:
     property_path: label
     type: text
     boost: !!float 3
+    dependencies:
+      module:
+        - group
+  group_status:
+    label: '[Group] Published'
+    datasource_id: 'entity:group'
+    property_path: status
+    type: boolean
     dependencies:
       module:
         - group

--- a/config/sync/search_api_sorts.search_api_sorts_field.views_page---global_overviews__search_aggregated_created.yml
+++ b/config/sync/search_api_sorts.search_api_sorts_field.views_page---global_overviews__search_aggregated_created.yml
@@ -1,0 +1,11 @@
+uuid: 2c97220e-a82a-4f4b-b3fa-8db1fbb4aa2e
+langcode: en
+status: true
+dependencies: {  }
+id: views_page---global_overviews__search_aggregated_created
+display_id: views_page---global_overviews__search
+field_identifier: aggregated_created
+default_sort: false
+default_order: desc
+label: 'Date created'
+weight: 0

--- a/config/sync/search_api_sorts.search_api_sorts_field.views_page---global_overviews__search_search_api_relevance.yml
+++ b/config/sync/search_api_sorts.search_api_sorts_field.views_page---global_overviews__search_search_api_relevance.yml
@@ -1,0 +1,11 @@
+uuid: 1c93f21e-a230-4465-894f-f10024c50df5
+langcode: en
+status: true
+dependencies: {  }
+id: views_page---global_overviews__search_search_api_relevance
+display_id: views_page---global_overviews__search
+field_identifier: search_api_relevance
+default_sort: true
+default_order: desc
+label: Relevance
+weight: 0

--- a/config/sync/views.view.global_overviews.yml
+++ b/config/sync/views.view.global_overviews.yml
@@ -58,7 +58,7 @@ display:
           expose:
             items_per_page: true
             items_per_page_label: 'Items per page'
-            items_per_page_options: '10,20,50,100'
+            items_per_page_options: '10,20,25'
             items_per_page_options_all: false
             items_per_page_options_all_label: '- All -'
             offset: false
@@ -80,23 +80,40 @@ display:
             'entity:flagging':
               bookmark_content: default
               bookmark_media: default
+              follow_content: default
+              follow_group: default
+              follow_group_content: default
+              follow_taxonomy: default
+              follow_user: default
+              highlight_content: default
+              highlight_group_content: default
+              like_comment: default
+              like_content: default
+              like_media: default
               recommend: default
+              recommend_group: default
             'entity:group':
               group: teaser
             'entity:group_content':
+              group-group_invitation: default
               group-group_membership: default
+              group-group_node-book: default
               group-group_node-discussion: default
               group-group_node-document: default
+              group-group_node-gallery: default
               group-group_node-wiki_page: default
+              group_content_type_ddd92dce39526: default
             'entity:node':
-              discussion: default
-              document: default
-              news: default
-              page: default
-              story: default
-              wiki_page: default
+              book: teaser
+              discussion: teaser
+              document: teaser
+              gallery: teaser
+              news: teaser
+              page: teaser
+              story: teaser
+              wiki_page: teaser
             'entity:user':
-              user: default
+              user: teaser
       fields:
         label:
           id: label
@@ -440,6 +457,209 @@ display:
         weight: 0
         context: '0'
         menu_name: main
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+      tags:
+        - 'config:search_api.index.global'
+  search:
+    display_plugin: page
+    id: search
+    display_title: Search
+    position: 2
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      title: Search
+      defaults:
+        title: false
+        filters: false
+        filter_groups: false
+        cache: false
+        arguments: false
+      path: search
+      filters:
+        search_api_datasource:
+          id: search_api_datasource
+          table: search_api_index_global
+          field: search_api_datasource
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            'entity:group': 'entity:group'
+            'entity:node': 'entity:node'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          plugin_id: search_api_datasource
+        search_api_fulltext:
+          id: search_api_fulltext
+          table: search_api_index_global
+          field: search_api_fulltext
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: and
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: search_api_fulltext_op
+            label: ''
+            description: ''
+            use_operator: false
+            operator: search_api_fulltext_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: keywords
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              trusted_user: '0'
+              content_administrator: '0'
+              service_authentication: '0'
+              administrator: '0'
+            placeholder: ''
+            expose_fields: false
+            searched_fields_id: search_api_fulltext_searched_fields
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          parse_mode: terms
+          min_length: 2
+          fields: {  }
+          plugin_id: search_api_fulltext
+        content_status:
+          id: content_status
+          table: search_api_index_global
+          field: content_status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 2
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: search_api_boolean
+        group_status:
+          id: group_status
+          table: search_api_index_global
+          field: group_status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 2
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: search_api_boolean
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+          2: OR
+      cache:
+        type: none
+      exposed_block: true
+      arguments: {  }
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
### Description

* Add fields to Search API. Some aggregated fields to combine values from node and group fields.
* Add search page to global overviews view.
* Add facets and facet summary for global search. (facets for content type, regions & countries, topics)

### Not included

* Filters for date taxonomy, themes taxonomy, language taxonomy.
* Sorts for comment count, number of views, recommendations, recently updated.

### Test

* Go to `/search`
* Check search, filters and sorts.
