### PR TITLE
EICNET-965: Update permissions to view book pages for admins and owners

### DIFF
--- a/config/sync/group.role.group-admin.yml
+++ b/config/sync/group.role.group-admin.yml
@@ -41,6 +41,7 @@ permissions:
   - 'view comments'
   - 'view group'
   - 'view group_membership content'
+  - 'view group_node:book entity'
   - 'view group_node:discussion entity'
   - 'view group_node:document entity'
   - 'view group_node:gallery entity'

--- a/config/sync/group.role.group-owner.yml
+++ b/config/sync/group.role.group-owner.yml
@@ -44,6 +44,7 @@ permissions:
   - 'view group latest version'
   - 'view group revisions'
   - 'view group_membership content'
+  - 'view group_node:book entity'
   - 'view group_node:discussion entity'
   - 'view group_node:document entity'
   - 'view group_node:gallery entity'


### PR DESCRIPTION
### Changes

- Allow group admins and group owners to view book pages.

### Tests

- [ ] As a content administrator, create a new group and publish it
- [ ] Go to the group book page (though `/admin/content`) and check if you have access to view the page