### PR TITLE
EICNET-983: Problem with author picture fixed

### DIFF
--- a/lib/themes/eic_community/sass/components/_author.scss
+++ b/lib/themes/eic_community/sass/components/_author.scss
@@ -176,6 +176,7 @@
     position: relative;
     overflow: hidden;
     background-color: map-get($ecl-colors, 'grey-10');
+    display: block;
 
     #{$node}:hover #{$node}__aside:only-child & {
       box-shadow: 0 0 0 map-get($ecl-spacing, '2xs') map-get($ecl-colors, 'blue-50');


### PR DESCRIPTION
The author picture is now visible again, the css bug affected the display everywhere.

It was noticed on the discussion detail page contributor grid. But I also saw it in the discussion teaser on the group page and in the comments on the discussion detail page.

