### PR TITLE
EICNET-1062: As a TU I can reply to a comment on discussion in a public group without being a GM

### DIFF
--- a/lib/modules/oec_group_comments/oec_group_comments.services.yml
+++ b/lib/modules/oec_group_comments/oec_group_comments.services.yml
@@ -2,3 +2,7 @@ services:
   oec_group_comments.group_permission_checker:
     class: Drupal\oec_group_comments\GroupPermissionChecker
     arguments: ['@renderer']
+  oec_group_comments.route_subscriber:
+    class: Drupal\oec_group_comments\EventSubscriber\GroupCommentsRouteSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/lib/modules/oec_group_comments/src/Controller/GroupCommentController.php
+++ b/lib/modules/oec_group_comments/src/Controller/GroupCommentController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Drupal\oec_group_comments\Controller;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\comment\Controller\CommentController;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\group\Entity\GroupContent;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Extends base controller for the comment entity.
+ */
+class GroupCommentController extends CommentController {
+
+  /**
+   * The group permission checker.
+   *
+   * @var \Drupal\oec_group_comments\GroupPermissionChecker
+   */
+  protected $groupPermissionChecker;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    $controller = parent::create($container);
+    $controller->groupPermissionChecker = $container->get('oec_group_comments.group_permission_checker');
+    return $controller;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function replyFormAccess(EntityInterface $entity, $field_name, $pid = NULL) {
+    $access = parent::replyFormAccess($entity, $field_name, $pid);
+
+    if (!($entity instanceof ContentEntityInterface)) {
+      return $access;
+    }
+
+    $group_contents = GroupContent::loadByEntity($entity);
+
+    // If entity is not a group content, we don't need extra logic.
+    if (empty($group_contents)) {
+      return $access;
+    }
+
+    $account = $this->currentUser();
+
+    // If user doesn't have permissions to post comments in a group we deny
+    // access to the reply form.
+    if ($this->groupPermissionChecker->getPermissionInGroups('post comments', $account, $group_contents)->isForbidden()) {
+      $group_content = reset($group_contents);
+      $access = AccessResult::forbidden()
+        ->cachePerPermissions()
+        ->addCacheableDependency($entity)
+        ->addCacheableDependency($group_content->getGroup());
+    }
+
+    return $access;
+  }
+
+}

--- a/lib/modules/oec_group_comments/src/EventSubscriber/GroupCommentsRouteSubscriber.php
+++ b/lib/modules/oec_group_comments/src/EventSubscriber/GroupCommentsRouteSubscriber.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Drupal\oec_group_comments\EventSubscriber;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Group Comments route subscriber.
+ */
+class GroupCommentsRouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+    if ($route = $collection->get('comment.reply')) {
+      $route->setRequirement('_custom_access', '\Drupal\oec_group_comments\Controller\GroupCommentController::replyFormAccess');
+    }
+  }
+
+}

--- a/lib/themes/eic_community/includes/preprocess/comments/comment.inc
+++ b/lib/themes/eic_community/includes/preprocess/comments/comment.inc
@@ -53,11 +53,16 @@ function eic_community_preprocess_comment(&$variables) {
     'comment_id' => $comment->cid->value,
     'comment_origin' => $comment_origin,
     'is_owner' => $current_user->id() == $comment->getOwnerId(),
-    'reply_path' => $comment_reply->toString(),
     'timestamp' => $created_at,
     'user' => $current_user,
     'icon_file_path' => $variables['eic_icon_path'],
   ];
+
+  // If user can reply to comments we add the comment reply path to the theme
+  // variables.
+  if ($comment_reply->access($current_user)) {
+    $variables['comment']['reply_path'] = $comment_reply->toString();
+  }
 
   $operations = \Drupal::entityTypeManager()->getListBuilder('comment')->getOperations($comment);
 


### PR DESCRIPTION
### Changes

- Improve code to update group permissions in` \Drupal\eic_groups\Hook\EntityOperations` class.
- Deny access to reply to comments when user does not have permission to post comments in groups.

### Tests

- [ ] Create a public group and publish it
- [ ] Create a new group discussion
- [ ] Add a comment
- [ ] Log in as a Trusted user, and navigate to the discussion page of the group
- [ ] Try to reply to the comment added previously. You should get an access denied.

### Todo

Hide Reply button when the user doesn't have access to reply. @xwero we need to add a condition in pattern `comment-base.html.twig` to check if the reply_path exists (**line 177**):
```twig
{% if reply_path %}
  <div class="ecl-comment__action">
    {% include "@ecl-twig/ec-component-link/ecl-link.html.twig" with {
      link: {
        label: reply_label|default('Reply'),
        path: reply_path,
      },
      extra_classes: 'ecl-comment__reply ecl-link--button ecl-link--button-ghost',
      extra_attributes: action_attributes,
    } %}
  </div>
{% endif %}
```