### PR TITLE
EICNET-803: Add membership links to group header

### DIFF
--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
@@ -95,7 +95,10 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
       'url.path',
     ]);
 
+    // Get group operation links.
     $operation_links = $this->eicGroupsHelper->getGroupOperationLinks($group, ['node'], $cacheable_metadata);
+    // Get group membership links.
+    $membership_links = $this->eicGroupsHelper->getGroupOperationLinks($group, ['user'], $cacheable_metadata);
 
     // Removes operation link of wiki page group content.
     if (isset($operation_links['gnode-create-wiki_page'])) {
@@ -111,6 +114,7 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
         'title' => $group->label(),
         'description' => $group->get('field_body')->value,
         'operation_links' => $operation_links,
+        'membership_links' => $membership_links,
       ],
     ];
 

--- a/lib/themes/eic_community/includes/preprocess/blocks/block--eic-group-header-block.inc
+++ b/lib/themes/eic_community/includes/preprocess/blocks/block--eic-group-header-block.inc
@@ -26,15 +26,25 @@ function eic_community_preprocess_eic_group_header_block(array &$variables) {
   }
 
   // @todo replace the hardcoded items with structure coming form operation_links.
-  $actions = [
-    [
+  $actions = [];
+
+  // Adds group operation links.
+  if (!empty($variables['group_values']['operation_links'])) {
+    $actions[] = [
       'label' => t('Post content'),
       'items' => [],
-    ],
-  ];
+    ];
+    foreach ($variables['group_values']['operation_links'] as $action) {
+      $actions[0]['items'][]['link'] = [
+        'label' => $action['title'],
+        'path' => $action['url'],
+      ];
+    }
+  }
 
-  foreach ($variables['group_values']['operation_links'] as $action) {
-    $actions[0]['items'][]['link'] = [
+  // Adds membership links.
+  foreach ($variables['group_values']['membership_links'] as $action) {
+    $actions[]['items'][]['link'] = [
       'label' => $action['title'],
       'path' => $action['url'],
     ];
@@ -46,6 +56,6 @@ function eic_community_preprocess_eic_group_header_block(array &$variables) {
   $variables['group_values']['tags'] = [];
   // Adds url to navigate back to the list of groups.
   $back_url = Url::fromRoute('view.global_overviews.page_1');
-  $variables['back_url'] = $back_url->getInternalPath();
+  $variables['back_url'] = $back_url->toString();
 
 }

--- a/lib/themes/eic_community/includes/preprocess/content/media--document--default.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/media--document--default.inc
@@ -16,7 +16,7 @@ function eic_community_preprocess_media__document__default(&$variables) {
   /** @var \Drupal\media\Entity\Media $media */
   $media = $variables['media'];
   $file_value = DocumentMediaValueExtractor::getFileValue($media);
-  if (!$file_value) {
+  if (!$file_value || is_null($file_value)) {
     return;
   }
 


### PR DESCRIPTION
### Description

This PR contains changes to the group header block in order to print the membership links. It also includes improvements to in the preprocess functions.

### Tests

- [ ] Create a public group and publish it
- [ ] Access the group page as a trusted user
- [ ] Check if there is an extra dropdown menu "More" with a link to Join the group
- [ ] Join the group
- [ ] Check if now there is a link to Leave the group