### PR TITLE
EICNET-1070: Improve - validation of URLs of social channels on the user profile

### DIFF
--- a/lib/modules/eic_user/eic_user.module
+++ b/lib/modules/eic_user/eic_user.module
@@ -6,24 +6,12 @@
  */
 
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\eic_user\ProfileConst;
+use Drupal\eic_user\Hooks\FieldWidgetOperations;
 
 /**
  * Implements hook_field_widget_WIDGET_TYPE_form_alter().
  */
-function eic_groups_field_widget_social_links_form_alter(&$element, FormStateInterface $form_state, $context) {
-  $form_build_info = $form_state->getBuildInfo();
-
-  // Removes some unused social networks from the widget options.
-  if ($form_build_info['base_form_id'] === 'profile_form') {
-    $allowed_social_networks = ProfileConst::ALLOWED_SOCIAL_NETWORKS;
-
-    // Filter out the allowed social networks.
-    $options = array_filter($element['social']['#options'], function ($item) use ($allowed_social_networks) {
-      return in_array($item, $allowed_social_networks);
-    }, ARRAY_FILTER_USE_KEY);
-
-    // Keep only the allowed social networks in the widget options.
-    $element['social']['#options'] = $options;
-  }
+function eic_user_field_widget_social_links_form_alter(&$element, FormStateInterface $form_state, $context) {
+  \Drupal::classResolver(FieldWidgetOperations::class)
+    ->fieldWidgetSocialLinksFormAlter($element, $form_state, $context);
 }

--- a/lib/modules/eic_user/src/Hooks/FieldWidgetOperations.php
+++ b/lib/modules/eic_user/src/Hooks/FieldWidgetOperations.php
@@ -8,7 +8,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 /**
  * Class FieldWidgetOperations.
  *
- * Implementations for entity hooks.
+ * Implementations for field widget hooks.
  */
 class FieldWidgetOperations {
 

--- a/lib/modules/eic_user/src/Hooks/FieldWidgetOperations.php
+++ b/lib/modules/eic_user/src/Hooks/FieldWidgetOperations.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Drupal\eic_user\Hooks;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
+/**
+ * Class FieldWidgetOperations.
+ *
+ * Implementations for entity hooks.
+ */
+class FieldWidgetOperations {
+
+  use StringTranslationTrait;
+
+  /**
+   * Implements hook_field_widget_social_links_form_alter().
+   */
+  public function fieldWidgetSocialLinksFormAlter(&$element, FormStateInterface $form_state, $context) {
+    $form_build_info = $form_state->getBuildInfo();
+
+    if ($form_build_info['base_form_id'] === 'profile_form') {
+      $selected_network = $element['social']['#default_value'];
+
+      // Adds custom helper texts needed to describe how to fill in certain
+      // social networks.
+      if (isset($this->getSocialLinksFieldDescriptions()[$selected_network])) {
+        $element['link']['#description'] = $this->getSocialLinksFieldDescriptions()[$selected_network];
+      }
+
+      // Adds custom element validation to fix the social network links when
+      // the user inserts the full url from the social network platform.
+      $element['#element_validate'] = [
+        [$this, 'socialLinksFieldValidate'],
+      ];
+    }
+  }
+
+  /**
+   * Custom element validation for social link fields.
+   */
+  public function socialLinksFieldValidate($element, FormStateInterface $form_state, $form) {
+    $social_network_name = $element['social']['#default_value'];
+    $social_network_base_url = $element['link']['#field_prefix'];
+    $field_name = reset($element['#parents']);
+
+    // Get form state values for the field.
+    $form_state_values = $form_state->getValue($field_name);
+
+    // Users will tend to add the full url from the social network platform
+    // instead of just the username. Because of this issue, we remove the
+    // social network base url from the values in order to pass in the
+    // validation so that users don't need to figure out how to properly insert
+    // their usernames.
+    foreach ($form_state_values as $key => $value) {
+      if ($value['social'] === $social_network_name) {
+        $form_state_values[$key]['link'] = str_replace($social_network_base_url, '', $value['link']);
+        break;
+      }
+    }
+
+    $form_state->setValue($field_name, $form_state_values);
+  }
+
+  /**
+   * Gets array of helper texts to help users fill in the social links field.
+   *
+   * @return array
+   *   Array of helper texts keyed by social network type.
+   */
+  public function getSocialLinksFieldDescriptions() {
+    return [
+      'linkedin' => $this->t('Insert your LinkedIn username in the following format: in/example-user-name.'),
+    ];
+  }
+
+}


### PR DESCRIPTION
### Improvements

- Add custom validation on social links from user profile in order to remove the social network base url when users fill in the social links field.

### Tests

- [ ] As a trusted user, edit your profile -> `/user/<user-id>/member`
- [ ] Try to add your social links LinkedIn, Facebook or twitter by copy pasting the full url of your profile
- [ ] Try to save your profile changes and check if there are no errors
- [ ] Try to edit your profile again and make sure the values in the social links field only contains your username in the correct form and not the full url

### Known issues

- Currently it fixes the usernames when the user inserts the full url (including https://). If the full url is not presented a form error will be thrown.