### PR TITLE
EICNET-809: Update text link of buttons to create wiki pages.

### DIFF
--- a/lib/modules/eic_groups/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_groups/src/Hooks/EntityOperations.php
@@ -105,10 +105,10 @@ class EntityOperations implements ContainerInjectionInterface {
           // Add wiki page create form url to the build array.
           if ($add_wiki_page_urls = $this->getWikiPageAddFormUrls($entity)) {
             $build['link_add_current_level_wiki_page'] = $add_wiki_page_urls['add_current_level_wiki_page']->toString();
-            $build['link_add_current_level_wiki_page_renderable'] = Link::fromTextAndUrl($this->t('Add a new wiki page at the current level'), $add_wiki_page_urls['add_current_level_wiki_page'])->toRenderable();
+            $build['link_add_current_level_wiki_page_renderable'] = Link::fromTextAndUrl($this->t('Add a new page on the current level'), $add_wiki_page_urls['add_current_level_wiki_page'])->toRenderable();
             $build['link_add_current_level_wiki_page_renderable']['#suffix'] = '<br>';
             $build['link_add_child_wiki_page'] = $add_wiki_page_urls['add_child_wiki_page']->toString();
-            $build['link_add_child_wiki_page_renderable'] = Link::fromTextAndUrl($this->t('Add a new wiki page bellow this level'), $add_wiki_page_urls['add_child_wiki_page'])->toRenderable();
+            $build['link_add_child_wiki_page_renderable'] = Link::fromTextAndUrl($this->t('Add a new wiki page below this page'), $add_wiki_page_urls['add_child_wiki_page'])->toRenderable();
           }
         }
         break;


### PR DESCRIPTION
### Changes

- [ ] EICNET-809: Update text link of buttons to create wiki pages.

### Test

- [ ] Create a new group
- [ ] Navigate to the book page of the group (you can use the **/admin/content** view) and create a new wiki page from there
- [ ] Check if the text links to add wiki pages are as follow:  "Add a new page on the current level" and "Add a new wiki page below this page".