### PR TITLE
EICNET-943: As a site user I can see the breadcrumbs when navigating through the platform

### DIFF
--- a/lib/modules/eic_content/eic_content.services.yml
+++ b/lib/modules/eic_content/eic_content.services.yml
@@ -2,3 +2,8 @@ services:
   eic_content.helper:
     class: Drupal\eic_content\EICContentHelper
     arguments: ['@entity_type.manager', '@module_handler']
+
+  eic_content.breadcrumb:
+    class: Drupal\eic_content\ContentBreadcrumbBuilder
+    tags:
+      - { name: breadcrumb_builder, priority: 999 }

--- a/lib/modules/eic_groups/src/Breadcrumb/GroupBreadcrumbBuilder.php
+++ b/lib/modules/eic_groups/src/Breadcrumb/GroupBreadcrumbBuilder.php
@@ -141,12 +141,14 @@ class GroupBreadcrumbBuilder implements BreadcrumbBuilderInterface {
             $breadcrumb->addCacheableDependency($access);
           }
 
-          // We add the group as cacheable dependency.
-          $breadcrumb->addCacheableDependency($group);
+
         }
         break;
 
     }
+
+    // We add the group as cacheable dependency.
+    $breadcrumb->addCacheableDependency($group);
 
     $breadcrumb->setLinks($links);
     $breadcrumb->addCacheContexts(['url.path']);

--- a/lib/modules/eic_groups/src/Breadcrumb/GroupBreadcrumbBuilder.php
+++ b/lib/modules/eic_groups/src/Breadcrumb/GroupBreadcrumbBuilder.php
@@ -123,11 +123,16 @@ class GroupBreadcrumbBuilder implements BreadcrumbBuilderInterface {
                 $links[] = Link::createFromRoute($this->t('Discussions'), 'view.group_overviews.page_1', ['group' => $group->id()]);
                 break;
 
+              case 'document':
+              case 'gallery':
+                // @todo Replace link route with overview page route when available.
+                $links[] = Link::createFromRoute($this->t('Library'), '<none>');
+                break;
+
             }
 
-            // We add the node and group objects as cacheable dependency.
+            // We add the node object as cacheable dependency.
             $breadcrumb->addCacheableDependency($node);
-            $breadcrumb->addCacheableDependency($group);
           }
         }
         break;
@@ -140,8 +145,6 @@ class GroupBreadcrumbBuilder implements BreadcrumbBuilderInterface {
           if ($access = $group->access('view', $this->account, TRUE)) {
             $breadcrumb->addCacheableDependency($access);
           }
-
-
         }
         break;
 

--- a/lib/modules/eic_groups/src/Breadcrumb/GroupBreadcrumbBuilder.php
+++ b/lib/modules/eic_groups/src/Breadcrumb/GroupBreadcrumbBuilder.php
@@ -119,6 +119,10 @@ class GroupBreadcrumbBuilder implements BreadcrumbBuilderInterface {
                 $breadcrumb->addCacheTags($book_breadcrumb->getCacheTags());
                 break;
 
+              case 'discussion':
+                $links[] = Link::createFromRoute($this->t('Discussions'), 'view.group_overviews.page_1', ['group' => $group->id()]);
+                break;
+
             }
 
             // We add the node and group objects as cacheable dependency.

--- a/lib/modules/eic_groups/src/Breadcrumb/GroupBreadcrumbBuilder.php
+++ b/lib/modules/eic_groups/src/Breadcrumb/GroupBreadcrumbBuilder.php
@@ -97,26 +97,28 @@ class GroupBreadcrumbBuilder implements BreadcrumbBuilderInterface {
             // group content entity from the array.
             $group_content_entity = reset($group_content);
             $group = $group_content_entity->getGroup();
+            $links[] = $group->toLink();
 
-            if (in_array($node->bundle(), ['book', 'wiki_page'])) {
-              $book_breadcrumb = $this->bookBreadcrumbBuilder->build($route_match);
-              // Replace links with book breadcrumb links.
-              $links = $book_breadcrumb->getLinks();
-              // Places the group link right after the "Home" link.
-              array_splice($links, 1, 0, [$group->toLink()]);
-              // Places the groups overview link right after the "Home" link.
-              array_splice($links, 1, 0, [Link::createFromRoute($this->t('Groups'), 'view.global_overviews.page_1')]);
-              // Replaces book link text with "Wiki".
-              if ($node->bundle() === 'wiki_page') {
-                $links[3]->setText($this->t('Wiki'));
-              }
-              // We want to keep cache contexts and cache tags from book
-              // breadcrumb.
-              $breadcrumb->addCacheContexts($book_breadcrumb->getCacheContexts());
-              $breadcrumb->addCacheTags($book_breadcrumb->getCacheTags());
-            }
-            else {
-              $links[] = $group->toLink();
+            switch ($node->bundle()) {
+              case 'book':
+              case 'wiki_page':
+                $book_breadcrumb = $this->bookBreadcrumbBuilder->build($route_match);
+                // Replace links with book breadcrumb links.
+                $links = $book_breadcrumb->getLinks();
+                // Places the group link right after the "Home" link.
+                array_splice($links, 1, 0, [$group->toLink()]);
+                // Places the groups overview link right after the "Home" link.
+                array_splice($links, 1, 0, [Link::createFromRoute($this->t('Groups'), 'view.global_overviews.page_1')]);
+                // Replaces book link text with "Wiki".
+                if ($node->bundle() === 'wiki_page') {
+                  $links[3]->setText($this->t('Wiki'));
+                }
+                // We want to keep cache contexts and cache tags from book
+                // breadcrumb.
+                $breadcrumb->addCacheContexts($book_breadcrumb->getCacheContexts());
+                $breadcrumb->addCacheTags($book_breadcrumb->getCacheTags());
+                break;
+
             }
 
             // We add the node and group objects as cacheable dependency.

--- a/lib/themes/eic_community/includes/preprocess/navigation/breadcrumb.inc
+++ b/lib/themes/eic_community/includes/preprocess/navigation/breadcrumb.inc
@@ -25,6 +25,11 @@ function eic_community_preprocess_breadcrumb(array &$variables): void {
         }
       }
       break;
+
+    case 'eic_groups.about_page':
+      $title = t('About');
+      break;
+
   }
 
   if (!isset($title)) {


### PR DESCRIPTION
### Improvements

- Minor improvements in the GroupBreadcrumbBuilder class.
- Fix breadcrumb for group contents: discussion, document, gallery.
- Fix breadcrumb for group discussion nodes.
- Fix breadcrumb for group about page;
- Create breadcrumb builder to handle breadcrumb links for nodes that dont belong to a group. Currently only needs to handle "News" and "Stories";

### Tests

- [x] Create a group
- [x] Go to the group about page and check if the breacrumb is `Home > Groups > Group Title > About`
- [x] Create a group discussion and navigate to its detail page. Check if the breadcrumb is `Home > Groups > Group Title > Discussions > Discussion title`
- [x] Create a group document and navigate to its detail page. Check if the breadcrumb is `Home > Groups > Group Title > Library > Document title`
- [x] Create a group gallery and navigate to its detail page. Check if the breadcrumb is `Home > Groups > Group Title > Library > Gallery title`
- [x] Create a News and check if the breadcrumb is `Home > Stories > News Title`
- [x] Create a Story and check if the breadcrumb is `Home > Stories > Story Title`

### More in depth:

Check if breadcrumb is ok for all the following cases:

- Story detail page
- News detail page
- Content page
- Help and guidance (book pages)
- **All global overviews**:

> - Group overview
> - News and story overview - The overview page has not been yet developed.
> - Member overview

- **Groups**:

> - landingpage
> - Discussion detail
> - Wiki detail page

### Known issues:

Group document and gallery:
- The library overview page is not yet developed and thus, we need to update the **Library** link url in the GroupBreadcrumbBuilder class when the overview page is available.

News and Stories:
- The Stories overview page is not yet developed and thus, we need to update the **Stories** link url in the ContentBreadcrumbBuilder class when the overview page is available.

### Final notes:

- [ ] This PR can only me merged after #319 