### PR TITLE
EICNET-849: Allow referencing content admins in discussion contributor

### DIFF
--- a/config/sync/field.field.paragraph.contributor.field_user_ref.yml
+++ b/config/sync/field.field.paragraph.contributor.field_user_ref.yml
@@ -22,6 +22,6 @@ settings:
   handler_settings:
     view:
       view_name: entity_reference_user
-      display_name: full_name_trusted
+      display_name: full_name_tu_ca
       arguments: {  }
 field_type: entity_reference

--- a/config/sync/views.view.entity_reference_user.yml
+++ b/config/sync/views.view.entity_reference_user.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.storage.user.field_first_name
     - field.storage.user.field_last_name
+    - user.role.content_administrator
     - user.role.trusted_user
   module:
     - user
@@ -616,6 +617,150 @@ display:
           operator: or
           value:
             trusted_user: trusted_user
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          entity_type: user
+          entity_field: roles
+          plugin_id: user_roles
+      defaults:
+        filters: false
+        filter_groups: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      display_description: ''
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user.permissions
+      tags:
+        - 'config:field.storage.user.field_first_name'
+        - 'config:field.storage.user.field_last_name'
+  full_name_tu_ca:
+    display_plugin: entity_reference
+    id: full_name_tu_ca
+    display_title: 'Full name trusted users/content admins'
+    position: 2
+    display_options:
+      display_extenders: {  }
+      style:
+        type: entity_reference
+        options:
+          search_fields:
+            field_first_name: field_first_name
+            field_last_name: field_last_name
+            mail: mail
+            name: name
+      row:
+        type: entity_reference
+        options:
+          default_field_elements: true
+          inline:
+            name: name
+            mail: mail
+          separator: ' | '
+          hide_empty: true
+      filters:
+        status:
+          value: '1'
+          table: users_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: user
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+          group: 1
+        uid_raw:
+          id: uid_raw
+          table: users_field_data
+          field: uid_raw
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '!='
+          value:
+            min: ''
+            max: ''
+            value: '0'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: user
+          plugin_id: numeric
+        roles_target_id:
+          id: roles_target_id
+          table: user__roles
+          field: roles_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            trusted_user: trusted_user
+            content_administrator: content_administrator
           group: 1
           exposed: false
           expose:


### PR DESCRIPTION
### Changes

- Create views entity reference display to be able to reference trusted users and content admins in contributors paragraph.

### Tests

- Create a group
- Create a discussion and check if you can reference trusted users and content admins.