### PR TITLE
Remove book.manager service from Drupal\eic_groups\Hooks\FormOperations::create() method.

### DIFF
--- a/lib/modules/eic_groups/src/Hooks/FormOperations.php
+++ b/lib/modules/eic_groups/src/Hooks/FormOperations.php
@@ -95,7 +95,6 @@ class FormOperations implements ContainerInjectionInterface {
       $container->get('config.factory'),
       $container->get('plugin.manager.group_feature'),
       $container->get('eic_groups.helper'),
-      $container->get('book.manager'),
       $container->get('current_route_match'),
       $container->get('request_stack')
     );


### PR DESCRIPTION
### Tests

- Try to access group creation form and check if there is not PHP error.