### PR TITLE
EICNET-928: As a GO I want to edit my group after creating it (when it's not reviewed by a SA/SCM yet)

### DIFF
--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -5,7 +5,6 @@
  * Primary module hooks for EIC Groups module.
  */
 
-use Drupal\content_moderation\Entity\ContentModerationState;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
@@ -191,23 +190,12 @@ function eic_groups_entity_field_access($operation, FieldDefinitionInterface $fi
       switch ($operation) {
         case 'edit':
           // Deny access if it's a new group and the user doesn't have
-          // permission to change the group moderation state from pending to
-          // draft.
+          // "administator" or "content_administrator" roles.
           if ($entity->isNew()) {
-            $access = AccessResult::forbiddenIf(!$account->hasPermission('use groups transition upgrade to draft'))
+
+            $access = AccessResult::forbiddenIf(!in_array('administrator', $account->getRoles(TRUE)) && !in_array('content_administrator', $account->getRoles(TRUE)))
               ->addCacheableDependency($account);
             break;
-          }
-
-          $content_moderation_state = ContentModerationState::loadFromModeratedEntity($entity);
-
-          // Deny access if group moderation state is "pending" and the user
-          // doesn't have permission to change the group moderation state from
-          // pending to draft.
-          if ($content_moderation_state) {
-            $access = AccessResult::forbiddenIf($content_moderation_state->get('moderation_state')->value === 'pending' && !$account->hasPermission('use groups transition upgrade to draft'))
-              ->addCacheableDependency($content_moderation_state)
-              ->addCacheableDependency($account);
           }
 
           break;

--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -176,31 +176,28 @@ function eic_groups_entity_field_access($operation, FieldDefinitionInterface $fi
     'field_related_news_stories',
   ];
 
-  // Access restrictions for group fields.
-  if (in_array($field_definition->getName(), $group_restricted_fields)) {
+  // If field is non of the restricted ones, we do nothing.
+  if (!in_array($field_definition->getName(), $group_restricted_fields)) {
+    return $access;
+  }
 
-    if (!$items) {
-      return $access;
-    }
+  if (!$items) {
+    return $access;
+  }
 
-    $entity = $items->getEntity();
+  $entity = $items->getEntity();
 
-    if ($entity instanceof GroupInterface && $entity->bundle() === 'group') {
-
-      switch ($operation) {
-        case 'edit':
-          // Deny access if it's a new group and the user doesn't have
-          // "administator" or "content_administrator" roles.
-          if ($entity->isNew()) {
-
-            $access = AccessResult::forbiddenIf(!in_array('administrator', $account->getRoles(TRUE)) && !in_array('content_administrator', $account->getRoles(TRUE)))
-              ->addCacheableDependency($account);
-            break;
-          }
-
+  if ($entity instanceof GroupInterface && $entity->bundle() === 'group') {
+    switch ($operation) {
+      case 'edit':
+        // Deny access if it's a new group and the user doesn't have
+        // "administator" or "content_administrator" roles.
+        if ($entity->isNew()) {
+          $access = AccessResult::forbiddenIf(!in_array('administrator', $account->getRoles(TRUE)) && !in_array('content_administrator', $account->getRoles(TRUE)))
+            ->addCacheableDependency($account);
           break;
-
-      }
+        }
+        break;
 
     }
   }

--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -5,16 +5,22 @@
  * Primary module hooks for EIC Groups module.
  */
 
+use Drupal\content_moderation\Entity\ContentModerationState;
+use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\BubbleableMetadata;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\eic_groups\Hooks\CronOperations;
 use Drupal\eic_groups\Hooks\EntityOperations;
 use Drupal\eic_groups\Hooks\GroupTokens;
 use Drupal\eic_groups\Hooks\FormOperations;
 use Drupal\eic_groups\Hooks\Pathauto;
 use Drupal\eic_groups\Hooks\Preprocess;
+use Drupal\group\Entity\GroupInterface;
 
 /**
  * Implements hook_theme().
@@ -158,4 +164,58 @@ function eic_groups_pathauto_alias_alter(&$alias, array &$context) {
 function eic_groups_cron() {
   \Drupal::classResolver(CronOperations::class)
     ->cron();
+}
+
+/**
+ * Implements hook_entity_field_access().
+ */
+function eic_groups_entity_field_access($operation, FieldDefinitionInterface $field_definition, AccountInterface $account, FieldItemListInterface $items = NULL) {
+  $access = AccessResult::neutral();
+
+  $group_restricted_fields = [
+    'field_related_groups',
+    'field_related_news_stories',
+  ];
+
+  // Access restrictions for group fields.
+  if (in_array($field_definition->getName(), $group_restricted_fields)) {
+
+    if (!$items) {
+      return $access;
+    }
+
+    $entity = $items->getEntity();
+
+    if ($entity instanceof GroupInterface && $entity->bundle() === 'group') {
+
+      switch ($operation) {
+        case 'edit':
+          // Deny access if it's a new group and the user doesn't have
+          // permission to change the group moderation state from pending to
+          // draft.
+          if ($entity->isNew()) {
+            $access = AccessResult::forbiddenIf(!$account->hasPermission('use groups transition upgrade to draft'))
+              ->addCacheableDependency($account);
+            break;
+          }
+
+          $content_moderation_state = ContentModerationState::loadFromModeratedEntity($entity);
+
+          // Deny access if group moderation state is "pending" and the user
+          // doesn't have permission to change the group moderation state from
+          // pending to draft.
+          if ($content_moderation_state) {
+            $access = AccessResult::forbiddenIf($content_moderation_state->get('moderation_state')->value === 'pending' && !$account->hasPermission('use groups transition upgrade to draft'))
+              ->addCacheableDependency($content_moderation_state)
+              ->addCacheableDependency($account);
+          }
+
+          break;
+
+      }
+
+    }
+  }
+
+  return $access;
 }


### PR DESCRIPTION
### Improvements

- Implement hook_entity_field_access() to restrict access on group fields (**field_related_groups** and **field_related_news_stories**) when group moderation state is pending.

### Test

- [ ] As a trusted user try to create a new group `/group/add/group` and check if the fields **field_related_groups** and **field_related_news_stories** are not visible;
- [ ] Save the group
- [ ] Try to edit the group and make sure you can edit the fields **field_related_groups** and **field_related_news_stories**;