### PR TITLE
EICNET-866: Validation on custom restrictions when creating a restricted group

### DIFF
--- a/lib/modules/oec_group_flex/src/Plugin/CustomRestrictedVisibility/RestrictedEmailDomains.php
+++ b/lib/modules/oec_group_flex/src/Plugin/CustomRestrictedVisibility/RestrictedEmailDomains.php
@@ -7,7 +7,6 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\group\Access\GroupAccessResult;
 use Drupal\group\Entity\GroupInterface;
-use Drupal\oec_group_flex\Annotation\CustomRestrictedVisibility;
 use Drupal\oec_group_flex\GroupVisibilityRecordInterface;
 use Drupal\oec_group_flex\Plugin\CustomRestrictedVisibilityBase;
 
@@ -90,6 +89,24 @@ class RestrictedEmailDomains extends CustomRestrictedVisibilityBase {
     }
     // Fallback to neutral access.
     return parent::hasViewAccess($entity, $account, $group_visibility_record);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validatePluginForm(array &$element, FormStateInterface $form_state) {
+    $status_key = $this->getPluginId() . '_status';
+    // If plugin status is disabled, we do nothing.
+    if (!$form_state->getValue($status_key)) {
+      return;
+    }
+    $conf_key = $this->getPluginId() . '_conf';
+    // If plugin has configurations, the validation will be handled in
+    // ::validateEmailDomains() so we skip it from here.
+    if ($form_state->getValue($conf_key)) {
+      return;
+    }
+    return $form_state->setError($element[$this->getPluginId() . '_conf'], $this->t('You need to enter at least 1 email domain.'));
   }
 
 }

--- a/lib/modules/oec_group_flex/src/Plugin/CustomRestrictedVisibility/RestrictedEmailDomains.php
+++ b/lib/modules/oec_group_flex/src/Plugin/CustomRestrictedVisibility/RestrictedEmailDomains.php
@@ -95,9 +95,8 @@ class RestrictedEmailDomains extends CustomRestrictedVisibilityBase {
    * {@inheritdoc}
    */
   public function validatePluginForm(array &$element, FormStateInterface $form_state) {
-    $status_key = $this->getPluginId() . '_status';
     // If plugin status is disabled, we do nothing.
-    if (!$form_state->getValue($status_key)) {
+    if (parent::validatePluginForm($element, $form_state)) {
       return;
     }
     $conf_key = $this->getPluginId() . '_conf';

--- a/lib/modules/oec_group_flex/src/Plugin/CustomRestrictedVisibility/RestrictedUsers.php
+++ b/lib/modules/oec_group_flex/src/Plugin/CustomRestrictedVisibility/RestrictedUsers.php
@@ -104,9 +104,7 @@ class RestrictedUsers extends CustomRestrictedVisibilityBase {
    * {@inheritdoc}
    */
   public function validatePluginForm(array &$element, FormStateInterface $form_state) {
-    $status_key = $this->getPluginId() . '_status';
-    // If plugin status is disabled, we do nothing.
-    if (!$form_state->getValue($status_key)) {
+    if (parent::validatePluginForm($element, $form_state)) {
       return;
     }
     $conf_key = $this->getPluginId() . '_conf';

--- a/lib/modules/oec_group_flex/src/Plugin/CustomRestrictedVisibility/RestrictedUsers.php
+++ b/lib/modules/oec_group_flex/src/Plugin/CustomRestrictedVisibility/RestrictedUsers.php
@@ -2,11 +2,11 @@
 
 namespace Drupal\oec_group_flex\Plugin\CustomRestrictedVisibility;
 
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\group\Access\GroupAccessResult;
 use Drupal\group\Entity\GroupInterface;
-use Drupal\oec_group_flex\Annotation\CustomRestrictedVisibility;
 use Drupal\oec_group_flex\GroupVisibilityRecordInterface;
 use Drupal\oec_group_flex\Plugin\CustomRestrictedVisibilityBase;
 use Drupal\user\Entity\User;
@@ -98,6 +98,24 @@ class RestrictedUsers extends CustomRestrictedVisibilityBase {
     }
     // Fallback to neutral access.
     return parent::hasViewAccess($entity, $account, $group_visibility_record);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validatePluginForm(array &$element, FormStateInterface $form_state) {
+    $status_key = $this->getPluginId() . '_status';
+    // If plugin status is disabled, we do nothing.
+    if (!$form_state->getValue($status_key)) {
+      return;
+    }
+    $conf_key = $this->getPluginId() . '_conf';
+    // If plugin has configurations, the validation will be handled in
+    // field type itself so we skip it from here.
+    if ($form_state->getValue($conf_key)) {
+      return;
+    }
+    return $form_state->setError($element[$this->getPluginId() . '_conf'], $this->t('You need to select at least 1 trusted user.'));
   }
 
 }

--- a/lib/modules/oec_group_flex/src/Plugin/CustomRestrictedVisibilityBase.php
+++ b/lib/modules/oec_group_flex/src/Plugin/CustomRestrictedVisibilityBase.php
@@ -37,6 +37,13 @@ abstract class CustomRestrictedVisibilityBase extends PluginBase implements Cust
    * {@inheritdoc}
    */
   public function validatePluginForm(array &$element, FormStateInterface $form_state) {
+    $status_key = $this->getPluginId() . '_status';
+    // If plugin status is disabled, we don't need any validation and therefore
+    // we return TRUE.
+    if (!$form_state->getValue($status_key)) {
+      return TRUE;
+    }
+    return FALSE;
   }
 
   /**


### PR DESCRIPTION
### Improvements

- Create form validation to validate when a custom restriction with (email domains or specific trusted users) are empty.

### Tests

- [ ] Navigate to the group add form -> group/add/group
- [ ] Fill in the mandatory fields
- [ ] Select custom restriction visibility
- [ ] Select option restricted by email domains and leave the email domains field as empty
- [ ] Try to save the group and check if an error message will show up "**You need to enter at least 1 email domain.**"
- [ ] Fill in the email domains field
- [ ] Select option restricted by trusted users
- [ ] Try to save the group and check if an error message will show up "**You need to select at least 1 trusted user.**"
- [ ] Fill in the trusted users field
- [ ] Try to save and see if the group gets successfully created