### PR TITLE
[EICNET-831] feat: Introduce drush.yml and load drush.local.yml with it

### DIFF
--- a/drush/drush.yml
+++ b/drush/drush.yml
@@ -1,0 +1,7 @@
+drush:
+  paths:
+    config:
+      # Load any local config files. Is silently skipped if not found.
+      # Include drush.yml inside default (the only one not being auto-discovered)
+      # See: https://github.com/drush-ops/drush/pull/4345
+      - web/sites/default/drush.local.yml


### PR DESCRIPTION
Will allow anyone to create a drush.local.yml to set the base uri for drush and any other needed configuration

Example:
```
options:
  # Specify the base_url that should be used when generating links.
  uri: 'http://localhost:8080'
```
