### PR TITLE
EICNET-848: html tags shown in teaser components as plain text

### DIFF
--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
@@ -5,6 +5,7 @@ namespace Drupal\eic_groups\Plugin\Block;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Render\Markup;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\eic_groups\EICGroupsHelperInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -114,7 +115,7 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
         'id' => $group->id(),
         'bundle' => $group->bundle(),
         'title' => $group->label(),
-        'description' => $group->get('field_body')->value,
+        'description' => Markup::create($group->get('field_body')->value),
         'operation_links' => $operation_links,
         'membership_links' => $membership_links,
       ],

--- a/lib/themes/eic_community/includes/preprocess/content/node--discussion.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--discussion.inc
@@ -7,6 +7,7 @@
 
 use Drupal\taxonomy\Entity\Term;
 use Drupal\comment\Entity\Comment;
+use Drupal\Component\Utility\Xss;
 
 /**
  * Implements hook_preprocess_node() for discussion node.
@@ -45,7 +46,7 @@ function eic_community_preprocess_node__discussion(array &$variables) {
         ],
       ],
       'author' => eic_community_get_teaser_user_display($node->getOwner()),
-      'description' => $node->get('field_body')->first()->getValue()['value'],
+      'description' => Xss::filter($node->get('field_body')->first()->getValue()['value']),
       'tags' => $tags,
       'highlight' => FALSE,
       'timestamp' => [

--- a/lib/themes/eic_community/includes/preprocess/content/node--discussion.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--discussion.inc
@@ -46,7 +46,7 @@ function eic_community_preprocess_node__discussion(array &$variables) {
         ],
       ],
       'author' => eic_community_get_teaser_user_display($node->getOwner()),
-      'description' => Xss::filter($node->get('field_body')->first()->getValue()['value']),
+      'description' => Xss::filter($node->get('field_body')->value),
       'tags' => $tags,
       'highlight' => FALSE,
       'timestamp' => [
@@ -75,7 +75,7 @@ function eic_community_preprocess_node__discussion(array &$variables) {
       $comment = Comment::load($last_comment_id);
 
       $discussion_item['featured'] = [
-        'comment' => $comment->get('comment_body')->first()->getValue()['value'],
+        'comment' => $comment->get('comment_body')->value,
         'comment_id' => $last_comment_id,
         'author' => eic_community_get_teaser_user_display($comment->getOwner()),
         'timestamp' => eic_community_get_teaser_time_display($comment->getCreatedTime()),


### PR DESCRIPTION
### Changes

Fix description text in group header and discussion teaser components.

### Tests

- [ ] Create a group and check if the body field is now shown as full html when viewing the group header;
- [ ] Create a group discussion and check if the body text tags have been stripped when viewing group discussions overview