### PR TITLE
EICNET-1036: Re-adapt group wiki navigation block plugin to meet drupal API changes

### DIFF
--- a/lib/modules/eic_content/modules/eic_content_book/src/Plugin/Block/EICBookNavigationBlock.php
+++ b/lib/modules/eic_content/modules/eic_content_book/src/Plugin/Block/EICBookNavigationBlock.php
@@ -6,9 +6,10 @@ use Drupal\book\BookManagerInterface;
 use Drupal\book\Plugin\Block\BookNavigationBlock;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\eic_content\EICContentHelperInterface;
+use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Provides a 'Book navigation' block.
@@ -37,8 +38,8 @@ class EICBookNavigationBlock extends BookNavigationBlock {
    *   The plugin_id for the plugin instance.
    * @param mixed $plugin_definition
    *   The plugin implementation definition.
-   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
-   *   The request stack object.
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The current route match.
    * @param \Drupal\book\BookManagerInterface $book_manager
    *   The book manager.
    * @param \Drupal\Core\Entity\EntityStorageInterface $node_storage
@@ -46,8 +47,8 @@ class EICBookNavigationBlock extends BookNavigationBlock {
    * @param \Drupal\eic_content\EICContentHelperInterface $eic_content_helper
    *   The EIC content helper.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, RequestStack $request_stack, BookManagerInterface $book_manager, EntityStorageInterface $node_storage, EICContentHelperInterface $eic_content_helper) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $request_stack, $book_manager, $node_storage);
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, RouteMatchInterface $route_match, BookManagerInterface $book_manager, EntityStorageInterface $node_storage, EICContentHelperInterface $eic_content_helper) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $route_match, $book_manager, $node_storage);
     $this->eicContentHelper = $eic_content_helper;
   }
 
@@ -59,7 +60,7 @@ class EICBookNavigationBlock extends BookNavigationBlock {
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('request_stack'),
+      $container->get('current_route_match'),
       $container->get('book.manager'),
       $container->get('entity_type.manager')->getStorage('node'),
       $container->get('eic_content.helper')
@@ -84,7 +85,12 @@ class EICBookNavigationBlock extends BookNavigationBlock {
    * {@inheritdoc}
    */
   public function build() {
-    if (!$node = $this->requestStack->getCurrentRequest()->get('node')) {
+    // If there wasn't any node found in the route context, we do nothing.
+    if (!$node = $this->routeMatch->getParameter('node')) {
+      return [];
+    }
+
+    if (!($node instanceof NodeInterface)) {
       return [];
     }
 


### PR DESCRIPTION
### Fixes

- Re-adapt block plugin classes eic_groups_wiki_book_navigation and eic_content_book_navigation due to changes on the BookNavigationBlock base class.

### Tests

- [ ] Fresh install the website and check if there are no errors;
- [ ] Check if the book navigation is presented in Group book and wiki pages;
- [ ] Check if the book navigation is presented in book pages outside groups;