### PR TITLE
[EICNET-927] feat: Display a message for pending groups

### DIFF
--- a/config/sync/context.context.group_group_homepage.yml
+++ b/config/sync/context.context.group_group_homepage.yml
@@ -84,7 +84,7 @@ reactions:
         provider: system
         label_display: '0'
         region: breadcrumbs
-        weight: '0'
+        weight: '-10'
         context_mapping: {  }
         custom_id: system_breadcrumb_block
         theme: eic_community
@@ -124,6 +124,21 @@ reactions:
         unique: 0
         context_id: group_group_homepage
         uuid: f981ffbe-9d2f-455d-af1e-0dde97e7d74d
+      281d84b0-070f-4a70-a76e-00e811da6ce9:
+        id: eic_overview_message
+        label: 'EIC Overview Messages'
+        provider: eic_groups
+        label_display: '0'
+        region: content
+        weight: '0'
+        context_mapping:
+          group: '@group.group_route_context:group'
+        custom_id: eic_overview_message
+        theme: eic_community
+        css_class: ''
+        unique: 0
+        context_id: group_group_homepage
+        uuid: 281d84b0-070f-4a70-a76e-00e811da6ce9
     id: blocks
     saved: false
     uuid: db598f5e-00b5-4ba6-b443-bbe6d3ca2c59

--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -32,6 +32,13 @@ function eic_groups_theme($existing, $type, $theme, $path) {
         'group_values' => NULL,
       ],
     ],
+    'eic_group_moderated_message_box' => [
+      'variables' => [
+        'group' => NULL,
+        'edit_link' => NULL,
+        'delete_link' => NULL,
+      ],
+    ]
   ];
 }
 

--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupOverviewMessageBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupOverviewMessageBlock.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Drupal\eic_groups\Plugin\Block;
+
+use Drupal\content_moderation\ModerationInformationInterface;
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\eic_groups\EICGroupsHelper;
+use Drupal\eic_groups\GroupsModerationHelper;
+use Drupal\group\GroupMembership;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides an EICGroupOverviewMessageBlock block.
+ *
+ * @Block(
+ *   id = "eic_overview_message",
+ *   admin_label = @Translation("EIC Overview Messages"),
+ *   category = @Translation("European Innovation Council"),
+ *   context_definitions = {
+ *     "group" = @ContextDefinition("entity:group")
+ *   }
+ * )
+ */
+class EICGroupOverviewMessageBlock extends BlockBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * @var \Drupal\Core\Session\AccountProxyInterface
+   */
+  private $account;
+
+  /**
+   * @var \Drupal\content_moderation\ModerationInformationInterface
+   */
+  private $moderationInformation;
+
+  /**
+   * EICGroupOverviewMessageBlock constructor.
+   *
+   * @param array $configuration
+   * @param $plugin_id
+   * @param $plugin_definition
+   * @param \Drupal\content_moderation\ModerationInformationInterface $moderation_information
+   * @param \Drupal\Core\Session\AccountProxyInterface $account
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    ModerationInformationInterface $moderation_information,
+    AccountProxyInterface $account
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+
+    $this->moderationInformation = $moderation_information;
+    $this->account = $account;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(
+    ContainerInterface $container,
+    array $configuration,
+    $plugin_id,
+    $plugin_definition
+  ) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('content_moderation.moderation_information'),
+      $container->get('current_user')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $build = [];
+    /** @var \Drupal\group\Entity\GroupInterface $group */
+    if ((!$group = $this->getContextValue('group')) || !$this->account->isAuthenticated()) {
+      return $build;
+    }
+
+    $cacheable_metadata = new CacheableMetadata();
+    $cacheable_metadata->setCacheContexts([
+      'user.group_permissions',
+    ]);
+
+    $required_roles = [EICGroupsHelper::GROUP_OWNER_ROLE];
+    $group_membership = $group->getMember($this->account);
+    $user_group_roles = $group_membership instanceof GroupMembership
+      ? array_keys($group_membership->getRoles())
+      : [];
+
+    // This block is only shown to group admins.
+    if (empty(array_intersect($user_group_roles, $required_roles))) {
+      return $build;
+    }
+
+    $has_group_content = FALSE;
+    if (!$has_group_content && $group->isPublished()) {
+      //TODO return the published without content box
+      return $build;
+    }
+
+    if ($this->moderationInformation->isModeratedEntity($group) && !$group->isPublished()) {
+      $moderation_state = $group->get('moderation_state')->value;
+      if ($moderation_state === GroupsModerationHelper::GROUP_PENDING_STATE
+        || $moderation_state === GroupsModerationHelper::GROUP_DRAFT_STATE
+      ) {
+        $build = [
+          '#theme' => 'eic_group_moderated_message_box',
+          '#group' => $group,
+          '#edit_link' => $group->toUrl('edit-form'),
+          '#delete_link' => $group->toUrl('delete-form'),
+        ];
+      }
+    }
+
+    $cacheable_metadata->applyTo($build);
+
+    return $build;
+  }
+
+}

--- a/lib/modules/eic_groups/templates/eic-group-moderated-message-box.html.twig
+++ b/lib/modules/eic_groups/templates/eic-group-moderated-message-box.html.twig
@@ -1,0 +1,14 @@
+{#
+/**
+ * @file
+ * Default template for a pending/draft group's message box.
+ *
+ * Available variables:
+ * - group: The group being displayed
+ *
+ * @ingroup themeable
+ */
+#}
+
+<p>Edit: {{ edit_link }}</p>
+<p>Delete: {{ delete_link }}</p>

--- a/lib/themes/eic_community/templates/blocks/eic-group-moderated-message-box.html.twig
+++ b/lib/themes/eic_community/templates/blocks/eic-group-moderated-message-box.html.twig
@@ -1,0 +1,14 @@
+{#
+/**
+ * @file
+ * Default template for a pending/draft group's message box.
+ *
+ * Available variables:
+ * - group: The group being displayed
+ *
+ * @ingroup themeable
+ */
+#}
+
+<p>This group is pending approval from our community team. We will endeavour to approve the group within 3 days.</p>
+<p>You can still <a href="{{ edit_link }}">manage</a> or <a href="{{ delete_link }}">delete</a> your group</p>


### PR DESCRIPTION
Add a message box on the group homepage for GO only
This PR introduces the text informing that the group is in pending state only.

### To Test

- [ ] Create a group with the pending state (default)
- [ ] The text with the edit and delete links should appear on the group homepage