### PR TITLE
EICNET-942: Add group "delete" operation to the group header block.

### DIFF
--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
@@ -200,9 +200,14 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
       ];
     }
 
+    // We extract only the group edit/delete operation links into a new array.
     $visible_group_operation_links = array_filter($group_operation_links, function ($key) {
-      return $key === 'edit';
+      return in_array($key, ['edit', 'delete']);
     }, ARRAY_FILTER_USE_KEY);
+
+    // Sorts group operation links by key. "Delete" operation needs to show
+    // first.
+    ksort($visible_group_operation_links);
 
     $membership_links = [];
 


### PR DESCRIPTION
### Changes

- Add group "delete" operation to the group header block.

### Tests

- [ ] Create a group
- [ ] Go to the group overview page and check if there is a button to delete the group in the group header block.