### PR TITLE
Feature/eicnet 830

### DIFF
--- a/config/sync/core.entity_form_display.flagging.request_delete_comment.default.yml
+++ b/config/sync/core.entity_form_display.flagging.request_delete_comment.default.yml
@@ -1,0 +1,29 @@
+uuid: 2c4bb9ef-780e-41aa-9770-38ca748f766f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.flagging.request_delete_comment.field_deletion_reason
+    - field.field.flagging.request_delete_comment.field_deletion_status
+    - flag.flag.request_delete_comment
+id: flagging.request_delete_comment.default
+targetEntityType: flagging
+bundle: request_delete_comment
+mode: default
+content:
+  field_deletion_reason:
+    weight: 0
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textarea
+    region: content
+  field_deletion_status:
+    weight: 1
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
+hidden: {  }

--- a/config/sync/core.entity_form_display.flagging.request_delete_content.default.yml
+++ b/config/sync/core.entity_form_display.flagging.request_delete_content.default.yml
@@ -1,0 +1,29 @@
+uuid: 53bcaeec-d05b-446b-b8ea-14dadf5a2303
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.flagging.request_delete_content.field_deletion_reason
+    - field.field.flagging.request_delete_content.field_deletion_status
+    - flag.flag.request_delete_content
+id: flagging.request_delete_content.default
+targetEntityType: flagging
+bundle: request_delete_content
+mode: default
+content:
+  field_deletion_reason:
+    weight: 0
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textarea
+    region: content
+  field_deletion_status:
+    weight: 1
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
+hidden: {  }

--- a/config/sync/core.entity_view_display.flagging.request_delete_comment.default.yml
+++ b/config/sync/core.entity_view_display.flagging.request_delete_comment.default.yml
@@ -1,0 +1,32 @@
+uuid: 4ff61fe8-65e1-45d8-8491-affcc23ff154
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.flagging.request_delete_comment.field_deletion_reason
+    - field.field.flagging.request_delete_comment.field_deletion_status
+    - flag.flag.request_delete_comment
+id: flagging.request_delete_comment.default
+targetEntityType: flagging
+bundle: request_delete_comment
+mode: default
+content:
+  field_deletion_reason:
+    weight: 0
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+  field_deletion_status:
+    weight: 1
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    type: boolean
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.flagging.request_delete_content.default.yml
+++ b/config/sync/core.entity_view_display.flagging.request_delete_content.default.yml
@@ -1,0 +1,32 @@
+uuid: f4f60d2e-37fb-48a5-be68-b6a494c2718d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.flagging.request_delete_content.field_deletion_reason
+    - field.field.flagging.request_delete_content.field_deletion_status
+    - flag.flag.request_delete_content
+id: flagging.request_delete_content.default
+targetEntityType: flagging
+bundle: request_delete_content
+mode: default
+content:
+  field_deletion_reason:
+    weight: 0
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+  field_deletion_status:
+    weight: 1
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    type: boolean
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/field.field.flagging.request_delete_comment.field_deletion_reason.yml
+++ b/config/sync/field.field.flagging.request_delete_comment.field_deletion_reason.yml
@@ -1,0 +1,19 @@
+uuid: ca0baf30-afaa-4efa-bc00-a8c86335c49b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.flagging.field_deletion_reason
+    - flag.flag.request_delete_comment
+id: flagging.request_delete_comment.field_deletion_reason
+field_name: field_deletion_reason
+entity_type: flagging
+bundle: request_delete_comment
+label: Reason
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/sync/field.field.flagging.request_delete_comment.field_deletion_status.yml
+++ b/config/sync/field.field.flagging.request_delete_comment.field_deletion_status.yml
@@ -1,0 +1,23 @@
+uuid: 80878b10-b437-492f-a053-ff183343c6c1
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.flagging.field_deletion_status
+    - flag.flag.request_delete_comment
+id: flagging.request_delete_comment.field_deletion_status
+field_name: field_deletion_status
+entity_type: flagging
+bundle: request_delete_comment
+label: Status
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.field.flagging.request_delete_content.field_deletion_reason.yml
+++ b/config/sync/field.field.flagging.request_delete_content.field_deletion_reason.yml
@@ -1,0 +1,19 @@
+uuid: f2ca9ecd-2c18-4bc5-85a7-2fd0f999c5bc
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.flagging.field_deletion_reason
+    - flag.flag.request_delete_content
+id: flagging.request_delete_content.field_deletion_reason
+field_name: field_deletion_reason
+entity_type: flagging
+bundle: request_delete_content
+label: Reason
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/sync/field.field.flagging.request_delete_content.field_deletion_status.yml
+++ b/config/sync/field.field.flagging.request_delete_content.field_deletion_status.yml
@@ -1,0 +1,23 @@
+uuid: 65e26031-02b1-458a-9f9b-00c982151c1c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.flagging.field_deletion_status
+    - flag.flag.request_delete_content
+id: flagging.request_delete_content.field_deletion_status
+field_name: field_deletion_status
+entity_type: flagging
+bundle: request_delete_content
+label: Status
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.storage.flagging.field_deletion_reason.yml
+++ b/config/sync/field.storage.flagging.field_deletion_reason.yml
@@ -1,0 +1,19 @@
+uuid: af46cdca-90c3-4e24-b2e1-33039f290982
+langcode: en
+status: true
+dependencies:
+  module:
+    - flag
+id: flagging.field_deletion_reason
+field_name: field_deletion_reason
+entity_type: flagging
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.flagging.field_deletion_status.yml
+++ b/config/sync/field.storage.flagging.field_deletion_status.yml
@@ -1,0 +1,18 @@
+uuid: c0b6b565-f8af-412c-9770-e6f03448d806
+langcode: en
+status: true
+dependencies:
+  module:
+    - flag
+id: flagging.field_deletion_status
+field_name: field_deletion_status
+entity_type: flagging
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/flag.flag.request_delete_comment.yml
+++ b/config/sync/flag.flag.request_delete_comment.yml
@@ -1,0 +1,33 @@
+uuid: 64638af0-765e-4c95-850d-c7f7be32193f
+langcode: en
+status: true
+dependencies:
+  module:
+    - comment
+id: request_delete_comment
+label: 'Request Delete (Comment)'
+bundles: {  }
+entity_type: comment
+global: false
+weight: 0
+flag_short: 'Flag this item'
+flag_long: ''
+flag_message: ''
+unflag_short: 'Unflag this item'
+unflag_long: ''
+unflag_message: ''
+unflag_denied_text: ''
+flood_control_active: false
+flood_control_limit: 0
+flood_control_window: 0
+flag_type: 'entity:comment'
+link_type: ajax_link
+flagTypeConfig:
+  show_in_links: {  }
+  show_as_field: false
+  show_on_form: false
+  show_contextual_link: false
+  extra_permissions:
+    owner: '0'
+    parent_owner: '0'
+linkTypeConfig: {  }

--- a/config/sync/flag.flag.request_delete_content.yml
+++ b/config/sync/flag.flag.request_delete_content.yml
@@ -1,0 +1,38 @@
+uuid: a28f7217-5596-4e65-936e-705e146133f8
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: request_delete_content
+label: 'Request Delete (Content)'
+bundles:
+  - discussion
+  - document
+  - gallery
+  - news
+  - story
+  - wiki_page
+entity_type: node
+global: false
+weight: 0
+flag_short: 'Flag this item'
+flag_long: ''
+flag_message: ''
+unflag_short: 'Unflag this item'
+unflag_long: ''
+unflag_message: ''
+unflag_denied_text: ''
+flood_control_active: false
+flood_control_limit: 0
+flood_control_window: 0
+flag_type: 'entity:node'
+link_type: ajax_link
+flagTypeConfig:
+  show_in_links: {  }
+  show_as_field: false
+  show_on_form: false
+  show_contextual_link: false
+  extra_permissions:
+    owner: '0'
+linkTypeConfig: {  }

--- a/config/sync/flag.flag.request_delete_group.yml
+++ b/config/sync/flag.flag.request_delete_group.yml
@@ -1,0 +1,32 @@
+uuid: 570da22a-8ca1-440e-9e71-27c5911ae126
+langcode: en
+status: true
+dependencies:
+  module:
+    - group
+id: request_delete_group
+label: 'Request Delete (Group)'
+bundles: {  }
+entity_type: group
+global: false
+weight: 0
+flag_short: 'Flag this item'
+flag_long: ''
+flag_message: ''
+unflag_short: 'Unflag this item'
+unflag_long: ''
+unflag_message: ''
+unflag_denied_text: ''
+flood_control_active: false
+flood_control_limit: 0
+flood_control_window: 0
+flag_type: 'entity:group'
+link_type: ajax_link
+flagTypeConfig:
+  show_in_links: {  }
+  show_as_field: false
+  show_on_form: false
+  show_contextual_link: false
+  extra_permissions:
+    owner: '0'
+linkTypeConfig: {  }

--- a/config/sync/system.action.flag_action.request_delete_comment_flag.yml
+++ b/config/sync/system.action.flag_action.request_delete_comment_flag.yml
@@ -1,0 +1,15 @@
+uuid: b3e5939b-e81b-4839-a62b-04ffc8d21701
+langcode: en
+status: true
+dependencies:
+  config:
+    - flag.flag.request_delete_comment
+  module:
+    - flag
+id: flag_action.request_delete_comment_flag
+label: 'Flag this item'
+type: comment
+plugin: 'flag_action:request_delete_comment_flag'
+configuration:
+  flag_id: request_delete_comment
+  flag_action: flag

--- a/config/sync/system.action.flag_action.request_delete_comment_unflag.yml
+++ b/config/sync/system.action.flag_action.request_delete_comment_unflag.yml
@@ -1,0 +1,15 @@
+uuid: f3cf5dcc-1233-42bb-8c85-5e0f97ce6981
+langcode: en
+status: true
+dependencies:
+  config:
+    - flag.flag.request_delete_comment
+  module:
+    - flag
+id: flag_action.request_delete_comment_unflag
+label: 'Unflag this item'
+type: comment
+plugin: 'flag_action:request_delete_comment_unflag'
+configuration:
+  flag_id: request_delete_comment
+  flag_action: unflag

--- a/config/sync/system.action.flag_action.request_delete_content_flag.yml
+++ b/config/sync/system.action.flag_action.request_delete_content_flag.yml
@@ -1,0 +1,15 @@
+uuid: ea7c0ee2-de21-490a-b2ac-d9e65a87c72b
+langcode: en
+status: true
+dependencies:
+  config:
+    - flag.flag.request_delete_content
+  module:
+    - flag
+id: flag_action.request_delete_content_flag
+label: 'Flag this item'
+type: node
+plugin: 'flag_action:request_delete_content_flag'
+configuration:
+  flag_id: request_delete_content
+  flag_action: flag

--- a/config/sync/system.action.flag_action.request_delete_content_unflag.yml
+++ b/config/sync/system.action.flag_action.request_delete_content_unflag.yml
@@ -1,0 +1,15 @@
+uuid: 57765121-abe9-4dbf-9f81-adedf8a69744
+langcode: en
+status: true
+dependencies:
+  config:
+    - flag.flag.request_delete_content
+  module:
+    - flag
+id: flag_action.request_delete_content_unflag
+label: 'Unflag this item'
+type: node
+plugin: 'flag_action:request_delete_content_unflag'
+configuration:
+  flag_id: request_delete_content
+  flag_action: unflag

--- a/config/sync/system.action.flag_action.request_delete_group_flag.yml
+++ b/config/sync/system.action.flag_action.request_delete_group_flag.yml
@@ -1,0 +1,15 @@
+uuid: 1c5e4489-262c-4083-918f-58241f60d9a2
+langcode: en
+status: true
+dependencies:
+  config:
+    - flag.flag.request_delete_group
+  module:
+    - flag
+id: flag_action.request_delete_group_flag
+label: 'Flag this item'
+type: group
+plugin: 'flag_action:request_delete_group_flag'
+configuration:
+  flag_id: request_delete_group
+  flag_action: flag

--- a/config/sync/system.action.flag_action.request_delete_group_unflag.yml
+++ b/config/sync/system.action.flag_action.request_delete_group_unflag.yml
@@ -1,0 +1,15 @@
+uuid: 9c5ca1ba-b494-4213-b3ab-d37e3f8b4d51
+langcode: en
+status: true
+dependencies:
+  config:
+    - flag.flag.request_delete_group
+  module:
+    - flag
+id: flag_action.request_delete_group_unflag
+label: 'Unflag this item'
+type: group
+plugin: 'flag_action:request_delete_group_unflag'
+configuration:
+  flag_id: request_delete_group
+  flag_action: unflag

--- a/lib/modules/eic_flags/eic_flags.module
+++ b/lib/modules/eic_flags/eic_flags.module
@@ -79,7 +79,8 @@ function eic_flags_entity_operation(EntityInterface $entity) {
   $class_name = strtolower((new \ReflectionClass($entity))->getShortName());
   if (!$entity instanceof ContentEntityInterface
     || !in_array($class_name, DeleteRequestManager::$supportedEntityTypes)
-    || !$entity->access('request-delete')) {
+    || !$entity->access('request-delete')
+    || \Drupal::service('router.admin_context')->isAdminRoute()) {
     return [];
   }
 

--- a/lib/modules/eic_flags/eic_flags.module
+++ b/lib/modules/eic_flags/eic_flags.module
@@ -5,6 +5,14 @@
  * Main module file for EIC Flags module.
  */
 
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Url;
+use Drupal\eic_flags\Form\RequestDeleteForm;
+use Drupal\eic_flags\Service\DeleteRequestManager;
+
 /**
  * Implements hook_theme().
  */
@@ -46,5 +54,56 @@ function eic_flags_cron() {
   foreach ($result as $row) {
     $row = (array) $row;
     $queue->createItem($row);
+  }
+}
+
+/**
+ * Implements hook_entity_type_alter.
+ */
+function eic_flags_entity_type_build(array &$entity_types) {
+  foreach (DeleteRequestManager::$supportedEntityTypes as $entity_id) {
+    if (!isset($entity_types[$entity_id])) {
+      continue;
+    }
+
+    $entity_types[$entity_id]
+      ->setFormClass('request-delete', RequestDeleteForm::class)
+      ->setLinkTemplate('request-delete-form', '/{entity_type}/{entity_id}/request-delete');
+  }
+}
+
+/**
+ * Implements hook_entity_operation.
+ */
+function eic_flags_entity_operation(EntityInterface $entity) {
+  $class_name = strtolower((new \ReflectionClass($entity))->getShortName());
+  if (!$entity instanceof ContentEntityInterface
+    || !in_array($class_name, DeleteRequestManager::$supportedEntityTypes)
+    || !$entity->access('request-delete')) {
+    return [];
+  }
+
+  $operations = [];
+  $operations['request_delete'] = [
+    'title' => t('Request delete'),
+    'url' => $entity->toUrl('request-delete-form')->setRouteParameter('destination', \Drupal::request()
+      ->getRequestUri()),
+  ];
+
+  return $operations;
+}
+
+/**
+ * Implements hook_entity_access.
+ */
+function eic_flags_entity_access(EntityInterface $entity, $operation, AccountInterface $account) {
+  $class_name = strtolower((new \ReflectionClass($entity))->getShortName());
+  if (!in_array($class_name, DeleteRequestManager::$supportedEntityTypes) || $operation !== 'request-delete') {
+    return AccessResult::neutral();
+  }
+
+  // We allow delete requests only for certain roles.
+  if (empty(array_intersect(['administrator', 'trusted_user', 'content_administrator'], $account->getRoles()))) {
+    return AccessResult::forbidden();
   }
 }

--- a/lib/modules/eic_flags/eic_flags.routing.yml
+++ b/lib/modules/eic_flags/eic_flags.routing.yml
@@ -1,0 +1,2 @@
+route_callbacks:
+  - '\Drupal\eic_flags\Routing\RequestDeleteRoutes::routes'

--- a/lib/modules/eic_flags/eic_flags.services.yml
+++ b/lib/modules/eic_flags/eic_flags.services.yml
@@ -1,0 +1,4 @@
+services:
+  eic_flags.delete_request_manager:
+    class: Drupal\eic_flags\Service\DeleteRequestManager
+    arguments: [ '@flag' ]

--- a/lib/modules/eic_flags/src/Form/RequestDeleteForm.php
+++ b/lib/modules/eic_flags/src/Form/RequestDeleteForm.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Drupal\eic_flags\Form;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Entity\ContentEntityDeleteForm;
+use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\eic_flags\Service\DeleteRequestManager;
+use Drupal\flag\Entity\Flag;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class RequestDeleteForm
+ *
+ * @package Drupal\eic_flags\Form
+ */
+class RequestDeleteForm extends ContentEntityDeleteForm {
+
+  /**
+   * @var \Drupal\eic_flags\Service\DeleteRequestManager
+   */
+  private $deleteRequestManager;
+
+  /**
+   * RequestDeleteForm constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityRepositoryInterface $entity_repository
+   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info
+   * @param \Drupal\Component\Datetime\TimeInterface $time
+   * @param \Drupal\eic_flags\Service\DeleteRequestManager $deleteRequestManager
+   */
+  public function __construct(EntityRepositoryInterface $entity_repository, EntityTypeBundleInfoInterface $entity_type_bundle_info, TimeInterface $time, DeleteRequestManager $deleteRequestManager) {
+    parent::__construct($entity_repository, $entity_type_bundle_info, $time);
+
+    $this->deleteRequestManager = $deleteRequestManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity.repository'),
+      $container->get('entity_type.bundle.info'),
+      $container->get('datetime.time'),
+      $container->get('eic_flags.delete_request_manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'entity_request_delete_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDescription() {
+    return $this->t('You\'re about to request a deletion for this entity. Are you sure?');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form = parent::buildForm($form, $form_state);
+
+    $form['reason'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Please explain why this content should be deleted'),
+      '#required' => TRUE,
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    if (!$form_state->getValue('reason')) {
+      $form_state->setErrorByName('reason', $this->t('Reason field is required'));
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $flag = $this->deleteRequestManager->flagEntity($this->entity, $form_state->getValue('reason'));
+    if (!$flag instanceof Flag) {
+      $this->messenger()->addError($this->t('You are not allowed to do this'));
+    }
+
+    $this->messenger()->addStatus($this->t('The request has been made'));
+  }
+
+}

--- a/lib/modules/eic_flags/src/Form/RequestDeleteForm.php
+++ b/lib/modules/eic_flags/src/Form/RequestDeleteForm.php
@@ -31,7 +31,12 @@ class RequestDeleteForm extends ContentEntityDeleteForm {
    * @param \Drupal\Component\Datetime\TimeInterface $time
    * @param \Drupal\eic_flags\Service\DeleteRequestManager $deleteRequestManager
    */
-  public function __construct(EntityRepositoryInterface $entity_repository, EntityTypeBundleInfoInterface $entity_type_bundle_info, TimeInterface $time, DeleteRequestManager $deleteRequestManager) {
+  public function __construct(
+    EntityRepositoryInterface $entity_repository,
+    EntityTypeBundleInfoInterface $entity_type_bundle_info,
+    TimeInterface $time,
+    DeleteRequestManager $deleteRequestManager
+  ) {
     parent::__construct($entity_repository, $entity_type_bundle_info, $time);
 
     $this->deleteRequestManager = $deleteRequestManager;

--- a/lib/modules/eic_flags/src/Routing/RequestDeleteRoutes.php
+++ b/lib/modules/eic_flags/src/Routing/RequestDeleteRoutes.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Drupal\eic_flags\Routing;
+
+use Drupal\eic_flags\Service\DeleteRequestManager;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Class RequestDeleteRoutes
+ *
+ * @package Drupal\eic_flags\Routing
+ */
+class RequestDeleteRoutes {
+
+  /**
+   * @return \Symfony\Component\Routing\RouteCollection
+   */
+  public function routes() {
+    $route_collection = new RouteCollection();
+
+    // We must define a route for each supported entity type and set the 'entity_form' default on the route
+    // This will ensure that the form controller handling this request is "HtmlEntityFormController"
+    foreach (DeleteRequestManager::$supportedEntityTypes as $entity_type) {
+      $route = (new Route('/' . $entity_type . '/{' . $entity_type . '}/request-delete'))
+        ->addDefaults([
+          '_entity_form' => $entity_type . '.request-delete',
+          '_title' => 'Delete',
+        ])
+        ->setRequirement($entity_type, '\d+')
+        ->setRequirement('_role', 'trusted_user+administrator+content_administrator');
+
+      $route_collection->add('entity.' . $entity_type . '.request_delete_form', $route);
+    }
+
+    return $route_collection;
+  }
+
+}

--- a/lib/modules/eic_flags/src/Service/DeleteRequestManager.php
+++ b/lib/modules/eic_flags/src/Service/DeleteRequestManager.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Drupal\eic_flags\Service;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\flag\Entity\Flag;
+use Drupal\flag\FlagService;
+use Drupal\user\Entity\User;
+
+/**
+ * Class DeleteRequestManager
+ *
+ * @package Drupal\eic_flags\Service
+ */
+class DeleteRequestManager {
+
+  /**
+   * Entity types allowed to go through the request a deletion flow.
+   *
+   * @var string[]
+   */
+  public static $supportedEntityTypes = [
+    'node',
+    'group',
+    'comment',
+  ];
+
+  /**
+   * @var \Drupal\flag\FlagService
+   */
+  private $flagService;
+
+  /**
+   * @var string[]
+   */
+  private static $flagsByType = [
+    'node' => 'request_delete_content',
+    'group' => 'request_delete_group',
+    'comment' => 'request_delete_comment',
+  ];
+
+  /**
+   * DeleteRequestManager constructor.
+   *
+   * @param \Drupal\flag\FlagService $flagService
+   */
+  public function __construct(FlagService $flagService) {
+    $this->flagService = $flagService;
+  }
+
+  /**
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   * @param string $reason
+   *
+   * @return \Drupal\Core\Entity\EntityInterface|\Drupal\flag\FlagInterface|null
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function flagEntity(ContentEntityInterface $entity, string $reason) {
+    // Entity type is not supported
+    $class_name = strtolower((new \ReflectionClass($entity))->getShortName());
+    if (!array_key_exists($class_name, self::$flagsByType)) {
+      return NULL;
+    }
+
+    $current_user = \Drupal::currentUser();
+    if (!$current_user->isAuthenticated()) {
+      return NULL;
+    }
+
+    $current_user = User::load($current_user->id());
+    $flag = $this->flagService->getFlagById(self::$flagsByType[$class_name]);
+    if (!$flag instanceof Flag || $flag->isFlagged($entity, $current_user)) {
+      return NULL;
+    }
+
+    $flag = $this->flagService->flag($flag, $entity, $current_user);
+    $flag->set('field_deletion_reason', $reason);
+    $flag->set('field_deletion_status', TRUE);
+    $flag->save();
+
+    return $flag;
+  }
+
+}

--- a/lib/themes/eic_community/patterns/compositions/comment/comment-base.html.twig
+++ b/lib/themes/eic_community/patterns/compositions/comment/comment-base.html.twig
@@ -91,7 +91,16 @@
                 extra_classes: 'ecl-comment__delete',
                 extra_attributes: action_attributes,
               },
-          ] : [])
+          ] : [])|merge( can_request_delete_comment ? [
+              {
+                link: {
+                  label: request_delete_label|default('Request deletion'),
+                  path: request_delete_path
+                },
+                extra_classes: 'ecl-comment__delete',
+                extra_attributes: action_attributes,
+              }
+            ] : [])
           } %}
             {% block trigger%}
               {% include "@ecl-twig/ec-component-button/ecl-button.html.twig" with {


### PR DESCRIPTION
This PR introduces:

- request_delete_form routes for every content entity
- request_delete operation for allowed entity types (node, comment, group)
- everything related to this (a confirm form, access checks, etc.)