### PR TITLE
EICNET-762 : Restricted group follow-ups

### DIFF
--- a/lib/modules/eic_groups/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_groups/src/Hooks/EntityOperations.php
@@ -120,20 +120,23 @@ class EntityOperations implements ContainerInjectionInterface {
    * Creates top level book page for group wiki section.
    */
   public function createGroupWikiBook(GroupInterface $entity) {
-    $node_values = [
-      'title' => "{$entity->label()} - Wiki",
-      'type' => 'book',
-      'uid' => $entity->getOwnerId(),
-      'status' => 1,
-      'langcode' => $entity->language()->getId(),
-      'book' => [
-        'bid' => 'new',
-        'plid' => 0,
-      ],
-    ];
-    $node = $this->entityTypeManager->getStorage('node')->create($node_values);
-    $node->save();
-    $entity->addContent($node, 'group_node:book');
+    $installedContentPlugins = $entity->getGroupType()->getInstalledContentPlugins();
+    if ($installedContentPlugins && in_array('group_node:book', $installedContentPlugins->getInstanceIds())) {
+      $node_values = [
+        'title' => "{$entity->label()} - Wiki",
+        'type' => 'book',
+        'uid' => $entity->getOwnerId(),
+        'status' => 1,
+        'langcode' => $entity->language()->getId(),
+        'book' => [
+          'bid' => 'new',
+          'plid' => 0,
+        ],
+      ];
+      $node = $this->entityTypeManager->getStorage('node')->create($node_values);
+      $node->save();
+      $entity->addContent($node, 'group_node:book');
+    }
   }
 
   /**

--- a/lib/modules/oec_group_flex/oec_group_flex.links.menu.yml
+++ b/lib/modules/oec_group_flex/oec_group_flex.links.menu.yml
@@ -1,0 +1,6 @@
+oec_group_flex.visibility_settings:
+  title: 'Group visibility'
+  description: 'Configure the group visibility settings.'
+  route_name: 'oec_group_flex.visibility_settings'
+  parent: 'system.admin_group'
+  weight: 15

--- a/lib/modules/oec_group_flex/oec_group_flex.links.task.yml
+++ b/lib/modules/oec_group_flex/oec_group_flex.links.task.yml
@@ -1,0 +1,5 @@
+oec_group_flex.visibility_settings:
+  title: 'Visibility settings'
+  base_route: 'entity.group.collection'
+  route_name: 'oec_group_flex.visibility_settings'
+  weight: 15

--- a/lib/modules/oec_group_flex/oec_group_flex.module
+++ b/lib/modules/oec_group_flex/oec_group_flex.module
@@ -57,10 +57,12 @@ function oec_group_flex_entity_access(EntityInterface $entity, $operation, Accou
     $group_visibility_storage = \Drupal::service('oec_group_flex.group_visibility.storage');
 
     if ($group_visibility_record = $group_visibility_storage->load($entity->id())) {
-      $group_visibility_plugin = $group_visibility_plugin_manager->createInstance($group_visibility_record->getType());
+      if ($group_visibility_record->getType() !== '') {
+        $group_visibility_plugin = $group_visibility_plugin_manager->createInstance($group_visibility_record->getType());
 
-      if ($group_visibility_plugin instanceof GroupVisibilityOptionsInterface) {
-        return $group_visibility_plugin->groupAccess($entity, $operation, $account);
+        if ($group_visibility_plugin instanceof GroupVisibilityOptionsInterface) {
+          return $group_visibility_plugin->groupAccess($entity, $operation, $account);
+        }
       }
     }
   }

--- a/lib/modules/oec_group_flex/oec_group_flex.routing.yml
+++ b/lib/modules/oec_group_flex/oec_group_flex.routing.yml
@@ -1,0 +1,8 @@
+# General routes for the OEC Group Flex module.
+oec_group_flex.visibility_settings:
+  path: '/admin/group/visibility-settings'
+  defaults:
+    _form: '\Drupal\oec_group_flex\Form\GroupVisibilitySettingsForm'
+    _title: 'Group visibility settings'
+  requirements:
+    _permission: 'administer group'

--- a/lib/modules/oec_group_flex/src/Entity/Form/GroupForm.php
+++ b/lib/modules/oec_group_flex/src/Entity/Form/GroupForm.php
@@ -203,10 +203,12 @@ class GroupForm extends GroupFormBase {
       'joining_methods' => $form_state->getValue('group_joining_methods'),
     ];
 
-    $groupVisibilityPlugin = $this->visibilityManager->createInstance($groupFlexSettings['visibility']['plugin_id']);
+    if ($groupFlexSettings['visibility']['plugin_id']) {
+      $groupVisibilityPlugin = $this->visibilityManager->createInstance($groupFlexSettings['visibility']['plugin_id']);
 
-    if ($groupVisibilityPlugin instanceof GroupVisibilityOptionsInterface) {
-      $groupFlexSettings['visibility']['visibility_options'] = $groupVisibilityPlugin->getFormStateValues($form_state);
+      if ($groupVisibilityPlugin instanceof GroupVisibilityOptionsInterface) {
+        $groupFlexSettings['visibility']['visibility_options'] = $groupVisibilityPlugin->getFormStateValues($form_state);
+      }
     }
 
     $this->groupFlexSettings = $groupFlexSettings;

--- a/lib/modules/oec_group_flex/src/Entity/Form/GroupForm.php
+++ b/lib/modules/oec_group_flex/src/Entity/Form/GroupForm.php
@@ -242,7 +242,7 @@ class GroupForm extends GroupFormBase {
           // Extract array into variables.
           extract($value);
 
-          if (is_null($visibility_options)) {
+          if (!isset($visibility_options) || is_null($visibility_options)) {
             $visibility_options = [];
           }
 

--- a/lib/modules/oec_group_flex/src/Form/GroupVisibilitySettingsForm.php
+++ b/lib/modules/oec_group_flex/src/Form/GroupVisibilitySettingsForm.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Drupal\oec_group_flex\Form;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Handles the visibility settings form.
+ */
+class GroupVisibilitySettingsForm extends ConfigFormBase {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  private $entityTypeManager;
+
+  /**
+   * Constructs a \Drupal\system\ConfigFormBase object.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The factory for configuration objects.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, EntityTypeManagerInterface $entityTypeManager) {
+    parent::__construct($config_factory);
+    $this->entityTypeManager = $entityTypeManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'group_visibility_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames(): array {
+    return [
+      'oec_group_flex.settings',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state): array {
+    $form = parent::buildForm($form, $form_state);
+
+    $config = $this->config('oec_group_flex.settings');
+
+    $userRoles = $this->entityTypeManager->getStorage('user_role')->loadMultiple();
+    $disallowedRoles = ['anonymous', 'authenticated'];
+    $userRoleOptions = [];
+    foreach ($userRoles as $role) {
+      if (!in_array($role->id(), $disallowedRoles)) {
+        $userRoleOptions[$role->id()] = $role->label();
+      }
+    }
+
+    $defaultRoles = $config->get('oec_group_visibility_setings.restricted_community_members.internal_roles');
+    $form['restricted_community_members_roles'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Restricted community members roles'),
+      '#description' => $this->t('Select roles for restricted community members visibility.'),
+      '#options' => $userRoleOptions,
+      '#default_value' => $defaultRoles ?: [],
+      '#multiple' => TRUE,
+    ];
+
+    $defaultRoles = $config->get('oec_group_visibility_setings.custom_restricted.internal_roles');
+    $form['custom_restricted_roles'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Custom restricted roles'),
+      '#description' => $this->t('Select roles for custom restricted visibility.'),
+      '#options' => $userRoleOptions,
+      '#default_value' => $defaultRoles ?: [],
+      '#multiple' => TRUE,
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->config('oec_group_flex.settings')
+      ->set('oec_group_visibility_setings.restricted_community_members.internal_roles', $form_state->getValue('restricted_community_members_roles'))
+      ->set('oec_group_visibility_setings.custom_restricted.internal_roles', $form_state->getValue('custom_restricted_roles'))
+      ->save();
+
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/lib/modules/oec_group_flex/src/Plugin/CustomRestrictedVisibility/RestrictedEmailDomains.php
+++ b/lib/modules/oec_group_flex/src/Plugin/CustomRestrictedVisibility/RestrictedEmailDomains.php
@@ -73,8 +73,9 @@ class RestrictedEmailDomains extends CustomRestrictedVisibilityBase {
    * {@inheritdoc}
    */
   public function hasViewAccess(GroupInterface $entity, AccountInterface $account, GroupVisibilityRecordInterface $group_visibility_record) {
+    $conf_key = $this->getPluginId() . '_conf';
     $options = $this->getOptionsForPlugin($group_visibility_record);
-    $configurated_emails = array_key_exists('email_domains_conf', $options) ? $options['email_domains_conf'] : '';
+    $configurated_emails = array_key_exists($conf_key, $options) ? $options[$conf_key] : '';
 
     $email_domains = explode(',', $configurated_emails);
     $account_email_domain = explode('@', $account->getEmail())[1];

--- a/lib/modules/oec_group_flex/src/Plugin/GroupVisibility/CustomRestrictedVisibility.php
+++ b/lib/modules/oec_group_flex/src/Plugin/GroupVisibility/CustomRestrictedVisibility.php
@@ -193,7 +193,7 @@ class CustomRestrictedVisibility extends RestrictedGroupVisibilityBase implement
   public function groupAccess(GroupInterface $entity, $operation, AccountInterface $account) {
     if ($operation === 'view') {
       if (!$entity->getMember($account)) {
-        if ($entity->hasPermission('view group', $account)) {
+        if ($entity->hasPermission('view group', $account) && $entity->isPublished()) {
           $group_visibility_record = $this->groupVisibilityStorage->load($entity->id());
 
           // Loop through all of the options, they are keyed by pluginId.

--- a/lib/modules/oec_group_flex/src/Plugin/GroupVisibility/CustomRestrictedVisibility.php
+++ b/lib/modules/oec_group_flex/src/Plugin/GroupVisibility/CustomRestrictedVisibility.php
@@ -10,6 +10,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\group\Access\GroupAccessResult;
 use Drupal\group\Entity\GroupInterface;
 use Drupal\group\Entity\GroupTypeInterface;
+use Drupal\group\GroupRoleSynchronizer;
 use Drupal\oec_group_flex\GroupVisibilityDatabaseStorageInterface;
 use Drupal\oec_group_flex\Plugin\CustomRestrictedVisibilityInterface;
 use Drupal\oec_group_flex\Plugin\CustomRestrictedVisibilityManager;
@@ -67,6 +68,8 @@ class CustomRestrictedVisibility extends RestrictedGroupVisibilityBase implement
    *   The plugin implementation definition.
    * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
    *   The configuration factory service.
+   * @param \Drupal\group\GroupRoleSynchronizer $groupRoleSynchronizer
+   *   The group role synchronizer.
    * @param \Drupal\oec_group_flex\GroupVisibilityDatabaseStorageInterface $groupVisibilityStorage
    *   The group visibility storage service.
    * @param \Drupal\Component\Utility\EmailValidatorInterface $email_validator
@@ -74,8 +77,8 @@ class CustomRestrictedVisibility extends RestrictedGroupVisibilityBase implement
    * @param \Drupal\oec_group_flex\Plugin\CustomRestrictedVisibilityManager $customRestrictedVisibilityManager
    *   The custom restricted visibility manager.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, ConfigFactoryInterface $configFactory, GroupVisibilityDatabaseStorageInterface $groupVisibilityStorage, EmailValidatorInterface $email_validator, CustomRestrictedVisibilityManager $customRestrictedVisibilityManager) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $configFactory);
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ConfigFactoryInterface $configFactory, GroupRoleSynchronizer $groupRoleSynchronizer, GroupVisibilityDatabaseStorageInterface $groupVisibilityStorage, EmailValidatorInterface $email_validator, CustomRestrictedVisibilityManager $customRestrictedVisibilityManager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $configFactory, $groupRoleSynchronizer);
     $this->groupVisibilityStorage = $groupVisibilityStorage;
     $this->emailValidator = $email_validator;
     $this->customRestrictedVisibilityManager = $customRestrictedVisibilityManager;
@@ -91,6 +94,7 @@ class CustomRestrictedVisibility extends RestrictedGroupVisibilityBase implement
       $plugin_id,
       $plugin_definition,
       $container->get('config.factory'),
+      $container->get('group_role.synchronizer'),
       $container->get('oec_group_flex.group_visibility.storage'),
       $container->get('email.validator'),
       $container->get('plugin.manager.custom_restricted_visibility')

--- a/lib/themes/eic_community/includes/preprocess/groups/group--teaser.inc
+++ b/lib/themes/eic_community/includes/preprocess/groups/group--teaser.inc
@@ -19,7 +19,7 @@ function eic_community_preprocess_group(array &$variables) {
     'stats' => [],
   ];
 
-  if (!$group->get('field_hero')->isEmpty()) {
+  if ($group->hasField('field_hero') && !$group->get('field_hero')->isEmpty()) {
     /** @var \Drupal\media\Entity\Media $media */
     $media = \Drupal::service('entity.repository')->getTranslationFromContext($group->get('field_hero')->entity, $group->language()->getId());
     $image_item = ImageValueObject::fromImageItem($media->get('oe_media_image')->first());


### PR DESCRIPTION
Fixes:

- Validation of the custom restricted visibility option. At least one needs to be selected. 
bd775c6
- Checks if the Group is published before giving access. c7b6344 3f71c71
- Retrieve the group outsider roles via a service provided by Group. 
e8295dc
- Small notice when saving a group with community member visibility. 
e0b270c
- We forgot to change the key email_domains_conf to restricted_email_domains_conf . The access is not working for this plugin right now. See: b8e603a
- Making visibility plugin work on Group Type level again.
4420c45
da4f495
14ed336
- Added Group Visibility settings on `/admin/group/visibility-settings`.