### PR TITLE
EICNET-850: Public group content should be available to trusted users and anonymous user

### DIFF
--- a/lib/modules/oec_group_flex/oec_group_flex.module
+++ b/lib/modules/oec_group_flex/oec_group_flex.module
@@ -96,3 +96,14 @@ function oec_group_flex_group_flex_group_joining_method_info_alter(array &$defin
     unset($definitions['join_button']);
   }
 }
+
+/**
+ * Implements hook_group_flex_group_visibility_info_alter().
+ */
+function oec_group_flex_group_flex_group_visibility_info_alter(array &$definitions) {
+  // Overrides the standard public group visibility plugin class provided by
+  // group flex.
+  if (isset($definitions['public'])) {
+    $definitions['public']['class'] = '\Drupal\oec_group_flex\Plugin\GroupVisibility\PublicVisibility';
+  }
+}

--- a/lib/modules/oec_group_flex/src/Plugin/GroupVisibility/PublicVisibility.php
+++ b/lib/modules/oec_group_flex/src/Plugin/GroupVisibility/PublicVisibility.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Drupal\oec_group_flex\Plugin\GroupVisibility;
+
+use Drupal\group\Entity\GroupInterface;
+use Drupal\group\Entity\GroupTypeInterface;
+use Drupal\group_flex\Plugin\GroupVisibility\PublicVisibility as PublicVisibilityBase;
+
+/**
+ * Provides a custom plugin to extend the 'public' group visibility plugin.
+ */
+class PublicVisibility extends PublicVisibilityBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getGroupPermissions(GroupInterface $group): array {
+    $groupType = $group->getGroupType();
+    $group_view_permissions = ['view group'];
+
+    $installedContentPlugins = $groupType->getInstalledContentPlugins();
+    foreach ($installedContentPlugins->getIterator() as $pluginId => $plugin) {
+      /** @var \Drupal\group\Plugin\GroupContentEnablerInterface $plugin */
+      switch ($plugin->getPluginDefinition()['id']) {
+        case 'group_node':
+        case 'group_membership':
+        case 'group_content_menu':
+          $group_view_permissions[] = "view $pluginId entity";
+          break;
+
+      }
+    }
+
+    // Add perm when anonymous role has permission to view group on group type.
+    $anonymousPermissions = [];
+    if ($groupType->getAnonymousRole()->hasPermission('view group')) {
+      $anonymousPermissions = [$groupType->getAnonymousRoleId() => $group_view_permissions];
+    }
+    return array_merge($anonymousPermissions, [
+      $groupType->getOutsiderRoleId() => $group_view_permissions,
+      $groupType->getMemberRoleId() => $group_view_permissions,
+    ]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getGroupLabel(GroupTypeInterface $groupType): string {
+    return $this->t('Public (The @group_type_name and all its content will be viewed by non-members of the group)', ['@group_type_name' => $groupType->label()]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getValueDescription(GroupTypeInterface $groupType): string {
+    return $this->t('The @group_type_name and all its content will be viewed by non-members of the group', ['@group_type_name' => $groupType->label()]);
+  }
+
+}

--- a/lib/modules/oec_group_flex/src/Plugin/GroupVisibility/PublicVisibility.php
+++ b/lib/modules/oec_group_flex/src/Plugin/GroupVisibility/PublicVisibility.php
@@ -7,7 +7,7 @@ use Drupal\group\Entity\GroupTypeInterface;
 use Drupal\group_flex\Plugin\GroupVisibility\PublicVisibility as PublicVisibilityBase;
 
 /**
- * Provides a custom plugin to extend the 'public' group visibility plugin.
+ * Provides a custom plugin that overrides the 'public' group visibility plugin.
  */
 class PublicVisibility extends PublicVisibilityBase {
 


### PR DESCRIPTION
### Changes

- Create class that overrides public group visibility plugin in order to allow anonymous and trusted users to view group content of a public group.

### Tests

- [ ] Create a public group and publish it
- [ ] Create a discussion
- [ ] As anonymous user when I go to the group page I should be able to view the group header and the discussion.