### PR TITLE
EICNET-813: Create cron job to update group content URL aliases when group url alias is updated

### DIFF
--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -9,6 +9,7 @@ use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\BubbleableMetadata;
+use Drupal\eic_groups\Hooks\CronOperations;
 use Drupal\eic_groups\Hooks\EntityOperations;
 use Drupal\eic_groups\Hooks\GroupTokens;
 use Drupal\eic_groups\Hooks\FormOperations;
@@ -109,4 +110,12 @@ function eic_groups_pathauto_alias_alter(&$alias, array &$context) {
   /** @var \Drupal\eic_groups\Hooks\Pathauto $class */
   $class = \Drupal::classResolver(Pathauto::class);
   $class->aliasAlter($alias, $context);
+}
+
+/**
+ * Implements hook_cron().
+ */
+function eic_groups_cron() {
+  \Drupal::classResolver(CronOperations::class)
+    ->cron();
 }

--- a/lib/modules/eic_groups/src/Hooks/CronOperations.php
+++ b/lib/modules/eic_groups/src/Hooks/CronOperations.php
@@ -21,17 +21,17 @@ class CronOperations implements ContainerInjectionInterface {
   /**
    * Group alias update queue name.
    */
-  const GROUP_URL_ALIAS_UPDATE_QUEUE = 'cron_group_url_alias_update';
+  const GROUP_URL_ALIAS_UPDATE_QUEUE = 'eic_groups_cron_group_url_alias_update';
 
   /**
    * Group alias update state cache base machine name.
    */
-  const GROUP_URL_ALIAS_UPDATE_STATE_CACHE = 'cron_group_url_alias_update:gid:';
+  const GROUP_URL_ALIAS_UPDATE_STATE_CACHE = 'eic_groups_cron_group_url_alias_update:gid:';
 
   /**
    * Group content alias update queue name.
    */
-  const GROUP_CONTENT_URL_ALIAS_UPDATE_QUEUE = 'group_content_url_alias_update';
+  const GROUP_CONTENT_URL_ALIAS_UPDATE_QUEUE = 'eic_groups_group_content_url_alias_update';
 
   /**
    * The entity type manager.

--- a/lib/modules/eic_groups/src/Hooks/CronOperations.php
+++ b/lib/modules/eic_groups/src/Hooks/CronOperations.php
@@ -29,7 +29,7 @@ class CronOperations implements ContainerInjectionInterface {
   const GROUP_URL_ALIAS_UPDATE_STATE_CACHE = 'cron_group_url_alias_update:gid:';
 
   /**
-   * Group alias update queue name.
+   * Group content alias update queue name.
    */
   const GROUP_CONTENT_URL_ALIAS_UPDATE_QUEUE = 'group_content_url_alias_update';
 

--- a/lib/modules/eic_groups/src/Hooks/CronOperations.php
+++ b/lib/modules/eic_groups/src/Hooks/CronOperations.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace Drupal\eic_groups\Hooks;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Queue\QueueFactory;
+use Drupal\Core\Queue\QueueWorkerManagerInterface;
+use Drupal\Core\Queue\SuspendQueueException;
+use Drupal\Core\State\StateInterface;
+use Drupal\pathauto\PathautoGeneratorInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class CronOperations.
+ *
+ * Implementations for hook_cron().
+ */
+class CronOperations implements ContainerInjectionInterface {
+
+  /**
+   * Group alias update queue name.
+   */
+  const GROUP_URL_ALIAS_UPDATE_QUEUE = 'cron_group_url_alias_update';
+
+  /**
+   * Group alias update state cache base machine name.
+   */
+  const GROUP_URL_ALIAS_UPDATE_STATE_CACHE = 'cron_group_url_alias_update:gid:';
+
+  /**
+   * Group alias update queue name.
+   */
+  const GROUP_CONTENT_URL_ALIAS_UPDATE_QUEUE = 'group_content_url_alias_update';
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The pathauto generator.
+   *
+   * @var \Drupal\pathauto\PathautoGeneratorInterface
+   */
+  protected $pathautoGenerator;
+
+  /**
+   * The queue factory service.
+   *
+   * @var \Drupal\Core\Queue\QueueFactory
+   */
+  protected $queueFactory;
+
+  /**
+   * The state service.
+   *
+   * @var \Drupal\Core\State\StateInterface
+   */
+  protected $state;
+
+  /**
+   * The queue worker manager.
+   *
+   * @var \Drupal\Core\Queue\QueueWorkerManagerInterface
+   */
+  protected $queueManager;
+
+  /**
+   * Constructs a CronOperations object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\pathauto\PathautoGeneratorInterface $pathauto_generator
+   *   The pathauto generator.
+   * @param \Drupal\Core\Queue\QueueFactory $queue_factory
+   *   The queue factory service.
+   * @param \Drupal\Core\Queue\QueueWorkerManagerInterface $queue_worker_manager
+   *   The queue worker manager.
+   * @param \Drupal\Core\State\StateInterface $state
+   *   The state service.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, PathautoGeneratorInterface $pathauto_generator, QueueFactory $queue_factory, QueueWorkerManagerInterface $queue_worker_manager, StateInterface $state) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->pathautoGenerator = $pathauto_generator;
+    $this->queueFactory = $queue_factory;
+    $this->queueManager = $queue_worker_manager;
+    $this->state = $state;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('pathauto.generator'),
+      $container->get('queue'),
+      $container->get('plugin.manager.queue_worker'),
+      $container->get('state')
+    );
+  }
+
+  /**
+   * Implements hook_cron().
+   */
+  public function cron() {
+    $this->processGroupUrlAliasUpdateQueue();
+    $this->processGroupContentUrlAliasUpdateQueue();
+  }
+
+  /**
+   * Process Group alias update queue.
+   *
+   * @todo We should update all url alias of group content and nodes using
+   * a queue worker and the queue should be filled using ultimate cron.
+   */
+  protected function processGroupUrlAliasUpdateQueue() {
+    $group_alias_queue = $this->queueFactory->get(self::GROUP_URL_ALIAS_UPDATE_QUEUE);
+
+    while ($item = $group_alias_queue->claimItem()) {
+      try {
+        if (!empty($item->data['gid'])) {
+          /** @var \Drupal\group\Entity\GroupInterface $group */
+          $group = $this->entityTypeManager->getStorage('group')->load($item->data['gid']);
+
+          $installedContentPluginIds = $group->getGroupType()->getInstalledContentPlugins()->getInstanceIds();
+          foreach ($installedContentPluginIds as $key => $pluginId) {
+            $installedContentPluginIds[$key] = 'group-' . str_replace(':', '-', $pluginId);
+          }
+
+          $query = $this->entityTypeManager->getStorage('group_content')->getQuery();
+          $query->condition('type', $installedContentPluginIds, 'IN');
+          $results = $query->execute();
+
+          if (!empty($results)) {
+            $group_content_url_alias_update_queue = $this->queueFactory->get(self::GROUP_CONTENT_URL_ALIAS_UPDATE_QUEUE);
+
+            foreach ($results as $group_content_id) {
+              $group_content_url_alias_update_queue->createItem($group_content_id);
+            }
+          }
+        }
+
+        $group_alias_queue->deleteItem($item);
+        $this->state->delete(self::GROUP_URL_ALIAS_UPDATE_STATE_CACHE . $group->id());
+      }
+      catch (SuspendQueueException $e) {
+        $group_alias_queue->releaseItem($item);
+        break;
+      }
+    }
+  }
+
+  /**
+   * Process Group content url alias update queue.
+   *
+   * @todo We should update all url alias of group content and nodes using
+   * a queue worker.
+   */
+  protected function processGroupContentUrlAliasUpdateQueue() {
+    $queue = $this->queueFactory->get(self::GROUP_CONTENT_URL_ALIAS_UPDATE_QUEUE);
+    $queue_worker = $this->queueManager->createInstance(self::GROUP_CONTENT_URL_ALIAS_UPDATE_QUEUE);
+
+    while ($item = $queue->claimItem()) {
+      try {
+        $queue_worker->processItem($item->data);
+        $queue->deleteItem($item);
+      }
+      catch (SuspendQueueException $e) {
+        $queue->releaseItem($item);
+        break;
+      }
+    }
+  }
+
+}

--- a/lib/modules/eic_groups/src/Hooks/CronOperations.php
+++ b/lib/modules/eic_groups/src/Hooks/CronOperations.php
@@ -114,8 +114,7 @@ class CronOperations implements ContainerInjectionInterface {
   /**
    * Process Group alias update queue.
    *
-   * @todo We should update all url alias of group content and nodes using
-   * a queue worker and the queue should be filled using ultimate cron.
+   * @todo In the future this method should be called by ultimate cron module.
    */
   protected function processGroupUrlAliasUpdateQueue() {
     $group_alias_queue = $this->queueFactory->get(self::GROUP_URL_ALIAS_UPDATE_QUEUE);
@@ -157,8 +156,8 @@ class CronOperations implements ContainerInjectionInterface {
   /**
    * Process Group content url alias update queue.
    *
-   * @todo We should update all url alias of group content and nodes using
-   * a queue worker.
+   * @todo This method should be removed after installing and configure
+   * ultimate cron module.
    */
   protected function processGroupContentUrlAliasUpdateQueue() {
     $queue = $this->queueFactory->get(self::GROUP_CONTENT_URL_ALIAS_UPDATE_QUEUE);

--- a/lib/modules/eic_groups/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_groups/src/Hooks/EntityOperations.php
@@ -125,16 +125,10 @@ class EntityOperations implements ContainerInjectionInterface {
       $this->publishGroupWiki($entity);
     }
 
-    // If group alias has changed we add the group id into a queue so all group
-    // content url aliases can be updated at a later stage with cron.
+    // If group alias has changed we add the group id into a queue so that all
+    // group content url aliases can be updated at a later stage with cron.
     if ($entity->get('path')->alias !== $this->pathautoGenerator->createEntityAlias($entity, 'return')) {
-      if (is_null($this->state->get(CronOperations::GROUP_URL_ALIAS_UPDATE_STATE_CACHE . $entity->id()))) {
-        $queue = $this->queueFactory->get(CronOperations::GROUP_URL_ALIAS_UPDATE_QUEUE);
-        $queue->createItem([
-          'gid' => $entity->id(),
-        ]);
-        $this->state->set(CronOperations::GROUP_URL_ALIAS_UPDATE_STATE_CACHE . $entity->id(), TRUE);
-      }
+      $this->createGroupUrlAliasUpdateQueueItem($entity);
     }
   }
 
@@ -259,6 +253,22 @@ class EntityOperations implements ContainerInjectionInterface {
         $node_book->setPublished();
         $node_book->save();
       }
+    }
+  }
+
+  /**
+   * Creates an item in the queue CronOperations::GROUP_URL_ALIAS_UPDATE_QUEUE.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $entity
+   *   The group entity object.
+   */
+  private function createGroupUrlAliasUpdateQueueItem(GroupInterface $entity) {
+    if (is_null($this->state->get(CronOperations::GROUP_URL_ALIAS_UPDATE_STATE_CACHE . $entity->id()))) {
+      $queue = $this->queueFactory->get(CronOperations::GROUP_URL_ALIAS_UPDATE_QUEUE);
+      $queue->createItem([
+        'gid' => $entity->id(),
+      ]);
+      $this->state->set(CronOperations::GROUP_URL_ALIAS_UPDATE_STATE_CACHE . $entity->id(), TRUE);
     }
   }
 

--- a/lib/modules/eic_groups/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_groups/src/Hooks/EntityOperations.php
@@ -7,9 +7,7 @@ use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Link;
-use Drupal\Core\Queue\QueueFactory;
 use Drupal\Core\Routing\RouteMatchInterface;
-use Drupal\Core\State\StateInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Url;
 use Drupal\eic_groups\EICGroupsHelperInterface;
@@ -57,20 +55,6 @@ class EntityOperations implements ContainerInjectionInterface {
   protected $pathautoGenerator;
 
   /**
-   * The queue factory service.
-   *
-   * @var \Drupal\Core\Queue\QueueFactory
-   */
-  protected $queueFactory;
-
-  /**
-   * The state service.
-   *
-   * @var \Drupal\Core\State\StateInterface
-   */
-  protected $state;
-
-  /**
    * Constructs a new EntityOperations object.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
@@ -81,18 +65,12 @@ class EntityOperations implements ContainerInjectionInterface {
    *   The EIC Groups helper service.
    * @param \Drupal\pathauto\PathautoGeneratorInterface $pathauto_generator
    *   The pathauto generator.
-   * @param \Drupal\Core\Queue\QueueFactory $queue_factory
-   *   The queue factory service.
-   * @param \Drupal\Core\State\StateInterface $state
-   *   The state service.
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, RouteMatchInterface $route_match, EICGroupsHelperInterface $eic_groups_helper, PathautoGeneratorInterface $pathauto_generator, QueueFactory $queue_factory, StateInterface $state) {
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, RouteMatchInterface $route_match, EICGroupsHelperInterface $eic_groups_helper, PathautoGeneratorInterface $pathauto_generator) {
     $this->entityTypeManager = $entity_type_manager;
     $this->routeMatch = $route_match;
     $this->eicGroupsHelper = $eic_groups_helper;
     $this->pathautoGenerator = $pathauto_generator;
-    $this->queueFactory = $queue_factory;
-    $this->state = $state;
   }
 
   /**
@@ -103,9 +81,7 @@ class EntityOperations implements ContainerInjectionInterface {
       $container->get('entity_type.manager'),
       $container->get('current_route_match'),
       $container->get('eic_groups.helper'),
-      $container->get('pathauto.generator'),
-      $container->get('queue'),
-      $container->get('state')
+      $container->get('pathauto.generator')
     );
   }
 
@@ -123,12 +99,6 @@ class EntityOperations implements ContainerInjectionInterface {
     // Publish group wiki when group is published.
     if (!$entity->original->isPublished() && $entity->isPublished()) {
       $this->publishGroupWiki($entity);
-    }
-
-    // If group alias has changed we add the group id into a queue so that all
-    // group content url aliases can be updated at a later stage with cron.
-    if ($entity->get('path')->alias !== $this->pathautoGenerator->createEntityAlias($entity, 'return')) {
-      $this->createGroupUrlAliasUpdateQueueItem($entity);
     }
   }
 
@@ -253,22 +223,6 @@ class EntityOperations implements ContainerInjectionInterface {
         $node_book->setPublished();
         $node_book->save();
       }
-    }
-  }
-
-  /**
-   * Creates an item in the queue CronOperations::GROUP_URL_ALIAS_UPDATE_QUEUE.
-   *
-   * @param \Drupal\group\Entity\GroupInterface $entity
-   *   The group entity object.
-   */
-  private function createGroupUrlAliasUpdateQueueItem(GroupInterface $entity) {
-    if (is_null($this->state->get(CronOperations::GROUP_URL_ALIAS_UPDATE_STATE_CACHE . $entity->id()))) {
-      $queue = $this->queueFactory->get(CronOperations::GROUP_URL_ALIAS_UPDATE_QUEUE);
-      $queue->createItem([
-        'gid' => $entity->id(),
-      ]);
-      $this->state->set(CronOperations::GROUP_URL_ALIAS_UPDATE_STATE_CACHE . $entity->id(), TRUE);
     }
   }
 

--- a/lib/modules/eic_groups/src/Hooks/Pathauto.php
+++ b/lib/modules/eic_groups/src/Hooks/Pathauto.php
@@ -4,7 +4,10 @@ namespace Drupal\eic_groups\Hooks;
 
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Queue\QueueFactory;
+use Drupal\Core\State\StateInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\group\Entity\GroupInterface;
 use Drupal\node\NodeInterface;
 use Drupal\pathauto\AliasStorageHelperInterface;
 use Drupal\pathauto\PathautoGeneratorInterface;
@@ -41,6 +44,20 @@ class Pathauto implements ContainerInjectionInterface {
   protected $aliasStorageHelper;
 
   /**
+   * The queue factory service.
+   *
+   * @var \Drupal\Core\Queue\QueueFactory
+   */
+  protected $queueFactory;
+
+  /**
+   * The state service.
+   *
+   * @var \Drupal\Core\State\StateInterface
+   */
+  protected $state;
+
+  /**
    * Constructs a new GroupTokens object.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
@@ -49,11 +66,17 @@ class Pathauto implements ContainerInjectionInterface {
    *   The pathauto generator.
    * @param \Drupal\pathauto\AliasStorageHelperInterface $alias_storage_helper
    *   The alias storage helper service.
+   * @param \Drupal\Core\Queue\QueueFactory $queue_factory
+   *   The queue factory service.
+   * @param \Drupal\Core\State\StateInterface $state
+   *   The state service.
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, PathautoGeneratorInterface $pathauto_generator, AliasStorageHelperInterface $alias_storage_helper) {
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, PathautoGeneratorInterface $pathauto_generator, AliasStorageHelperInterface $alias_storage_helper, QueueFactory $queue_factory, StateInterface $state) {
     $this->entityTypeManager = $entity_type_manager;
     $this->pathautoGenerator = $pathauto_generator;
     $this->aliasStorageHelper = $alias_storage_helper;
+    $this->queueFactory = $queue_factory;
+    $this->state = $state;
   }
 
   /**
@@ -63,7 +86,9 @@ class Pathauto implements ContainerInjectionInterface {
     return new static(
       $container->get('entity_type.manager'),
       $container->get('pathauto.generator'),
-      $container->get('pathauto.alias_storage_helper')
+      $container->get('pathauto.alias_storage_helper'),
+      $container->get('queue'),
+      $container->get('state')
     );
   }
 
@@ -74,35 +99,108 @@ class Pathauto implements ContainerInjectionInterface {
     // Alters URL alias of book nodes that belong to a group.
     if (isset($context['data']['node'])) {
       if (($node = $context['data']['node']) && $node instanceof NodeInterface) {
-
-        // We don't change alias for nodes other than books.
-        if ($node->bundle() !== 'book') {
-          return;
-        }
-
-        if ($group_contents = $this->entityTypeManager->getStorage('group_content')->loadByEntity($node)) {
-          /** @var \Drupal\group\Entity\GroupContentInterface $group_content */
-          $group_content = reset($group_contents);
-          if ($group_content->hasTranslation($node->language()->getId())) {
-            $group = $group_content->getGroup()->getTranslation($node->language()->getId());
-          }
-          else {
-            $group = $group_content->getGroup();
-          }
-
-          // If the group has an alias we use it as a prefix.
-          if ($group_alias = $this->aliasStorageHelper->loadBySource($group->toUrl()->getInternalPath(), $group->language()->getId())) {
-            $alias = "{$group_alias['alias']}/wiki";
-            return;
-          }
-
-          // We use pathauto generator to retrieve the group alias so we can
-          // use it as a prefix.
-          $group_alias = $this->pathautoGenerator->createEntityAlias($group, 'return');
-
-          $alias = "{$group_alias}/wiki";
-        }
+        $this->nodeAliasAlter($alias, $context, $node);
       }
+    }
+    elseif (isset($context['data']['group'])) {
+      if (($group = $context['data']['group']) && $group instanceof GroupInterface) {
+        $this->groupAliasAlter($alias, $context, $group);
+      }
+    }
+  }
+
+  /**
+   * Do changes in node alias before saving.
+   *
+   * @param string $alias
+   *   The automatic alias after token replacement and strings cleaned.
+   * @param array $context
+   *   An associative array of additional options, with the following elements:
+   *   - 'module': The module or entity type being aliased.
+   *   - 'op': A string with the operation being performed on the object being
+   *     aliased. Can be either 'insert', 'update', 'return', or 'bulkupdate'.
+   *   - 'source': A string of the source path for the alias (e.g. 'node/1').
+   *     This can be altered by reference.
+   *   - 'data': An array of keyed objects to pass to token_replace().
+   *   - 'type': The sub-type or bundle of the object being aliased.
+   *   - 'language': A string of the language code for the alias (e.g. 'en').
+   *     This can be altered by reference.
+   *   - 'pattern': A string of the pattern used for aliasing the object.
+   * @param \Drupal\node\NodeInterface $node
+   *   The node entity object.
+   */
+  protected function nodeAliasAlter(&$alias, array &$context, NodeInterface $node) {
+    // We don't change alias for nodes other than books.
+    if ($node->bundle() !== 'book') {
+      return;
+    }
+
+    if ($group_contents = $this->entityTypeManager->getStorage('group_content')->loadByEntity($node)) {
+      /** @var \Drupal\group\Entity\GroupContentInterface $group_content */
+      $group_content = reset($group_contents);
+      if ($group_content->hasTranslation($node->language()->getId())) {
+        $group = $group_content->getGroup()->getTranslation($node->language()->getId());
+      }
+      else {
+        $group = $group_content->getGroup();
+      }
+
+      // If the group has an alias we use it as a prefix.
+      if ($group_alias = $this->aliasStorageHelper->loadBySource($group->toUrl()->getInternalPath(), $group->language()->getId())) {
+        $alias = "{$group_alias['alias']}/wiki";
+        return;
+      }
+
+      // We use pathauto generator to retrieve the group alias so we can
+      // use it as a prefix.
+      $group_alias = $this->pathautoGenerator->createEntityAlias($group, 'return');
+
+      $alias = "{$group_alias}/wiki";
+    }
+  }
+
+  /**
+   * Do changes in group alias before saving.
+   *
+   * @param string $alias
+   *   The automatic alias after token replacement and strings cleaned.
+   * @param array $context
+   *   An associative array of additional options, with the following elements:
+   *   - 'module': The module or entity type being aliased.
+   *   - 'op': A string with the operation being performed on the object being
+   *     aliased. Can be either 'insert', 'update', 'return', or 'bulkupdate'.
+   *   - 'source': A string of the source path for the alias (e.g. 'node/1').
+   *     This can be altered by reference.
+   *   - 'data': An array of keyed objects to pass to token_replace().
+   *   - 'type': The sub-type or bundle of the object being aliased.
+   *   - 'language': A string of the language code for the alias (e.g. 'en').
+   *     This can be altered by reference.
+   *   - 'pattern': A string of the pattern used for aliasing the object.
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group entity object.
+   */
+  protected function groupAliasAlter(&$alias, array &$context, GroupInterface $group) {
+    // If group alias has changed we add the group id into a queue so that
+    // all group content url aliases can be updated at a later stage with
+    // cron.
+    if ($group->get('path')->alias !== $alias) {
+      $this->createGroupUrlAliasUpdateQueueItem($group);
+    }
+  }
+
+  /**
+   * Creates an item in the queue CronOperations::GROUP_URL_ALIAS_UPDATE_QUEUE.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $entity
+   *   The group entity object.
+   */
+  private function createGroupUrlAliasUpdateQueueItem(GroupInterface $entity) {
+    if (is_null($this->state->get(CronOperations::GROUP_URL_ALIAS_UPDATE_STATE_CACHE . $entity->id()))) {
+      $queue = $this->queueFactory->get(CronOperations::GROUP_URL_ALIAS_UPDATE_QUEUE);
+      $queue->createItem([
+        'gid' => $entity->id(),
+      ]);
+      $this->state->set(CronOperations::GROUP_URL_ALIAS_UPDATE_STATE_CACHE . $entity->id(), TRUE);
     }
   }
 

--- a/lib/modules/eic_groups/src/Plugin/QueueWorker/GroupContentUrlAliasUpdate.php
+++ b/lib/modules/eic_groups/src/Plugin/QueueWorker/GroupContentUrlAliasUpdate.php
@@ -11,10 +11,10 @@ use Drupal\pathauto\PathautoGeneratorInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Defines 'group_content_url_alias_update' queue worker.
+ * Defines 'eic_groups_group_content_url_alias_update' queue worker.
  *
  * @QueueWorker(
- *   id = "group_content_url_alias_update",
+ *   id = "eic_groups_group_content_url_alias_update",
  *   title = @Translation("Task worker: Update group content url alias"),
  *   cron = {"time" = 60}
  * )

--- a/lib/modules/eic_groups/src/Plugin/QueueWorker/GroupContentUrlAliasUpdate.php
+++ b/lib/modules/eic_groups/src/Plugin/QueueWorker/GroupContentUrlAliasUpdate.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Drupal\eic_groups\Plugin\QueueWorker;
+
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Queue\QueueWorkerBase;
+use Drupal\group\Entity\GroupContent;
+use Drupal\node\NodeInterface;
+use Drupal\pathauto\PathautoGeneratorInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Defines 'group_content_url_alias_update' queue worker.
+ *
+ * @QueueWorker(
+ *   id = "group_content_url_alias_update",
+ *   title = @Translation("Task worker: Update group content url alias"),
+ *   cron = {"time" = 60}
+ * )
+ */
+class GroupContentUrlAliasUpdate extends QueueWorkerBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The pathauto generator.
+   *
+   * @var \Drupal\pathauto\PathautoGeneratorInterface
+   */
+  protected $pathautoGenerator;
+
+  /**
+   * Constructs a new GroupContentUrlAliasUpdate instance.
+   *
+   * @param array $configuration
+   *   The plugin configuration, i.e. an array with configuration values keyed
+   *   by configuration option name. The special key 'context' may be used to
+   *   initialize the defined contexts by setting it to an array of context
+   *   values keyed by context names.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\pathauto\PathautoGeneratorInterface $pathauto_generator
+   *   The pathauto generator.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, PathautoGeneratorInterface $pathauto_generator) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->pathautoGenerator = $pathauto_generator;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('pathauto.generator')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processItem($data) {
+    /** @var \Drupal\group\Entity\GroupContent $group_content */
+    $group_content = GroupContent::load($data);
+
+    // Update url alias of node that belongs to the group content that is
+    // being processed.
+    if (($node = $group_content->getEntity()) && $node instanceof NodeInterface) {
+      $this->pathautoGenerator->updateEntityAlias($node, 'update');
+      Cache::invalidateTags($node->getCacheTags());
+    }
+
+    // Update url alias of the group content.
+    $this->pathautoGenerator->updateEntityAlias($group_content, 'update');
+    Cache::invalidateTags($group_content->getCacheTags());
+  }
+
+}


### PR DESCRIPTION
### Changes

- Create a queue of groups when their urls alias has changed;
- Create queue worker to update group content url alias;
- Implement hook_cron to process queues;

### Tests

- [ ] Create a new group;
- [ ] Go to **/admin/content** and check if the url of the group book page is **/group-url/wiki**
- [ ] Edit the group and change its title. This will change the url alias of the group and also add the group to a queue so that its group content url aliases can be updated at a later stage by cron;.
- [ ] Run cron
- [ ] Go to **/admin/content** again and check if the url of the group book page has been updated.

Note: you can also try to create different group content entities and check if the url aliases have been updated as well.