### PR TITLE
EICNET-811: Overview groups - split up search input and items per page selection

### DIFF
--- a/config/sync/context.context.groups_overview.yml
+++ b/config/sync/context.context.groups_overview.yml
@@ -104,21 +104,20 @@ reactions:
         unique: 0
         context_id: groups_overview
         uuid: 97b594dc-7529-4ac6-973d-b43ffc569246
-      5cd6129d-7c65-4162-956e-641051af13d4:
-        id: 'views_exposed_filter_block:global_overviews-page_1'
-        label: ''
-        provider: views
+      bdf030ef-84f4-4a8e-a081-da63174cb1d1:
+        id: eic_theme_helper_views_filter_items_per_page
+        label: 'Views filter items per page block'
+        provider: eic_theme_helper
         label_display: '0'
-        views_label: ''
         region: content_before
         weight: '-3'
         context_mapping: {  }
-        custom_id: views_exposed_filter_block_global_overviews_page_1
+        custom_id: eic_theme_helper_views_filter_items_per_page
         theme: eic_community
         css_class: ''
         unique: 0
         context_id: groups_overview
-        uuid: 5cd6129d-7c65-4162-956e-641051af13d4
+        uuid: bdf030ef-84f4-4a8e-a081-da63174cb1d1
     id: blocks
     saved: false
     uuid: deeaf135-b781-47ec-b086-7d9fec72c007

--- a/config/sync/context.context.groups_overview.yml
+++ b/config/sync/context.context.groups_overview.yml
@@ -104,6 +104,21 @@ reactions:
         unique: 0
         context_id: groups_overview
         uuid: 97b594dc-7529-4ac6-973d-b43ffc569246
+      5cd6129d-7c65-4162-956e-641051af13d4:
+        id: 'views_exposed_filter_block:global_overviews-page_1'
+        label: ''
+        provider: views
+        label_display: '0'
+        views_label: ''
+        region: content_before
+        weight: '-3'
+        context_mapping: {  }
+        custom_id: views_exposed_filter_block_global_overviews_page_1
+        theme: eic_community
+        css_class: ''
+        unique: 0
+        context_id: groups_overview
+        uuid: 5cd6129d-7c65-4162-956e-641051af13d4
     id: blocks
     saved: false
     uuid: deeaf135-b781-47ec-b086-7d9fec72c007

--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -61,6 +61,18 @@ function eic_groups_form_alter(&$form, FormStateInterface $form_state, $form_id)
       $form['book']['bid']['#access'] = FALSE;
       break;
 
+    case 'views_exposed_form':
+      $view_machine_name = str_replace('views-exposed-form-', '', $form['#id']);
+
+      switch ($view_machine_name) {
+        case 'global-overviews-page-1':
+          // Removes items_per_page pager from the form.
+          unset($form['items_per_page']);
+          break;
+
+      }
+      break;
+
   }
 }
 

--- a/lib/modules/eic_theme_helper/src/Plugin/Block/ViewsFilterItemsPerPageBlock.php
+++ b/lib/modules/eic_theme_helper/src/Plugin/Block/ViewsFilterItemsPerPageBlock.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace Drupal\eic_theme_helper\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Link;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Url;
+use Drupal\views\ViewExecutable;
+use Drupal\views\Views;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Provides a ViewsFilterItemsPerPageBlock block.
+ *
+ * @Block(
+ *   id = "eic_theme_helper_views_filter_items_per_page",
+ *   admin_label = @Translation("Views filter items per page block"),
+ *   category = @Translation("OpenEuropa")
+ * )
+ */
+class ViewsFilterItemsPerPageBlock extends BlockBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The current route match.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
+   * The request stack.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
+   * Constructs a new ViewsFilterItemsPerPageBlock instance.
+   *
+   * @param array $configuration
+   *   The plugin configuration, i.e. an array with configuration values keyed
+   *   by configuration option name. The special key 'context' may be used to
+   *   initialize the defined contexts by setting it to an array of context
+   *   values keyed by context names.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The current route match.
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
+   *   The request stack.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, RouteMatchInterface $route_match, RequestStack $request_stack) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->entityTypeManager = $entity_type_manager;
+    $this->routeMatch = $route_match;
+    $this->requestStack = $request_stack;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+      $container->get('current_route_match'),
+      $container->get('request_stack')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $build = [];
+
+    // Get current route object.
+    $route = $this->routeMatch->getRouteObject();
+
+    if (is_null($route)) {
+      return $build;
+    }
+
+    // Get view id and display id from route.
+    $view_id = $route->getDefault('view_id');
+    $display_id = $route->getDefault('display_id');
+
+    if (empty($view_id) || empty($display_id)) {
+      return $build;
+    }
+
+    // Get current route name.
+    $current_route_name = $this->routeMatch->getRouteName();
+
+    // We check if the current route is actually a view page.
+    if ($current_route_name !== "view.$view_id.$display_id") {
+      return $build;
+    }
+
+    // // Get the view by id and initializes the right display.
+    $view = Views::getView($view_id);
+    $view->setDisplay($display_id);
+
+    // Check if items per page are exposed and grab the options.
+    if (!($items_per_age_options = $this->getItemsPerPageOptions($view))) {
+      return $build;
+    }
+
+    $query_params = $this->requestStack->getCurrentRequest()->query->all();
+
+    // Create items per page links.
+    $links = [];
+    foreach ($items_per_age_options as $option) {
+      $query_params['items_per_page'] = $option;
+      $url = Url::fromRoute($current_route_name, [], ['query' => $query_params]);
+      $links[] = Link::fromTextAndUrl($option, $url)->toString()->setCacheContexts([
+        'url.path',
+        'url.query_args',
+      ]);
+    }
+
+    if (empty($links)) {
+      return $build;
+    }
+
+    $build['content'] = [
+      '#theme' => 'item_list',
+      '#list_type' => 'ul',
+      '#title' => $this->t('Showing'),
+      '#items' => $links,
+    ];
+
+    return $build;
+  }
+
+  /**
+   * Gets the items per page options for a given View.
+   *
+   * @param \Drupal\views\ViewExecutable $view
+   *   The view executable instance object.
+   *
+   * @return array|bool
+   *   An array containing items per page values or FALSE if none.
+   */
+  private function getItemsPerPageOptions(ViewExecutable $view) {
+    $pager = $view->display_handler->getOption('pager');
+
+    if (empty($pager['options'])) {
+      return FALSE;
+    }
+
+    $pager_options = $pager['options'];
+
+    if (empty($pager_options['expose'])) {
+      return FALSE;
+    }
+
+    if (empty($pager_options['items_per_page'])) {
+      return FALSE;
+    }
+
+    return explode(',', $pager_options['expose']['items_per_page_options']);
+  }
+
+}

--- a/lib/modules/eic_theme_helper/src/Plugin/Block/ViewsFilterItemsPerPageBlock.php
+++ b/lib/modules/eic_theme_helper/src/Plugin/Block/ViewsFilterItemsPerPageBlock.php
@@ -114,7 +114,7 @@ class ViewsFilterItemsPerPageBlock extends BlockBase implements ContainerFactory
       return $build;
     }
 
-    // // Get the view by id and initializes the right display.
+    // Get the view by id and initializes the right display.
     $view = Views::getView($view_id);
     $view->setDisplay($display_id);
 

--- a/lib/themes/eic_community/includes/preprocess/forms/form.inc
+++ b/lib/themes/eic_community/includes/preprocess/forms/form.inc
@@ -12,4 +12,9 @@ function eic_community_preprocess_form(&$variables) {
   if ($variables['element']['#id'] == 'comment-form') {
     _eic_community_preprocess_comment_form($variables);
   }
+
+  // Preprocess views exposed form.
+  if (strpos($variables['element']['#id'], 'views-exposed-form-') !== FALSE) {
+    _eic_community_preprocess_views_exposed_form($variables);
+  }
 }

--- a/lib/themes/eic_community/includes/preprocess/forms/views-exposed-form.inc
+++ b/lib/themes/eic_community/includes/preprocess/forms/views-exposed-form.inc
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @file
+ * Common logic for views exposed forms.
+ */
+
+use Drupal\Component\Utility\Html;
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function _eic_community_preprocess_views_exposed_form(&$variables) {
+  // Make sure we have unique ids when views exposed forms are shown
+  // multiple times on the page.
+  $unique_id = Html::getUniqueId($variables['element']['#id']);
+  $variables['attributes']['id'] = $variables['attributes']['data-drupal-selector'] = $unique_id;
+}


### PR DESCRIPTION
### Description

This PR introduces a solution to split up search input and items per page selection in overview pages. Note that this is only working in Groups overview page (/groups).

- [ ] ~Place duplicated views exposed form in groups overview (Groups overview context - admin/structure/context/groups_overview)~
- [ ] ~Make sure views exposed forms have unique id attributes when shown multiple times on the page.~
- [ ] Create custom block plugin (**eic_theme_helper_views_filter_items_per_page**) to expose views "Item per page" filter in a block and turn it as a list of links;
- [ ] Place block **eic_theme_helper_views_filter_items_per_page** in groups overview page.
- [ ] Remove "items_per_page" filter from views_exposed_form (see hook **eic_groups_form_alter**).

### Tests

- [ ] Go to /groups and check
