### PR TITLE
EICNET-942: As a GO I can delete my group when it's in pending state

### DIFF
--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -204,3 +204,11 @@ function eic_groups_entity_field_access($operation, FieldDefinitionInterface $fi
 
   return $access;
 }
+
+/**
+ * Implements hook_ENTITY_TYPE_insert().
+ */
+function eic_groups_group_permission_insert(EntityInterface $entity) {
+  \Drupal::classResolver(EntityOperations::class)
+    ->groupPermissionInsert($entity);
+}

--- a/lib/modules/eic_groups/eic_groups.services.yml
+++ b/lib/modules/eic_groups/eic_groups.services.yml
@@ -6,7 +6,7 @@ services:
       - { name: event_subscriber }
   eic_groups.helper:
     class: Drupal\eic_groups\EICGroupsHelper
-    arguments: ['@database', '@current_route_match', '@module_handler']
+    arguments: ['@database', '@current_route_match', '@module_handler', '@current_user', '@datetime.time']
   eic_groups.book_page_redirect_subscriber:
     class: Drupal\eic_groups\EventSubscriber\BookPageRedirectSubscriber
     arguments: ['@book.manager', '@entity_type.manager']

--- a/lib/modules/eic_groups/src/EICGroupsHelperInterface.php
+++ b/lib/modules/eic_groups/src/EICGroupsHelperInterface.php
@@ -5,6 +5,7 @@ namespace Drupal\eic_groups;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\group\Entity\GroupInterface;
+use Drupal\group_permissions\Entity\GroupPermissionInterface;
 
 /**
  * Interface EICGroupsHelperInterface to implement in EICGroupHeader.
@@ -48,5 +49,43 @@ interface EICGroupsHelperInterface {
    *   - weight: The weight of the operation.
    */
   public function getGroupOperationLinks(GroupInterface $group, array $limit_entities = [], CacheableMetadata $cacheable_metadata = NULL);
+
+  /**
+   * Add role permissions to a groupPermission object without saving.
+   *
+   * @param \Drupal\group_permissions\Entity\GroupPermissionInterface $group_permissions
+   *   The group permission object.
+   * @param string $role
+   *   The user role ID.
+   * @param array $role_permissions
+   *   Associative array of permissions.
+   *
+   * @return \Drupal\group_permissions\Entity\GroupPermissionInterface
+   *   The updated group permissions.
+   */
+  public function addRolePermissionsToGroup(GroupPermissionInterface $group_permissions, string $role, array $role_permissions);
+
+  /**
+   * Remove role permissions from a certain group without saving.
+   *
+   * @param \Drupal\group_permissions\Entity\GroupPermissionInterface $group_permissions
+   *   The group permission object.
+   * @param string $role
+   *   The user role ID.
+   * @param array $role_permissions
+   *   Associative array of permissions.
+   *
+   * @return \Drupal\group_permissions\Entity\GroupPermissionInterface
+   *   The updated group permissions.
+   */
+  public function removeRolePermissionsFromGroup(GroupPermissionInterface $group_permissions, string $role, array $role_permissions);
+
+  /**
+   * Saves a GroupPermission object.
+   *
+   * @param \Drupal\group_permissions\Entity\GroupPermissionInterface $group_permissions
+   *   The GroupPermission object to be saved.
+   */
+  public function saveGroupPermissions(GroupPermissionInterface $group_permissions);
 
 }

--- a/lib/modules/eic_groups/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_groups/src/Hooks/EntityOperations.php
@@ -13,6 +13,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Url;
 use Drupal\eic_groups\EICGroupsHelper;
 use Drupal\eic_groups\EICGroupsHelperInterface;
+use Drupal\eic_groups\GroupsModerationHelper;
 use Drupal\eic_user\UserHelper;
 use Drupal\group\Entity\GroupContent;
 use Drupal\group\Entity\GroupInterface;
@@ -161,7 +162,7 @@ class EntityOperations implements ContainerInjectionInterface {
     $group = $group_permissions->getGroup();
     // Adds or removes "delete group" permission from group owner based on the
     // group moderation state.
-    if ($group->get('moderation_state')->value === 'pending') {
+    if ($group->get('moderation_state')->value === GroupsModerationHelper::GROUP_PENDING_STATE) {
       $this->eicGroupsHelper->addRolePermissionsToGroup($group_permissions, EICGroupsHelper::GROUP_OWNER_ROLE, ['delete group']);
     }
     else {
@@ -388,7 +389,7 @@ class EntityOperations implements ContainerInjectionInterface {
 
     // We add or remove "delete group" permission from the group owner based on
     // the new group moderation state.
-    if ($new_moderation_state === 'pending') {
+    if ($new_moderation_state === GroupsModerationHelper::GROUP_PENDING_STATE) {
       $this->eicGroupsHelper->addRolePermissionsToGroup($group_permissions, EICGroupsHelper::GROUP_OWNER_ROLE, ['delete group']);
     }
     else {


### PR DESCRIPTION
### Changes

- New group permission helper methods added to eic_groups.helper service;
- Add/remove **group delete** permission from group owner when moderation state is **pending**.

### Tests

- [ ] As a trusted user, create a new group;
- [ ] Go to the group edit page and check if the delete link is available; Also, validate if the user has access to -> `groups/<group-title>/delete`
- [ ] As a SA/SCM update the group status to "Draft";
- [ ] As a trusted user, go to the group edit page and check if the delete link is not visible; Also, validate if the access is denied in -> `groups/<group-title>/delete`.

### Todo

- [ ] The delete button in the group header block is not yet available and needs to be added after we merge #336 