### PR TITLE
EICNET-829: Book page sidebar navigation and add book page links (current level / child)

### DIFF
--- a/config/sync/context.context.book_page.yml
+++ b/config/sync/context.context.book_page.yml
@@ -1,0 +1,58 @@
+uuid: bfebbc46-2f78-4d31-8949-a2edc65524a6
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+name: book_page
+label: 'Book page'
+group: null
+description: ''
+requireAllConditions: false
+disabled: false
+conditions:
+  node_type:
+    id: node_type
+    bundles:
+      book: book
+    negate: false
+    uuid: 6ece8dd6-40fc-4f4a-b4cc-87351d4cb228
+    context_mapping:
+      node: '@node.node_route_context:node'
+reactions:
+  blocks:
+    blocks:
+      6f75b510-521a-45c2-8c11-45071427dac5:
+        id: system_breadcrumb_block
+        label: Breadcrumbs
+        provider: system
+        label_display: '0'
+        region: breadcrumbs
+        weight: '0'
+        context_mapping: {  }
+        custom_id: system_breadcrumb_block
+        theme: eic_community
+        css_class: ''
+        unique: 0
+        context_id: book_page
+        uuid: 6f75b510-521a-45c2-8c11-45071427dac5
+      f1f33438-3b3b-4c3e-bbeb-92b3ebe5f74b:
+        id: eic_content_book_navigation
+        label: 'EIC Content Book navigation'
+        provider: eic_content_book
+        label_display: '0'
+        region: sidebar
+        weight: '0'
+        block_mode: null
+        context_mapping: {  }
+        custom_id: eic_content_book_navigation
+        theme: eic_community
+        css_class: ''
+        unique: 0
+        context_id: book_page
+        uuid: f1f33438-3b3b-4c3e-bbeb-92b3ebe5f74b
+    id: blocks
+    saved: false
+    uuid: 66f27c63-843e-4141-8d84-2e722b3b4555
+    include_default_blocks: 0
+weight: 0

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -34,6 +34,7 @@ module:
   eic_blocks: 0
   eic_comments: 0
   eic_content: 0
+  eic_content_book: 0
   eic_content_discussion: 0
   eic_content_story: 0
   eic_deploy: 0

--- a/config/sync/node.type.wiki_page.yml
+++ b/config/sync/node.type.wiki_page.yml
@@ -29,4 +29,4 @@ description: ''
 help: ''
 new_revision: true
 preview_mode: 1
-display_submitted: true
+display_submitted: false

--- a/lib/modules/eic_content/eic_content.services.yml
+++ b/lib/modules/eic_content/eic_content.services.yml
@@ -1,0 +1,4 @@
+services:
+  eic_content.helper:
+    class: Drupal\eic_content\EICContentHelper
+    arguments: ['@entity_type.manager', '@module_handler']

--- a/lib/modules/eic_content/modules/eic_content_book/eic_content_book.info.yml
+++ b/lib/modules/eic_content/modules/eic_content_book/eic_content_book.info.yml
@@ -1,0 +1,9 @@
+name: EIC Content Book
+type: module
+description: Provides extra logic for CT Book.
+package: Custom
+core: 8.x
+core_version_requirement: ^8 || ^9
+php: 7.3
+dependencies:
+  - eic_content:eic_content

--- a/lib/modules/eic_content/modules/eic_content_book/eic_content_book.module
+++ b/lib/modules/eic_content/modules/eic_content_book/eic_content_book.module
@@ -12,6 +12,7 @@
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\eic_content_book\Hooks\EntityOperations;
+use Drupal\eic_content_book\Hooks\Preprocess;
 
 /**
  * Implements hook_ENTITY_TYPE_view().
@@ -19,4 +20,12 @@ use Drupal\eic_content_book\Hooks\EntityOperations;
 function eic_content_book_node_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
   \Drupal::classResolver(EntityOperations::class)
     ->nodeView($build, $entity, $display, $view_mode);
+}
+
+/**
+ * Implements hook_preprocess_links__node().
+ */
+function eic_content_book_preprocess_links__node(&$variables) {
+  \Drupal::classResolver(Preprocess::class)
+    ->preprocessLinksNode($variables);
 }

--- a/lib/modules/eic_content/modules/eic_content_book/eic_content_book.module
+++ b/lib/modules/eic_content/modules/eic_content_book/eic_content_book.module
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * @file
+ * Primary module hooks for EIC Content Book module.
+ *
+ * @DCG
+ * This file is no longer required in Drupal 8.
+ * @see https://www.drupal.org/node/2217931
+ */

--- a/lib/modules/eic_content/modules/eic_content_book/eic_content_book.module
+++ b/lib/modules/eic_content/modules/eic_content_book/eic_content_book.module
@@ -8,3 +8,15 @@
  * This file is no longer required in Drupal 8.
  * @see https://www.drupal.org/node/2217931
  */
+
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\eic_content_book\Hooks\EntityOperations;
+
+/**
+ * Implements hook_ENTITY_TYPE_view().
+ */
+function eic_content_book_node_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
+  \Drupal::classResolver(EntityOperations::class)
+    ->nodeView($build, $entity, $display, $view_mode);
+}

--- a/lib/modules/eic_content/modules/eic_content_book/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_content/modules/eic_content_book/src/Hooks/EntityOperations.php
@@ -92,7 +92,7 @@ class EntityOperations implements ContainerInjectionInterface {
             return;
           }
 
-          if (isset($entity->book) && $entity->book['pid'] === '0') {
+          if (isset($entity->book) && empty($entity->book['pid'])) {
             // If top level book page.
             $build['link_add_child_book_page'] = $add_book_page_urls['add_child_book_page']->toString();
             $build['link_add_child_book_page_renderable'] = Link::fromTextAndUrl($this->t('Add a new book page'), $add_book_page_urls['add_child_book_page'])->toRenderable();

--- a/lib/modules/eic_content/modules/eic_content_book/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_content/modules/eic_content_book/src/Hooks/EntityOperations.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Drupal\eic_content_book\Hooks;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Link;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\Url;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class EntityOperations.
+ *
+ * Implementations for entity hooks.
+ */
+class EntityOperations implements ContainerInjectionInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The current route match service.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
+   * The module handler service.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountProxyInterface
+   */
+  protected $currentUser;
+
+  /**
+   * Constructs a new EntityOperations object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The current route match service.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler service.
+   * @param \Drupal\Core\Session\AccountProxyInterface $current_user
+   *   The current user.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, RouteMatchInterface $route_match, ModuleHandlerInterface $module_handler, AccountProxyInterface $current_user) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->routeMatch = $route_match;
+    $this->moduleHandler = $module_handler;
+    $this->currentUser = $current_user;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('current_route_match'),
+      $container->get('module_handler'),
+      $container->get('current_user')
+    );
+  }
+
+  /**
+   * Implements hook_node_view().
+   */
+  public function nodeView(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
+    switch ($this->routeMatch->getRouteName()) {
+      case 'entity.node.canonical':
+        if ($entity->bundle() === 'book') {
+          // If book belongs to a group.
+          if ($this->moduleHandler->moduleExists('group_content') && $this->entityTypeManager->getStorage('group_content')->loadByEntity($entity)) {
+            return;
+          }
+          // Unsets book navigation since we already have that show in the
+          // eic_content_book_navigation block plugin.
+          unset($build['book_navigation']);
+
+          $add_book_page_urls = $this->getBookPageAddFormUrls($entity);
+
+          // If user can't access the route.
+          if (!$add_book_page_urls['add_child_book_page']->access($this->currentUser)) {
+            return;
+          }
+
+          if (isset($entity->book) && $entity->book['pid'] === '0') {
+            // If top level book page.
+            $build['link_add_child_book_page'] = $add_book_page_urls['add_child_book_page']->toString();
+            $build['link_add_child_book_page_renderable'] = Link::fromTextAndUrl($this->t('Add a new book page'), $add_book_page_urls['add_child_book_page'])->toRenderable();
+          }
+          else {
+            // If child book page.
+            $build['link_add_current_level_book_page'] = $add_book_page_urls['add_current_level_book_page']->toString();
+            $build['link_add_current_level_book_page_renderable'] = Link::fromTextAndUrl($this->t('Add a new page on the current level'), $add_book_page_urls['add_current_level_book_page'])->toRenderable();
+            $build['link_add_current_level_book_page_renderable']['#suffix'] = '<br>';
+            $build['link_add_child_book_page'] = $add_book_page_urls['add_child_book_page']->toString();
+            $build['link_add_child_book_page_renderable'] = Link::fromTextAndUrl($this->t('Add a new page below this page'), $add_book_page_urls['add_child_book_page'])->toRenderable();
+          }
+        }
+        break;
+
+    }
+  }
+
+  /**
+   * Gets book page add form Urls from the current book page.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The parent entity node book.
+   *
+   * @return \Drupal\Core\Url[]
+   *   The Url object for the book page add form route.
+   */
+  private function getBookPageAddFormUrls(EntityInterface $entity) {
+    $route_parameters = [
+      'node_type' => 'book',
+    ];
+    $link_options = [
+      'add_current_level_book_page' => [
+        'query' => [
+          'parent' => $entity->book['pid'],
+        ],
+      ],
+      'add_child_book_page' => [
+        'query' => [
+          'parent' => $entity->id(),
+        ],
+      ],
+    ];
+    $links = [];
+    foreach ($link_options as $key => $options) {
+      $links[$key] = Url::fromRoute('node.add', $route_parameters, $options);
+    }
+    return $links;
+  }
+
+}

--- a/lib/modules/eic_content/modules/eic_content_book/src/Hooks/Preprocess.php
+++ b/lib/modules/eic_content/modules/eic_content_book/src/Hooks/Preprocess.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Drupal\eic_content_book\Hooks;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\eic_content\EICContentHelperInterface;
+use Drupal\node\NodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class Preprocess.
+ *
+ * Implementations of preprocess hooks.
+ */
+class Preprocess implements ContainerInjectionInterface {
+
+  /**
+   * The current route match service.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
+   * The EIC content helper.
+   *
+   * @var \Drupal\eic_content\EICContentHelperInterface
+   */
+  protected $eicContentHelper;
+
+  /**
+   * Constructs a new EntityOperations object.
+   *
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The current route match service.
+   * @param \Drupal\eic_content\EICContentHelperInterface $eic_content_helper
+   *   The EIC Groups helper service.
+   */
+  public function __construct(RouteMatchInterface $route_match, EICContentHelperInterface $eic_content_helper) {
+    $this->routeMatch = $route_match;
+    $this->eicContentHelper = $eic_content_helper;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('current_route_match'),
+      $container->get('eic_content.helper')
+    );
+  }
+
+  /**
+   * Implements hook_preprocess_links__node().
+   */
+  public function preprocessLinksNode(&$variables) {
+    switch ($this->routeMatch->getRouteName()) {
+      case 'entity.node.canonical':
+        // Remove add child link from book pages that do not belong to a group.
+        if (($node = $this->routeMatch->getParameter('node'))
+          && $node instanceof NodeInterface
+          && $node->bundle() === 'book'
+          && !$this->eicContentHelper->getGroupContentByEntity($node)
+        ) {
+          unset($variables['links']['book_add_child']);
+        }
+        break;
+
+    }
+  }
+
+}

--- a/lib/modules/eic_content/modules/eic_content_book/src/Plugin/Block/EICBookNavigationBlock.php
+++ b/lib/modules/eic_content/modules/eic_content_book/src/Plugin/Block/EICBookNavigationBlock.php
@@ -4,11 +4,9 @@ namespace Drupal\eic_content_book\Plugin\Block;
 
 use Drupal\book\BookManagerInterface;
 use Drupal\book\Plugin\Block\BookNavigationBlock;
-use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\EntityStorageInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\eic_content\EICContentHelperInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -24,25 +22,11 @@ use Symfony\Component\HttpFoundation\RequestStack;
 class EICBookNavigationBlock extends BookNavigationBlock {
 
   /**
-   * The database service.
+   * The EIC content helper.
    *
-   * @var \Drupal\Core\Database\Connection
+   * @var \Drupal\eic_content\EICContentHelperInterface
    */
-  protected $database;
-
-  /**
-   * The module handler service.
-   *
-   * @var \Drupal\Core\Extension\ModuleHandlerInterface
-   */
-  protected $moduleHandler;
-
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
+  protected $eicContentHelper;
 
   /**
    * Constructs a new BookNavigationBlock instance.
@@ -59,18 +43,12 @@ class EICBookNavigationBlock extends BookNavigationBlock {
    *   The book manager.
    * @param \Drupal\Core\Entity\EntityStorageInterface $node_storage
    *   The node storage.
-   * @param \Drupal\Core\Database\Connection $database
-   *   The database service.
-   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-   *   The module handler service.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
+   * @param \Drupal\eic_content\EICContentHelperInterface $eic_content_helper
+   *   The EIC content helper.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, RequestStack $request_stack, BookManagerInterface $book_manager, EntityStorageInterface $node_storage, Connection $database, ModuleHandlerInterface $module_handler, EntityTypeManagerInterface $entity_type_manager) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, RequestStack $request_stack, BookManagerInterface $book_manager, EntityStorageInterface $node_storage, EICContentHelperInterface $eic_content_helper) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $request_stack, $book_manager, $node_storage);
-    $this->database = $database;
-    $this->moduleHandler = $module_handler;
-    $this->entityTypeManager = $entity_type_manager;
+    $this->eicContentHelper = $eic_content_helper;
   }
 
   /**
@@ -84,9 +62,7 @@ class EICBookNavigationBlock extends BookNavigationBlock {
       $container->get('request_stack'),
       $container->get('book.manager'),
       $container->get('entity_type.manager')->getStorage('node'),
-      $container->get('database'),
-      $container->get('module_handler'),
-      $container->get('entity_type.manager')
+      $container->get('eic_content.helper')
     );
   }
 
@@ -116,8 +92,8 @@ class EICBookNavigationBlock extends BookNavigationBlock {
       return [];
     }
 
-    // Ignore Book nodes in groups.
-    if ($this->moduleHandler->moduleExists('group_content') && $this->entityTypeManager->getStorage('group_content')->loadByEntity($node)) {
+    // Ignore book page that belongs to a group.
+    if ($this->eicContentHelper->getGroupContentByEntity($node)) {
       return [];
     }
 

--- a/lib/modules/eic_content/modules/eic_content_book/src/Plugin/Block/EICBookNavigationBlock.php
+++ b/lib/modules/eic_content/modules/eic_content_book/src/Plugin/Block/EICBookNavigationBlock.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Drupal\eic_content_book\Plugin\Block;
+
+use Drupal\book\BookManagerInterface;
+use Drupal\book\Plugin\Block\BookNavigationBlock;
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Provides a 'Book navigation' block.
+ *
+ * @Block(
+ *   id = "eic_content_book_navigation",
+ *   admin_label = @Translation("EIC Content Book navigation"),
+ *   category = @Translation("European Innovation Council")
+ * )
+ */
+class EICBookNavigationBlock extends BookNavigationBlock {
+
+  /**
+   * The database service.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected $database;
+
+  /**
+   * The module handler service.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a new BookNavigationBlock instance.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
+   *   The request stack object.
+   * @param \Drupal\book\BookManagerInterface $book_manager
+   *   The book manager.
+   * @param \Drupal\Core\Entity\EntityStorageInterface $node_storage
+   *   The node storage.
+   * @param \Drupal\Core\Database\Connection $database
+   *   The database service.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler service.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, RequestStack $request_stack, BookManagerInterface $book_manager, EntityStorageInterface $node_storage, Connection $database, ModuleHandlerInterface $module_handler, EntityTypeManagerInterface $entity_type_manager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $request_stack, $book_manager, $node_storage);
+    $this->database = $database;
+    $this->moduleHandler = $module_handler;
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('request_stack'),
+      $container->get('book.manager'),
+      $container->get('entity_type.manager')->getStorage('node'),
+      $container->get('database'),
+      $container->get('module_handler'),
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockForm($form, FormStateInterface $form_state) {
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    if (!$node = $this->requestStack->getCurrentRequest()->get('node')) {
+      return [];
+    }
+
+    if ($node->bundle() !== 'book') {
+      return [];
+    }
+
+    // Ignore Book nodes in groups.
+    if ($this->moduleHandler->moduleExists('group_content') && $this->entityTypeManager->getStorage('group_content')->loadByEntity($node)) {
+      return [];
+    }
+
+    $data = $this->bookManager->bookTreeAllData($node->book['bid']);
+    $book_data = reset($data);
+
+    if (empty($book_data['below'])) {
+      return [];
+    }
+
+    // Ignore top level book page from the menu data.
+    $book_data_below = $book_data['below'];
+    // Get book menu renderable array.
+    $book_menu = [$this->bookManager->bookTreeOutput($book_data_below)];
+
+    return [
+      '#theme' => 'book_all_books_block',
+    ] + $book_menu;
+  }
+
+}

--- a/lib/modules/eic_content/src/EICContentHelper.php
+++ b/lib/modules/eic_content/src/EICContentHelper.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Drupal\eic_content;
+
+use Drupal\Component\Plugin\Exception\PluginException;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+
+/**
+ * EICContentHelper service that provides helper functions for content.
+ */
+class EICContentHelper implements EICContentHelperInterface {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The module handler service.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * Constructs a new EICContentHelper object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity manager.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, ModuleHandlerInterface $module_handler) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->moduleHandler = $module_handler;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getGroupContentByEntity(ContentEntityInterface $entity) {
+    if (!$this->moduleHandler->moduleExists('group_content')) {
+      return FALSE;
+    }
+
+    try {
+      return $this->entityTypeManager->getStorage('group_content')->loadByEntity($entity);
+    }
+    catch (PluginException $e) {
+      return FALSE;
+    }
+  }
+
+}

--- a/lib/modules/eic_content/src/EICContentHelper.php
+++ b/lib/modules/eic_content/src/EICContentHelper.php
@@ -43,7 +43,7 @@ class EICContentHelper implements EICContentHelperInterface {
    * {@inheritDoc}
    */
   public function getGroupContentByEntity(ContentEntityInterface $entity) {
-    if (!$this->moduleHandler->moduleExists('group_content')) {
+    if (!$this->moduleHandler->moduleExists('group')) {
       return FALSE;
     }
 

--- a/lib/modules/eic_content/src/EICContentHelperInterface.php
+++ b/lib/modules/eic_content/src/EICContentHelperInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Drupal\eic_content;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+
+/**
+ * Interface for EICContentHelper that provides helper functions for content.
+ */
+interface EICContentHelperInterface {
+
+  /**
+   * Get all GroupContent entities that represent a given entity.
+   *
+   * Returns FALSE when group_content module is not enabled.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   An entity which may be within one or more groups.
+   *
+   * @return bool|\Drupal\group\Entity\GroupContentInterface[]
+   *   A list of GroupContent entities which refer to the given entity.
+   */
+  public function getGroupContentByEntity(ContentEntityInterface $entity);
+
+}

--- a/lib/modules/eic_groups/eic_groups.services.yml
+++ b/lib/modules/eic_groups/eic_groups.services.yml
@@ -9,6 +9,6 @@ services:
     arguments: ['@current_route_match', '@module_handler']
   eic_groups.book_page_redirect_subscriber:
     class: Drupal\eic_groups\EventSubscriber\BookPageRedirectSubscriber
-    arguments: ['@eic_groups.helper', '@book.manager']
+    arguments: ['@eic_groups.helper', '@book.manager', '@entity_type.manager']
     tags:
       - { name: event_subscriber }

--- a/lib/modules/eic_groups/eic_groups.services.yml
+++ b/lib/modules/eic_groups/eic_groups.services.yml
@@ -9,6 +9,6 @@ services:
     arguments: ['@current_route_match', '@module_handler']
   eic_groups.book_page_redirect_subscriber:
     class: Drupal\eic_groups\EventSubscriber\BookPageRedirectSubscriber
-    arguments: ['@eic_groups.helper', '@book.manager', '@entity_type.manager']
+    arguments: ['@book.manager', '@entity_type.manager']
     tags:
       - { name: event_subscriber }


### PR DESCRIPTION
* Add book navigation in sidebar for books that do not belong to a group
* Add links to add book page on current level or child page
* Fix circular redirect issue for book pages outside groups (BookPageRedirectSubscriber)
* Hide author and publish date information from wiki pages

### Test

* Create a new book page not linked to a group - /node/add/book
* SA/SCM can see and use add book page links ("Add a new book page" on top level book page) ("Add a new page on the current level" and "Add a new page below this page" on other book pages)
* All site users can see the book navigation in the sidebar for all book pages
* Book and wiki pages that belong to a group are not affected by these changes