### PR TITLE
EICNET-768: Fixes padding for card group teaser.

### DIFF
--- a/lib/themes/eic_community/sass/compositions/_teaser.scss
+++ b/lib/themes/eic_community/sass/compositions/_teaser.scss
@@ -51,7 +51,7 @@
       padding: ecl-box-model('padding');
     }
 
-    &:not(.ecl-teaser--event).ecl-teaser--as-card .ecl-teaser__main-wrapper {
+    &:not(.ecl-teaser--event):not(.ecl-teaser--group).ecl-teaser--as-card .ecl-teaser__main-wrapper {
       padding: 0 ecl-box-model('padding') ecl-box-model('padding');
     }
 


### PR DESCRIPTION
This PR should fix the issue where the teaser had incorrect padding for related groups within a group template. This bug was only visible for the overview sections with a coloured background.