### PR TITLE
EICNET-750/657: Joining methods available for all visibility types (except private)

### DIFF
--- a/lib/modules/oec_group_flex/src/Plugin/GroupJoiningMethod/TuGroupMembershipRequest.php
+++ b/lib/modules/oec_group_flex/src/Plugin/GroupJoiningMethod/TuGroupMembershipRequest.php
@@ -18,7 +18,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *  weight = -90,
  *  visibilityOptions = {
  *   "public",
- *   "flex"
+ *   "flex",
+ *   "restricted_community_members",
+ *   "custom_restricted"
  *  }
  * )
  */
@@ -27,7 +29,7 @@ class TuGroupMembershipRequest extends GroupJoiningMethodBase implements Contain
   /**
    * The group role synchronizer.
    *
-   * @var GroupRoleSynchronizer
+   * @var \Drupal\group\GroupRoleSynchronizer
    */
   protected $groupRoleSynchronizer;
 

--- a/lib/modules/oec_group_flex/src/Plugin/GroupJoiningMethod/TuOpenMethod.php
+++ b/lib/modules/oec_group_flex/src/Plugin/GroupJoiningMethod/TuOpenMethod.php
@@ -19,7 +19,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *  visibilityOptions = {
  *   "public",
  *   "flex",
- *   "restricted"
+ *   "restricted_community_members",
+ *   "custom_restricted"
  *  }
  * )
  */
@@ -28,7 +29,7 @@ class TuOpenMethod extends GroupJoiningMethodBase implements ContainerFactoryPlu
   /**
    * The group role synchronizer.
    *
-   * @var GroupRoleSynchronizer
+   * @var \Drupal\group\GroupRoleSynchronizer
    */
   protected $groupRoleSynchronizer;
 


### PR DESCRIPTION
As found in the internal demo meeting the joining method should be available for all visibility types, except private. This solves it.

Test:

- [x] Create group
- [x] Change visibility of the group. 
- [x] Notice the joining methods are always available, except if the group visibility is private.