### PR TITLE
EICNET-987: Remove char "a" from strings to remove from pathauto gene…

### DIFF
--- a/config/sync/pathauto.settings.yml
+++ b/config/sync/pathauto.settings.yml
@@ -40,7 +40,7 @@ max_component_length: 100
 transliterate: true
 reduce_ascii: false
 case: true
-ignore_words: 'a, an, as, at, before, but, by, for, from, is, in, into, like, of, off, on, onto, per, since, than, the, this, that, to, up, via, with'
+ignore_words: 'an, as, at, before, but, by, for, from, is, in, into, like, of, off, on, onto, per, since, than, the, this, that, to, up, via, with'
 update_action: 2
 safe_tokens:
   - alias


### PR DESCRIPTION
### Changes

- Remove char "a" from strings to remove from pathauto generated url.

### Tests

- [ ] Create group with title "Group A"
- [ ] Check if the group url is `group/group-a`
