### PR TITLE
EICNET-667: Match storybook html with current Drupal theme.

### DIFF
--- a/config/sync/context.context.groups_overview.yml
+++ b/config/sync/context.context.groups_overview.yml
@@ -24,7 +24,7 @@ reactions:
         label: 'Groups summary'
         provider: facets_summary
         label_display: '0'
-        region: content
+        region: content_before
         weight: '-1'
         context_mapping: {  }
         custom_id: facets_summary_block_groups_summary
@@ -95,7 +95,7 @@ reactions:
         label: 'Sort by'
         provider: search_api_sorts
         label_display: visible
-        region: content
+        region: content_before
         weight: '-2'
         context_mapping: {  }
         custom_id: search_api_sorts_block_views_page_global_overviews__page_1

--- a/lib/themes/eic_community/eic_community.info.yml
+++ b/lib/themes/eic_community/eic_community.info.yml
@@ -12,7 +12,9 @@ libraries:
 
 regions:
   breadcrumbs: 'Breadcrumbs'
+  content_before: 'Before content'
   content: 'Content'
+  content_after: 'After content'
   footer: 'Footer'
   navigation: 'Navigation'
   page_header: 'Page header'

--- a/lib/themes/eic_community/includes/alter/theme_suggestions/views.inc
+++ b/lib/themes/eic_community/includes/alter/theme_suggestions/views.inc
@@ -20,6 +20,10 @@ function eic_community_theme_suggestions_views_view_alter(array &$suggestions, a
       $suggestions[] = "views_view__featured_content_collection";
       break;
     case 'global_overviews':
+      if($variables['view']->getDisplay()->display['id'] === 'search') {
+        return;
+      }
+
       $suggestions[] = "views_view__teaser_overview";
       break;
   }

--- a/lib/themes/eic_community/includes/preprocess/groups/group--teaser.inc
+++ b/lib/themes/eic_community/includes/preprocess/groups/group--teaser.inc
@@ -17,6 +17,7 @@ function eic_community_preprocess_group(array &$variables) {
   $item = [
     'owner' => eic_community_get_teaser_user_display($group->getOwner()),
     'stats' => [],
+    'icon_file_path' => $variables['eic_icon_path'],
   ];
 
   if (!$group->get('field_hero')->isEmpty()) {

--- a/lib/themes/eic_community/templates/facets/facets-item-list--checkbox--groups.html.twig
+++ b/lib/themes/eic_community/templates/facets/facets-item-list--checkbox--groups.html.twig
@@ -23,6 +23,7 @@
  *
  * @ingroup themeable
  */#}
+{{ attach }}
 {% if facet.widget.type %}
   {%- set attributes = attributes.addClass('item-list__' ~ facet.widget.type) %}
 {% endif %}
@@ -67,7 +68,7 @@
               variant: 'ghost',
               label: expand_label|default('Show all'),
               icon: {
-                path: icon_file_path,
+                path: eic_icon_path,
                 type: 'ui',
                 name: 'rounded-arrow',
                 size: 'xs',
@@ -79,7 +80,7 @@
               variant: 'ghost',
               label: collapse_label|default('Collapse'),
               icon: {
-                path: icon_file_path,
+                path: eic_icon_path,
                 type: 'ui',
                 name: 'rounded-arrow',
                 size: 'xs',

--- a/lib/themes/eic_community/templates/facets/facets-summary-item-list.html.twig
+++ b/lib/themes/eic_community/templates/facets/facets-summary-item-list.html.twig
@@ -31,8 +31,19 @@
 
   {%- if items -%}
     <div class="ecl-teaser-overview__active-filters">
-    {%- for item in items -%}
-      {% if loop.index == 1 %}
+      {% set clearItem = items|first %}
+      {% include "@ecl-twig/ec-component-button/ecl-button.html.twig" with {
+        icon: {
+          path: eic_icon_path,
+          name: 'clear',
+          type: 'custom',
+          size: '2xs',
+        },
+        variant: 'ghost',
+        extra_classes: 'ecl-teaser-overview__active-filters-clear-all facet-summary-item--clear',
+        label: clearItem.value
+      } only %}
+      {%- for item in items|slice(start + 1, length) -%}
         {% include "@ecl-twig/ec-component-button/ecl-button.html.twig" with {
           icon: {
             path: eic_icon_path,
@@ -41,20 +52,10 @@
             size: '2xs',
           },
           variant: 'ghost',
-          extra_classes: 'ecl-teaser-overview__active-filters-clear-all',
+          extra_classes: 'facet-summary-item--facet',
           label: item.value
         } only %}
-      {% else %}
-        {% include "@ecl-twig/ec-component-tag/ecl-tag.html.twig" with {
-          tag: {
-            type: 'removable',
-            label: item.value
-          },
-          default_icon_path: eic_icon_path,
-          extra_classes: 'ecl-teaser-overview__active-filters-tag'
-        } only %}
-      {% endif %}
-    {%- endfor -%}
+      {%- endfor -%}
     </div>
   {%- endif -%}
 {%- endif %}

--- a/lib/themes/eic_community/templates/layout/page--groups.html.twig
+++ b/lib/themes/eic_community/templates/layout/page--groups.html.twig
@@ -1,0 +1,106 @@
+{#
+/**
+ * @file
+ * Theme override to display a single page.
+ *
+ * @see ./core/themes/stable/templates/layout/page.html.twig
+ */
+#}
+{% if page.sidebar is not empty %}
+  {% set output_sidebar = page.sidebar %}
+{% elseif block('sidebar') is defined %}
+  {% set output_sidebar = block('sidebar') %}
+{% endif %}
+
+{% if page.content_before is not empty %}
+  {% set output_content_before = page.content_before %}
+{% elseif block('content_before') is defined %}
+  {% set output_content_before = block('content_before') %}
+{% endif %}
+
+{% if page.content_after is not empty %}
+  {% set output_content_after = page.content_after %}
+{% elseif block('content_after') is defined %}
+  {% set output_content_after = block('content_after') %}
+{% endif %}
+
+<div class="ecl-viewport">
+  <div class="ecl-viewport__top">
+    {% block site_top_bar %}
+      {{ page.site_top_bar }}
+    {% endblock %}
+
+    {% block site_header %}
+      {% if top_menu %}
+        {% include "@theme/patterns/compositions/top-menu.html.twig" with top_menu|default({}) only %}
+      {% endif %}
+
+      {% if site_header %}
+        {% include "@theme/patterns/compositions/global-header.html.twig" with site_header|default({})|merge({
+          user: user|default(NULL)
+        }) only %}
+      {% endif %}
+
+      {% if mainmenu %}
+        {% include "@theme/patterns/compositions/mainmenu.html.twig" with {
+          label: mainmenu_label,
+          mainmenu: mainmenu|default({}),
+          searchform: searchform|default({}),
+        } only %}
+      {% endif %}
+    {% endblock %}
+
+    {% block navigation %}
+      {{ page.navigation }}
+    {% endblock %}
+
+    {% block breadcrumbs %}
+      {{ page.breadcrumbs }}
+    {% endblock %}
+  </div>
+
+  <div class="ecl-viewport__middle">
+    {% block page_header %}
+      {{ page.page_header }}
+    {% endblock %}
+
+    <div class="ecl-base-layout{{ output_sidebar ? ' ecl-base-layout--contain' }} {{ layout ? layout.extra_classes }}">
+      <div class="ecl-base-layout__content">
+        <div class="ecl-base-layout__main">
+          <main{{ main_attributes }}>
+            <div class="ecl-teaser-overview ecl-teaser-overview--has-compact-layout ecl-teaser-overview--has-columns">
+            {% block content %}
+              {{ page.content }}
+            {% endblock %}
+            {% if output_content_before %}
+              <section class="ecl-teaser-overview__options">
+                {{ output_content_before }}
+              </section>
+            {% endif %}
+            </div>
+          </main>
+        </div>
+
+        {% if output_sidebar %}
+          <div class="ecl-base-layout__aside">
+            {{ output_sidebar }}
+          </div>
+        {% endif %}
+      </div>
+
+      {% if output_content_after %}
+        <div class="ecl-base-layout__content-after">
+          {{ output_content_after }}
+        </div>
+      {% endif %}
+    </div>
+  </div>
+
+  <div class="ecl-viewport__bottom">
+    {% block footer %}
+      {% if site_footer %}
+        {% include "@theme/patterns/compositions/site-footer.html.twig" with site_footer|default({}) only %}
+      {% endif %}
+    {% endblock %}
+  </div>
+</div>

--- a/lib/themes/eic_community/templates/region/region--sidebar.html.twig
+++ b/lib/themes/eic_community/templates/region/region--sidebar.html.twig
@@ -1,0 +1,47 @@
+{#
+/**
+ * @file
+ * Override theme implementation to display the sidebar region.
+ *
+ * Available variables:
+ * - content: The content for this region, typically blocks.
+ * - attributes: HTML attributes for the region <div>.
+ * - region: The name of the region variable as defined in the theme's
+ *   .info.yml file.
+ *
+ * @see template_preprocess_region()
+ *
+ * @ingroup themeable
+ */
+#}
+{% if content %}
+  <div{{ attributes.addClass('ecl-filter-sidebar') }}>
+    {{ content }}
+    <div class="ecl-filter-sidebar__splash">
+      {% include '@ecl-twig/ec-component-button/ecl-button.html.twig' with {
+        variant: 'primary',
+        icon_position: 'before',
+        icon: icon_file_path ? {
+          path: eic_icon_path,
+          name: 'plus',
+          type: 'ui',
+          size: 's',
+        } : {},
+        label: show_filters_label|default('Show filters'),
+        extra_classes: 'ecl-filter-sidebar__expand',
+      } only %}
+      {% include '@ecl-twig/ec-component-button/ecl-button.html.twig' with {
+        variant: 'primary',
+        icon_position: 'before',
+        icon: icon_file_path ? {
+          path: eic_icon_path,
+          name: 'clear',
+          type: 'custom',
+          size: '2xs',
+        } : {},
+        label: hide_filters_label|default('Hide filters'),
+        extra_classes: 'ecl-filter-sidebar__collapse',
+      } only %}
+    </div>
+  </div>
+{% endif %}

--- a/lib/themes/eic_community/templates/views/views-view--teaser-overview.html.twig
+++ b/lib/themes/eic_community/templates/views/views-view--teaser-overview.html.twig
@@ -38,20 +38,23 @@
 
 {% if rows -%}
   {% set _rows_length = rows[0]['#rows']|length %}
-  {% set _items = [] %}
+  {% set items = [] %}
 
   {% for row in rows[0]['#rows'] %}
     {%
-      set _items = _items|merge([{
+      set items = items|merge([{
         content: row,
       }])
     %}
   {% endfor %}
+  <div class="ecl-teaser-overview__items">
+    {% for item in items %}
+      <div class="ecl-teaser-overview__item {{ item.extra_classes }}">
+        {{ item.content }}
+      </div>
+    {% endfor %}
+  </div>
 
-  {% include "@theme/patterns/compositions/teaser-overview.html.twig" with {
-    items: _items,
-    extra_classes: 'ecl-teaser-overview ecl-teaser-overview--has-compact-layout ecl-teaser-overview--has-columns',
-  } only %}
 {% endif %}
 
 {{ pager }}


### PR DESCRIPTION
Added content_before and content_after regions to the theme.
Moved sort by and selected topics/regions to content_before.
Made collapsing of Topics/regions work.
Show default picture if the group has no image.