### PR TITLE
EICNET-865: Add prefix of entity type to URL to make it clear what type of content the site user is viewing

### DIFF
--- a/config/sync/pathauto.pattern.group_content.yml
+++ b/config/sync/pathauto.pattern.group_content.yml
@@ -12,7 +12,7 @@ type: 'canonical_entities:group_content'
 pattern: 'group/[group_content:group:id]/[group_content:pretty-path-key]/[group_content:id]'
 selection_criteria: {  }
 selection_logic: and
-weight: -6
+weight: -3
 relationships:
   'group_content:langcode:language':
     label: Language

--- a/config/sync/pathauto.pattern.group_group.yml
+++ b/config/sync/pathauto.pattern.group_group.yml
@@ -8,16 +8,16 @@ dependencies:
 id: group_group
 label: 'Group - Group'
 type: 'canonical_entities:group'
-pattern: '[group:title]'
+pattern: 'group/[group:title]'
 selection_criteria:
-  7b70289a-ef5c-4c7c-9933-cf064ce3ec3c:
+  e56ddab0-efca-48de-aa22-d30eb66a3604:
     id: 'entity_bundle:group'
     bundles:
       group: group
     negate: false
     context_mapping:
       group: group
-    uuid: 7b70289a-ef5c-4c7c-9933-cf064ce3ec3c
+    uuid: e56ddab0-efca-48de-aa22-d30eb66a3604
 selection_logic: and
-weight: -7
+weight: -4
 relationships: {  }

--- a/config/sync/pathauto.pattern.library.yml
+++ b/config/sync/pathauto.pattern.library.yml
@@ -1,0 +1,23 @@
+uuid: e5e92fcd-1725-4164-8d96-bd6490ec86d8
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: library
+label: Library
+type: 'canonical_entities:node'
+pattern: '[eic_groups_tokens:node_group_url]/library/[node:title]'
+selection_criteria:
+  51ec4726-84c3-4bdc-bab0-0d69ff230f1b:
+    id: node_type
+    bundles:
+      document: document
+      gallery: gallery
+    negate: false
+    context_mapping:
+      node: node
+    uuid: 51ec4726-84c3-4bdc-bab0-0d69ff230f1b
+selection_logic: and
+weight: -8
+relationships: {  }

--- a/config/sync/pathauto.pattern.news.yml
+++ b/config/sync/pathauto.pattern.news.yml
@@ -1,0 +1,22 @@
+uuid: 07fc8145-a809-43f6-ab24-9e171e643e68
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: news
+label: News
+type: 'canonical_entities:node'
+pattern: '[eic_groups_tokens:node_group_url]/news/[node:title]'
+selection_criteria:
+  fa81abf5-640d-4efc-a8d3-7bea7be61832:
+    id: node_type
+    bundles:
+      news: news
+    negate: false
+    context_mapping:
+      node: node
+    uuid: fa81abf5-640d-4efc-a8d3-7bea7be61832
+selection_logic: and
+weight: -7
+relationships: {  }

--- a/config/sync/pathauto.pattern.stories.yml
+++ b/config/sync/pathauto.pattern.stories.yml
@@ -1,0 +1,22 @@
+uuid: 44dacad2-b3dd-421e-a3ba-9294e5ccf3bd
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: stories
+label: Stories
+type: 'canonical_entities:node'
+pattern: '[eic_groups_tokens:node_group_url]/stories/[node:title]'
+selection_criteria:
+  9576bc1d-7c9e-426e-b9c0-23bac8084a58:
+    id: node_type
+    bundles:
+      story: story
+    negate: false
+    context_mapping:
+      node: node
+    uuid: 9576bc1d-7c9e-426e-b9c0-23bac8084a58
+selection_logic: and
+weight: -6
+relationships: {  }

--- a/config/sync/pathauto.pattern.wiki_pages.yml
+++ b/config/sync/pathauto.pattern.wiki_pages.yml
@@ -7,16 +7,16 @@ dependencies:
 id: wiki_pages
 label: 'Wiki pages'
 type: 'canonical_entities:node'
-pattern: '[eic_groups_tokens:node_group_url]/[node:book:parents:join-path]/[node:title]'
+pattern: '[node:book:parent:url:relative]/[node:title]'
 selection_criteria:
-  2a195ea2-0fb2-4aee-b499-8320caaf3125:
+  4f8b89a4-f875-42e5-bee1-141f41c42822:
     id: node_type
     bundles:
       wiki_page: wiki_page
     negate: false
     context_mapping:
       node: node
-    uuid: 2a195ea2-0fb2-4aee-b499-8320caaf3125
+    uuid: 4f8b89a4-f875-42e5-bee1-141f41c42822
 selection_logic: and
-weight: -8
+weight: -5
 relationships: {  }

--- a/lib/themes/eic_community/includes/preprocess/content/node--document.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--document.inc
@@ -17,6 +17,10 @@ function eic_community_preprocess_node__document(array &$variables) {
   if ($variables['teaser']) {
     $file = File::load($node->get('field_document_media')->getString());
 
+    if (!$file) {
+      return;
+    }
+
     $document = [
       'language' => $node->language()->getName(),
       'timestamp' => eic_community_get_teaser_time_display($node->get('changed')->getString()),


### PR DESCRIPTION
### Changes

- New pathauto patterns: Library, News and Stories;
- Updated pathauto patterns: Group, Wiki pages;
- Fixed error when trying to show a document teaser without a media.