### PR TITLE
EICNET-794: Disable access to manually create book pages in groups

### DIFF
--- a/config/sync/user.role.content_administrator.yml
+++ b/config/sync/user.role.content_administrator.yml
@@ -7,8 +7,9 @@ label: 'Content administrator'
 weight: -7
 is_admin: null
 permissions:
-  - 'administer comments'
   - 'access group overview'
+  - 'add content to books'
+  - 'administer comments'
   - 'bypass node access'
   - 'create group group'
   - 'flag recommend_group'

--- a/config/sync/user.role.trusted_user.yml
+++ b/config/sync/user.role.trusted_user.yml
@@ -9,6 +9,7 @@ is_admin: null
 permissions:
   - 'access comments'
   - 'access group overview'
+  - 'add content to books'
   - 'create eic_document media'
   - 'create group group'
   - 'create image media'

--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -10,6 +10,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\eic_groups\Hooks\EntityOperations;
 use Drupal\eic_groups\Hooks\FormOperations;
+use Drupal\eic_groups\Hooks\Preprocess;
 
 /**
  * Implements hook_theme().
@@ -61,4 +62,13 @@ function eic_groups_form_alter(&$form, FormStateInterface $form_state, $form_id)
       break;
 
   }
+}
+
+/**
+ * Implements hook_preprocess_links__node().
+ */
+function eic_groups_preprocess_links__node(&$variables) {
+  /** @var \Drupal\eic_groups\Hooks\Preprocess $class */
+  $class = \Drupal::classResolver(Preprocess::class);
+  $class->preprocessLinksNode($variables);
 }

--- a/lib/modules/eic_groups/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_groups/src/Hooks/EntityOperations.php
@@ -96,6 +96,9 @@ class EntityOperations implements ContainerInjectionInterface {
               $build['link_add_child_wiki_page'] = $add_wiki_page_urls['add_child_wiki_page']->toString();
               $build['link_add_child_wiki_page_renderable'] = Link::fromTextAndUrl($this->t('Add a new wiki page'), $add_wiki_page_urls['add_child_wiki_page'])->toRenderable();
             }
+            // Unsets book navigation since we already have that show in the
+            // eic_groups_wiki_book_navigation block plugin.
+            unset($build['book_navigation']);
           }
         }
         elseif ($entity->bundle() === 'wiki_page') {

--- a/lib/modules/eic_groups/src/Hooks/Preprocess.php
+++ b/lib/modules/eic_groups/src/Hooks/Preprocess.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Drupal\eic_groups\Hooks;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\eic_groups\EICGroupsHelperInterface;
+use Drupal\node\NodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class Preprocess.
+ *
+ * Implementations of preprocess hooks.
+ */
+class Preprocess implements ContainerInjectionInterface {
+
+  /**
+   * The current route match service.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
+   * The EIC Groups helper service.
+   *
+   * @var \Drupal\eic_groups\EICGroupsHelperInterface
+   */
+  protected $eicGroupsHelper;
+
+  /**
+   * Constructs a new EntityOperations object.
+   *
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The current route match service.
+   * @param \Drupal\eic_groups\EICGroupsHelperInterface $eic_groups_helper
+   *   The EIC Groups helper service.
+   */
+  public function __construct(RouteMatchInterface $route_match, EICGroupsHelperInterface $eic_groups_helper) {
+    $this->routeMatch = $route_match;
+    $this->eicGroupsHelper = $eic_groups_helper;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('current_route_match'),
+      $container->get('eic_groups.helper')
+    );
+  }
+
+  /**
+   * Implements hook_preprocess_links__node().
+   */
+  public function preprocessLinksNode(&$variables) {
+    switch ($this->routeMatch->getRouteName()) {
+      case 'entity.node.canonical':
+        // Removes "Add child page" from book and wiki pages that belong to a
+        // group.
+        if (($node = $this->routeMatch->getParameter('node')) && $node instanceof NodeInterface) {
+          if (in_array($node->bundle(), ['book', 'wiki_page'])) {
+            if ($this->eicGroupsHelper->getGroupByEntity($node)) {
+              unset($variables['links']['book_add_child']);
+            }
+          }
+        }
+        break;
+
+    }
+  }
+
+}


### PR DESCRIPTION
### Description

This PR contains changes to the book and wiki pages so that it removes extra links from the front-end which come from the book module.

List of changes:

- [ ] Add permissions to users to manage the book hierarchy when creating new wiki pages;
- [ ] Remove duplicated navigation from book and wiki pages;
- [ ] Remove "Add child page" from book and wiki pages;

### Tests

- [ ] Create a group as a user with content adminitrator role and publish it
- [ ] Go to the book page of the group via -> http://eic.europa.eu/admin/content
- [ ] Check if the "Add child page" link is not presented. Only the link to add a new wiki page ("Add a new wiki page") should be shown;
- [ ] Create a new wiki page from the book page and check if you are able to change the **Parent item** and **Weight** in the Book Outline options;