### PR TITLE
EICNET-954: User profile - add validation to social channel links (Part 2)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5266,6 +5266,9 @@
                         "status": "not-covered",
                         "message": "Alpha releases are not covered by Drupal security advisories."
                     }
+                },
+                "patches_applied": {
+                    "#3155628 - Limited values are randomised": "https://www.drupal.org/files/issues/2020-09-02/3155628-10.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -31,6 +31,9 @@
     "drupal/realname": {
       "#3059311 - Autocomplete suggestions should respect the entity reference View": "patches/realname/autocomplete-condition-fix-3059311-5.patch"
     },
+    "drupal/social_link_field": {
+      "#3155628 - Limited values are randomised": "https://www.drupal.org/files/issues/2020-09-02/3155628-10.patch"
+    },
     "drupal/subpathauto": {
       "3130139 - Group Content Add/Create Paths do not work": "https://www.drupal.org/files/issues/2020-04-23/subpathauto-group-content-create-urls-3130139-2.patch",
       "3188768 - Install from configuration fails due to missing dependencies": "./patches/subpathauto/3188768-subpathauto-add-dependencies.patch"

--- a/config/sync/field.field.profile.member.field_social_links.yml
+++ b/config/sync/field.field.profile.member.field_social_links.yml
@@ -15,7 +15,19 @@ label: 'Social links'
 description: ''
 required: false
 translatable: false
-default_value: {  }
+default_value:
+  -
+    actions: {  }
+    link: ''
+    social: linkedin
+  -
+    actions: {  }
+    link: ''
+    social: twitter
+  -
+    actions: {  }
+    link: ''
+    social: facebook
 default_value_callback: ''
 settings: {  }
 field_type: social_links

--- a/config/sync/field.storage.profile.field_social_links.yml
+++ b/config/sync/field.storage.profile.field_social_links.yml
@@ -12,7 +12,7 @@ type: social_links
 settings: {  }
 module: social_link_field
 locked: false
-cardinality: -1
+cardinality: 3
 translatable: true
 indexes: {  }
 persist_with_no_fields: false


### PR DESCRIPTION
### Changes

- Apply patch to fix with limited values being randomised (see https://www.drupal.org/project/social_link_field/issues/3155628).
- Limit field to only 3 social network links (LinkedIn, Twitter and Facebook).

### Tests

- [ ] Try to edit the admin profile -> /profile/1/edit
- [ ] Check if linkedin, twitter and facebook are already set as default networks. Also it shouldn't be allowed to add more than 3 or change the the network types.