### PR TITLE
Fixes some issues when deleting comments

### DIFF
--- a/lib/modules/eic_flags/src/FlaggedEntitiesListBuilder.php
+++ b/lib/modules/eic_flags/src/FlaggedEntitiesListBuilder.php
@@ -202,7 +202,7 @@ class FlaggedEntitiesListBuilder extends EntityListBuilder {
     }
 
     $request_count = count(
-      $this->flagService->getEntityFlaggings($flags[$entity_type_id], $flagged_entity)
+      $this->requestHandler->getOpenRequests($flagged_entity)
     );
 
     $type = '';

--- a/lib/modules/eic_flags/src/Form/RequestCloseForm.php
+++ b/lib/modules/eic_flags/src/Form/RequestCloseForm.php
@@ -87,8 +87,7 @@ class RequestCloseForm extends ContentEntityConfirmFormBase {
     return $this->t(
       'Are you sure you want to apply response "@response" to the @entity-type %label?',
       [
-        '@entity-type' => $this->getEntity()->getEntityType()->getSingularLabel(
-        ),
+        '@entity-type' => $this->getEntity()->getEntityType()->getSingularLabel(),
         '@response' => RequestStatus::DENIED,
         '%label' => $this->getEntity()->label(),
       ]
@@ -113,7 +112,8 @@ class RequestCloseForm extends ContentEntityConfirmFormBase {
   public function validateForm(array &$form, FormStateInterface $form_state) {
     if (!$form_state->getValue('response_text')) {
       $form_state->setErrorByName(
-        'response_text', $this->t('Reason field is required')
+        'response_text',
+        $this->t('Reason field is required')
       );
     }
   }
@@ -138,6 +138,7 @@ class RequestCloseForm extends ContentEntityConfirmFormBase {
     }
 
     $flag_id = $handler->getFlagId($this->entity->getEntityTypeId());
+    /** @var \Drupal\flag\FlaggingInterface $flag */
     $flag = $this->flagService->getFlagById($flag_id);
     if (!$flag instanceof FlagInterface) {
       throw new InvalidArgumentException('Flag doesn\'t exists');
@@ -171,13 +172,21 @@ class RequestCloseForm extends ContentEntityConfirmFormBase {
     }
 
     foreach ($entity_flags as $flag) {
-      call_user_func(
-        [$handler, $action],
+      // Close requests and trigger hooks, events, etc.
+      $handler->closeRequest(
         $flag,
         $this->entity,
+        $response,
         $form_state->getValue('response_text')
       );
     }
+
+    // Execute the response
+    call_user_func(
+      [$handler, $action],
+      $flag,
+      $this->entity
+    );
   }
 
   /**

--- a/lib/modules/eic_flags/src/Service/AbstractRequestHandler.php
+++ b/lib/modules/eic_flags/src/Service/AbstractRequestHandler.php
@@ -70,16 +70,16 @@ abstract class AbstractRequestHandler implements HandlerInterface {
    */
   abstract function accept(
     FlaggingInterface $flagging,
-    ContentEntityInterface $content_entity,
-    string $reason
+    ContentEntityInterface $content_entity
   );
 
   /**
    * {@inheritdoc}
    */
-  public function deny(
+  public function closeRequest(
     FlaggingInterface $flagging,
     ContentEntityInterface $content_entity,
+    string $response,
     string $reason
   ) {
     $this->moduleHandler->invokeAll(
@@ -87,14 +87,23 @@ abstract class AbstractRequestHandler implements HandlerInterface {
       [
         $flagging,
         $content_entity,
-        RequestStatus::DENIED,
+        $response,
         $reason,
       ]
     );
 
-    $flagging->set('field_request_status', RequestStatus::DENIED);
+    $flagging->set('field_request_status', $response);
     $flagging->save();
+  }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function deny(
+    FlaggingInterface $flagging,
+    ContentEntityInterface $content_entity
+  ) {
+    // Currently does nothing, this will change
     return TRUE;
   }
 

--- a/lib/modules/eic_flags/src/Service/DeleteRequestHandler.php
+++ b/lib/modules/eic_flags/src/Service/DeleteRequestHandler.php
@@ -33,17 +33,8 @@ class DeleteRequestHandler extends AbstractRequestHandler {
     ContentEntityInterface $content_entity,
     string $reason
   ) {
-    switch ($content_entity->getEntityTypeId()) {
-      case 'group':
-        /** @var GroupInterface $content_entity */
-        $this->deleteGroup($content_entity);
-        break;
-      case 'node':
-      case 'comment':
-        $content_entity->delete();
-        $content_entity->save();
-        break;
-    }
+    $flagging->set('field_request_status', RequestStatus::ACCEPTED);
+    $flagging->save();
 
     $this->moduleHandler->invokeAll(
       'request_close',
@@ -55,8 +46,16 @@ class DeleteRequestHandler extends AbstractRequestHandler {
       ]
     );
 
-    $flagging->set('field_request_status', RequestStatus::ACCEPTED);
-    $flagging->save();
+    switch ($content_entity->getEntityTypeId()) {
+      case 'group':
+        /** @var GroupInterface $content_entity */
+        $this->deleteGroup($content_entity);
+        break;
+      case 'node':
+      case 'comment':
+        $content_entity->delete();
+        break;
+    }
   }
 
   /**
@@ -78,8 +77,10 @@ class DeleteRequestHandler extends AbstractRequestHandler {
       $state = $content_entity->getEntityTypeId() === 'group' ? 'pending' : 'unpublished';
       $content_entity->set('moderation_state', $state);
     }
+    else {
+      $content_entity->set('status', FALSE);
+    }
 
-    $content_entity->set('status', FALSE);
     $content_entity->save();
 
     $this->moduleHandler->invokeAll(
@@ -92,8 +93,8 @@ class DeleteRequestHandler extends AbstractRequestHandler {
       ]
     );
 
-    $flagging->set('field_request_status', RequestStatus::ARCHIVED);
-    $flagging->save();
+    //$flagging->set('field_request_status', RequestStatus::ARCHIVED);
+    //$flagging->save();
   }
 
   /**

--- a/lib/modules/eic_flags/src/Service/DeleteRequestHandler.php
+++ b/lib/modules/eic_flags/src/Service/DeleteRequestHandler.php
@@ -93,8 +93,8 @@ class DeleteRequestHandler extends AbstractRequestHandler {
       ]
     );
 
-    //$flagging->set('field_request_status', RequestStatus::ARCHIVED);
-    //$flagging->save();
+    $flagging->set('field_request_status', RequestStatus::ARCHIVED);
+    $flagging->save();
   }
 
   /**

--- a/lib/modules/eic_flags/src/Service/DeleteRequestHandler.php
+++ b/lib/modules/eic_flags/src/Service/DeleteRequestHandler.php
@@ -30,22 +30,8 @@ class DeleteRequestHandler extends AbstractRequestHandler {
    */
   public function accept(
     FlaggingInterface $flagging,
-    ContentEntityInterface $content_entity,
-    string $reason
+    ContentEntityInterface $content_entity
   ) {
-    $flagging->set('field_request_status', RequestStatus::ACCEPTED);
-    $flagging->save();
-
-    $this->moduleHandler->invokeAll(
-      'request_close',
-      [
-        $flagging,
-        $content_entity,
-        RequestStatus::ACCEPTED,
-        $reason,
-      ]
-    );
-
     switch ($content_entity->getEntityTypeId()) {
       case 'group':
         /** @var GroupInterface $content_entity */
@@ -63,14 +49,12 @@ class DeleteRequestHandler extends AbstractRequestHandler {
    *
    * @param \Drupal\flag\FlaggingInterface $flagging
    * @param \Drupal\Core\Entity\ContentEntityInterface $content_entity
-   * @param string $reason
    *
    * @throws \Drupal\Core\Entity\EntityStorageException
    */
   public function archive(
     FlaggingInterface $flagging,
-    ContentEntityInterface $content_entity,
-    string $reason
+    ContentEntityInterface $content_entity
   ) {
     if ($this->moderationInformation->isModeratedEntity($content_entity)) {
       // TODO think about looping through every workflow to find an 'unpublished' state
@@ -82,19 +66,6 @@ class DeleteRequestHandler extends AbstractRequestHandler {
     }
 
     $content_entity->save();
-
-    $this->moduleHandler->invokeAll(
-      'request_close',
-      [
-        $flagging,
-        $content_entity,
-        RequestStatus::ARCHIVED,
-        $reason,
-      ]
-    );
-
-    $flagging->set('field_request_status', RequestStatus::ARCHIVED);
-    $flagging->save();
   }
 
   /**

--- a/lib/modules/eic_flags/src/Service/HandlerInterface.php
+++ b/lib/modules/eic_flags/src/Service/HandlerInterface.php
@@ -29,7 +29,11 @@ interface HandlerInterface {
    *
    * @return bool
    */
-  public function deny(FlaggingInterface $flagging, ContentEntityInterface $content_entity, string $reason);
+  public function deny(
+    FlaggingInterface $flagging,
+    ContentEntityInterface $content_entity,
+    string $reason
+  );
 
   /**
    * Starts the 'accept' workflow for a request.
@@ -40,7 +44,11 @@ interface HandlerInterface {
    *
    * @return bool
    */
-  public function accept(FlaggingInterface $flagging, ContentEntityInterface $content_entity, string $reason);
+  public function accept(
+    FlaggingInterface $flagging,
+    ContentEntityInterface $content_entity,
+    string $reason
+  );
 
   /**
    * Applies the given the corresponding flag to the given entity.
@@ -79,9 +87,21 @@ interface HandlerInterface {
 
   /**
    * @param \Drupal\Core\Entity\ContentEntityInterface $content_entity
+   * @param \Drupal\Core\Session\AccountInterface|null $account
+   *
+   * @return array
+   */
+  public function getOpenRequests(
+    ContentEntityInterface $content_entity,
+    ?AccountInterface $account = null
+  );
+
+  /**
+   * @param \Drupal\Core\Entity\ContentEntityInterface $content_entity
    * @param \Drupal\Core\Session\AccountInterface $account
    *
    * @return bool
    */
   public function hasOpenRequest(ContentEntityInterface $content_entity, AccountInterface $account);
+
 }

--- a/lib/modules/eic_flags/src/Service/HandlerInterface.php
+++ b/lib/modules/eic_flags/src/Service/HandlerInterface.php
@@ -21,18 +21,34 @@ interface HandlerInterface {
   public function getType();
 
   /**
+   * Method called before the action is executed.
+   * Can be used for sending notifications, triggering hooks, events, etc.
+   *
+   * @param \Drupal\flag\FlaggingInterface $flagging
+   * @param \Drupal\Core\Entity\ContentEntityInterface $content_entity
+   * @param string $response
+   * @param string $reason
+   *
+   * @return void
+   */
+  public function closeRequest(
+    FlaggingInterface $flagging,
+    ContentEntityInterface $content_entity,
+    string $response,
+    string $reason
+  );
+
+  /**
    * Starts the 'deny' workflow for a request.
    *
    * @param \Drupal\flag\FlaggingInterface $flagging
    * @param \Drupal\Core\Entity\ContentEntityInterface $content_entity
-   * @param string $reason
    *
    * @return bool
    */
   public function deny(
     FlaggingInterface $flagging,
-    ContentEntityInterface $content_entity,
-    string $reason
+    ContentEntityInterface $content_entity
   );
 
   /**
@@ -40,14 +56,12 @@ interface HandlerInterface {
    *
    * @param \Drupal\flag\FlaggingInterface $flagging
    * @param \Drupal\Core\Entity\ContentEntityInterface $content_entity
-   * @param string $reason
    *
    * @return bool
    */
   public function accept(
     FlaggingInterface $flagging,
-    ContentEntityInterface $content_entity,
-    string $reason
+    ContentEntityInterface $content_entity
   );
 
   /**
@@ -93,7 +107,7 @@ interface HandlerInterface {
    */
   public function getOpenRequests(
     ContentEntityInterface $content_entity,
-    ?AccountInterface $account = null
+    ?AccountInterface $account = NULL
   );
 
   /**

--- a/lib/modules/eic_messages/eic_messages.module
+++ b/lib/modules/eic_messages/eic_messages.module
@@ -42,7 +42,7 @@ function eic_messages_group_content_insert(EntityInterface $entity) {
 /**
  * Implements hook_delete_request_insert().
  */
-function eic_messages_delete_request_insert(FlaggingInterface $flag, ContentEntityInterface $entity) {
+function eic_messages_request_insert(FlaggingInterface $flag, ContentEntityInterface $entity) {
   /** @var DeleteRequestMessageCreator $class */
   $class = \Drupal::classResolver(DeleteRequestMessageCreator::class);
   $class->deleteRequestInsert($flag, $entity);


### PR DESCRIPTION
### Fixes
Error on approuval of a comment delete request
Count of open requests
Hook being not triggerred when request is created

### How to test

- [x] Introduce 2 delete request for content entities (e.g: a comment)
- [x] An email should be sent and available in mailhog when the queue runs
- [x] Go to /admin/community/request/delete, count of requests should match to the number of open requests
- [x] Approuve the delete request for an entity, the entity should be deleted