### PR TITLE
EICNET-808: Create banner fragment inline in page.

### DIFF
--- a/config/sync/core.entity_form_display.paragraph.banner.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.banner.default.yml
@@ -5,6 +5,9 @@ dependencies:
   config:
     - field.field.paragraph.banner.field_banner
     - paragraphs.paragraphs_type.banner
+  module:
+    - entity_browser_entity_form
+    - inline_entity_form
 id: paragraph.banner.default
 targetEntityType: paragraph
 bundle: banner
@@ -13,12 +16,21 @@ content:
   field_banner:
     weight: 0
     settings:
+      form_mode: default
+      label_singular: ''
+      label_plural: ''
+      allow_new: true
+      allow_existing: true
       match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: entity_reference_autocomplete
+      revision: false
+      override_labels: false
+      collapsible: false
+      collapsed: false
+      allow_duplicate: false
+    third_party_settings:
+      entity_browser_entity_form:
+        entity_browser_id: _none
+    type: inline_entity_form_complex
     region: content
 hidden:
   created: true


### PR DESCRIPTION
Changed field_banner form field so Banner fragments can be create inline or referenced in the Banner paragraph.

Test:
* /node/add/page