### PR TITLE
EICNET-848: <p> tag is shown in teaser components (News/Story teaser)

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/blocks/block--latest-news-stories.inc
+++ b/lib/themes/eic_community/includes/preprocess/blocks/block--latest-news-stories.inc
@@ -5,6 +5,7 @@
  * Contains implementation for ook_preprocess_block() for latest_news_stories.
  */
 
+use Drupal\Component\Utility\Xss;
 use Drupal\Core\Cache\Cache;
 use Drupal\eic_community\ValueObject\ImageValueObject;
 use Drupal\node\NodeInterface;
@@ -45,7 +46,7 @@ function eic_community_preprocess_block__latest_news_stories(&$variables, &$cach
 
     $item = [
       'title' => $node_translation->label(),
-      'description' => $node_translation->get('field_introduction')->value,
+      'description' => Xss::filter($node_translation->get('field_introduction')->value),
       'path' => $node_translation->toUrl()->toString(),
       'type' => [
         'label' => $node_translation->type->entity->label(),

--- a/lib/themes/eic_community/templates/content/node--story--teaser.html.twig
+++ b/lib/themes/eic_community/templates/content/node--story--teaser.html.twig
@@ -16,7 +16,7 @@
     {{ title_suffix }}
     {% include "@theme/patterns/compositions/story/story.teaser.html.twig" with story_item|default({})|merge({
       title: label|default(''),
-      description: node.field_introduction.value|default(''),
+      description: node.field_introduction.value|striptags|default(''),
       path: url,
     }) %}
   </div>


### PR DESCRIPTION
### Fixes

- Strip tags from field_introduction when viewing News/Story teasers.

### Tests

- [ ] Create public News and Stories
- [ ] Reference some stories in the homepage "Latest News & Stories" block
- [ ] View the homepage and check if the introduction field of the News/Stories doesn't contain a `<p></p>` in the text
- [ ] Create a group and reference some "Related Stories"
- [ ] Go to the group homepage and check if the introduction field of the related stories doesn't contain a `<p></p>` in the text