### PR TITLE
Feature/eicnet 1023 global footer

### DIFF
--- a/config/sync/block_content.type.basic.yml
+++ b/config/sync/block_content.type.basic.yml
@@ -1,0 +1,8 @@
+uuid: 1380116b-f0ef-4802-acd3-871c394c4c09
+langcode: en
+status: true
+dependencies: {  }
+id: basic
+label: Basic
+revision: 0
+description: 'Block type composed by an optional title and description.'

--- a/config/sync/context.context.global.yml
+++ b/config/sync/context.context.global.yml
@@ -27,6 +27,57 @@ reactions:
         unique: 0
         context_id: global
         uuid: 8a784846-74f8-451c-b47b-fcc1177d6629
+      6e7a0bbc-0152-4e8d-91b4-be66ea3bd664:
+        id: 'system_menu_block:footer---european-commision'
+        label: 'European Commision'
+        provider: system
+        label_display: visible
+        level: '1'
+        depth: '0'
+        expand_all_items: 0
+        region: footer
+        weight: '0'
+        context_mapping: {  }
+        custom_id: system_menu_block_footer_european_commision
+        theme: eic_community
+        css_class: ''
+        unique: 0
+        context_id: global
+        uuid: 6e7a0bbc-0152-4e8d-91b4-be66ea3bd664
+      4c79c45d-9cbe-4c6a-9e40-f3f8647544bb:
+        id: 'system_menu_block:footer---european-union'
+        label: 'European Union'
+        provider: system
+        label_display: visible
+        level: '1'
+        depth: '0'
+        expand_all_items: 0
+        region: footer
+        weight: '1'
+        context_mapping: {  }
+        custom_id: system_menu_block_footer_european_union
+        theme: eic_community
+        css_class: ''
+        unique: 0
+        context_id: global
+        uuid: 4c79c45d-9cbe-4c6a-9e40-f3f8647544bb
+      88c19636-8f74-41ec-801c-6829bfe3a44d:
+        id: 'block_content:34a810c9-d608-4979-ac40-00657bce344b'
+        label: 'Footer - Site info'
+        provider: block_content
+        label_display: '0'
+        status: true
+        info: ''
+        view_mode: full
+        region: footer
+        weight: '-1'
+        context_mapping: {  }
+        custom_id: block_content_34a810c9_d608_4979_ac40_00657bce344b
+        theme: eic_community
+        css_class: ''
+        unique: 0
+        context_id: global
+        uuid: 88c19636-8f74-41ec-801c-6829bfe3a44d
     id: blocks
     saved: false
     uuid: c1979d39-89a3-4939-97f7-0af5a52467f1

--- a/config/sync/core.entity_form_display.block_content.basic.default.yml
+++ b/config/sync/core.entity_form_display.block_content.basic.default.yml
@@ -1,0 +1,49 @@
+uuid: 44286bd1-fda8-4cf0-bcd6-22cb2561777e
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.basic
+    - field.field.block_content.basic.body
+    - field.field.block_content.basic.field_title
+  module:
+    - text
+id: block_content.basic.default
+targetEntityType: block_content
+bundle: basic
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 3
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: false
+    third_party_settings: {  }
+    region: content
+  field_title:
+    weight: 2
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  info:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 1
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+hidden: {  }

--- a/config/sync/core.entity_view_display.block_content.basic.default.yml
+++ b/config/sync/core.entity_view_display.block_content.basic.default.yml
@@ -1,0 +1,33 @@
+uuid: 6c2803b8-e420-4f6b-bc22-800ff8c07e87
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.basic
+    - field.field.block_content.basic.body
+    - field.field.block_content.basic.field_title
+  module:
+    - text
+id: block_content.basic.default
+targetEntityType: block_content
+bundle: basic
+mode: default
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 1
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  field_title:
+    weight: 0
+    label: visually_hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden:
+  langcode: true
+  search_api_excerpt: true

--- a/config/sync/field.field.block_content.basic.body.yml
+++ b/config/sync/field.field.block_content.basic.body.yml
@@ -1,0 +1,23 @@
+uuid: 6bb80eb6-6633-4a04-b524-fe199963be30
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.basic
+    - field.storage.block_content.body
+  module:
+    - text
+id: block_content.basic.body
+field_name: body
+entity_type: block_content
+bundle: basic
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: false
+  required_summary: false
+field_type: text_with_summary

--- a/config/sync/field.field.block_content.basic.field_title.yml
+++ b/config/sync/field.field.block_content.basic.field_title.yml
@@ -1,0 +1,19 @@
+uuid: c540e16a-cba5-43c0-9067-c2826b82771f
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.basic
+    - field.storage.block_content.field_title
+id: block_content.basic.field_title
+field_name: field_title
+entity_type: block_content
+bundle: basic
+label: Title
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/language.content_settings.block_content.basic.yml
+++ b/config/sync/language.content_settings.block_content.basic.yml
@@ -1,0 +1,11 @@
+uuid: b67cf68a-79f4-4a66-b30a-fca0a2fc4d19
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.basic
+id: block_content.basic
+target_entity_type_id: block_content
+target_bundle: basic
+default_langcode: site_default
+language_alterable: false

--- a/config/sync/system.menu.footer---european-commision.yml
+++ b/config/sync/system.menu.footer---european-commision.yml
@@ -1,0 +1,8 @@
+uuid: 37045eea-0e0e-44f1-ac45-8279d4f7ff19
+langcode: en
+status: true
+dependencies: {  }
+id: footer---european-commision
+label: 'Footer - European Commision'
+description: ''
+locked: false

--- a/config/sync/system.menu.footer---european-union.yml
+++ b/config/sync/system.menu.footer---european-union.yml
@@ -1,0 +1,8 @@
+uuid: 04c4232d-cc36-4058-9370-50684bfd63f0
+langcode: en
+status: true
+dependencies: {  }
+id: footer---european-union
+label: 'Footer - European Union'
+description: ''
+locked: false

--- a/lib/modules/eic_default_content/content/block_content/34a810c9-d608-4979-ac40-00657bce344b.yml
+++ b/lib/modules/eic_default_content/content/block_content/34a810c9-d608-4979-ac40-00657bce344b.yml
@@ -1,0 +1,27 @@
+_meta:
+  version: '1.0'
+  entity_type: block_content
+  uuid: 34a810c9-d608-4979-ac40-00657bce344b
+  bundle: basic
+  default_langcode: en
+default:
+  status:
+    -
+      value: true
+  info:
+    -
+      value: 'Footer - Site info'
+  reusable:
+    -
+      value: true
+  revision_translation_affected:
+    -
+      value: true
+  body:
+    -
+      value: "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Est, ut dicis, inquam. Unum est sine dolore esse, alterum cum voluptate.</p>\r\n\r\n<p>Honesta oratio, Socratica, Platonis etiam. Inquit, dasne adolescenti veniam? Qui est in parvis malis. Hunc vos beatum.</p>\r\n\r\n<p>&nbsp;</p>\r\n"
+      format: basic_text
+      summary: ''
+  field_title:
+    -
+      value: 'European Innovation Council Community'

--- a/lib/modules/eic_default_content/content/menu_link_content/51a20c19-583d-4d8e-997a-bd78688ddf51.yml
+++ b/lib/modules/eic_default_content/content/menu_link_content/51a20c19-583d-4d8e-997a-bd78688ddf51.yml
@@ -1,0 +1,36 @@
+_meta:
+  version: '1.0'
+  entity_type: menu_link_content
+  uuid: 51a20c19-583d-4d8e-997a-bd78688ddf51
+  bundle: menu_link_content
+  default_langcode: en
+default:
+  enabled:
+    -
+      value: true
+  title:
+    -
+      value: 'Policies information and services'
+  menu_name:
+    -
+      value: footer---european-commision
+  link:
+    -
+      uri: 'https://ec.europa.eu/info/index_en'
+      title: ''
+      options: {  }
+  external:
+    -
+      value: false
+  rediscover:
+    -
+      value: false
+  weight:
+    -
+      value: 0
+  expanded:
+    -
+      value: false
+  revision_translation_affected:
+    -
+      value: true

--- a/lib/modules/eic_default_content/content/menu_link_content/559d2b0b-f362-41af-b233-9e81c37badd9.yml
+++ b/lib/modules/eic_default_content/content/menu_link_content/559d2b0b-f362-41af-b233-9e81c37badd9.yml
@@ -1,0 +1,36 @@
+_meta:
+  version: '1.0'
+  entity_type: menu_link_content
+  uuid: 559d2b0b-f362-41af-b233-9e81c37badd9
+  bundle: menu_link_content
+  default_langcode: en
+default:
+  enabled:
+    -
+      value: true
+  title:
+    -
+      value: 'European Union'
+  menu_name:
+    -
+      value: footer---european-union
+  link:
+    -
+      uri: 'https://europa.eu/'
+      title: ''
+      options: {  }
+  external:
+    -
+      value: false
+  rediscover:
+    -
+      value: false
+  weight:
+    -
+      value: -49
+  expanded:
+    -
+      value: false
+  revision_translation_affected:
+    -
+      value: true

--- a/lib/modules/eic_default_content/content/menu_link_content/9db0bc0c-877e-43c9-a440-707c91ee9928.yml
+++ b/lib/modules/eic_default_content/content/menu_link_content/9db0bc0c-877e-43c9-a440-707c91ee9928.yml
@@ -1,0 +1,36 @@
+_meta:
+  version: '1.0'
+  entity_type: menu_link_content
+  uuid: 9db0bc0c-877e-43c9-a440-707c91ee9928
+  bundle: menu_link_content
+  default_langcode: en
+default:
+  enabled:
+    -
+      value: true
+  title:
+    -
+      value: 'EU institutions'
+  menu_name:
+    -
+      value: footer---european-union
+  link:
+    -
+      uri: 'https://europa.eu/european-union/about-eu_en'
+      title: ''
+      options: {  }
+  external:
+    -
+      value: false
+  rediscover:
+    -
+      value: false
+  weight:
+    -
+      value: -50
+  expanded:
+    -
+      value: false
+  revision_translation_affected:
+    -
+      value: true

--- a/lib/modules/eic_default_content/content/menu_link_content/f9f63eb3-d39d-46b1-90a8-f7511068d971.yml
+++ b/lib/modules/eic_default_content/content/menu_link_content/f9f63eb3-d39d-46b1-90a8-f7511068d971.yml
@@ -1,0 +1,36 @@
+_meta:
+  version: '1.0'
+  entity_type: menu_link_content
+  uuid: f9f63eb3-d39d-46b1-90a8-f7511068d971
+  bundle: menu_link_content
+  default_langcode: en
+default:
+  enabled:
+    -
+      value: true
+  title:
+    -
+      value: 'Commission and its priorities'
+  menu_name:
+    -
+      value: footer---european-commision
+  link:
+    -
+      uri: 'https://ec.europa.eu/commission/index_en'
+      title: ''
+      options: {  }
+  external:
+    -
+      value: false
+  rediscover:
+    -
+      value: false
+  weight:
+    -
+      value: 0
+  expanded:
+    -
+      value: false
+  revision_translation_affected:
+    -
+      value: true


### PR DESCRIPTION
- Created a "Basic" block type
- Created 2 menus with default menu links
- Created one block of Basic type
- Updated the context to show those blocks in the footer region

NB: the footer region is not displayed for now, but you can add this to page.html.twig to test:
```twig
{% block footer %}
  {{ page.footer }}
{% endblock %}
```