### PR TITLE
EICNET-990: Disable basic authentication module

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -4,7 +4,6 @@ module:
   admin_toolbar_links_access_filter: 0
   admin_toolbar_search: 0
   admin_toolbar_tools: 0
-  basic_auth: 0
   big_pipe: 0
   block: 0
   block_content: 0

--- a/config/sync/rest.resource.eic_webservices_user.yml
+++ b/config/sync/rest.resource.eic_webservices_user.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   module:
-    - basic_auth
     - eic_webservices
     - hal
     - user
@@ -17,5 +16,4 @@ configuration:
   formats:
     - hal_json
   authentication:
-    - basic_auth
-    - cookie
+    1: cookie

--- a/config/sync/rest.resource.eic_webservices_user_update.yml
+++ b/config/sync/rest.resource.eic_webservices_user_update.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   module:
-    - basic_auth
     - eic_webservices
     - hal
     - user
@@ -16,5 +15,4 @@ configuration:
   formats:
     - hal_json
   authentication:
-    - basic_auth
-    - cookie
+    1: cookie


### PR DESCRIPTION
### Changes

- Disabled basic authentication module since it's not being used at the moment and it brings some issues in staging;