### PR TITLE
Feature/EICNET-926: Display a message + actions for pending & draft groups

### DIFF
--- a/config/sync/context.context.group_group_homepage.yml
+++ b/config/sync/context.context.group_group_homepage.yml
@@ -124,21 +124,21 @@ reactions:
         unique: 0
         context_id: group_group_homepage
         uuid: f981ffbe-9d2f-455d-af1e-0dde97e7d74d
-      281d84b0-070f-4a70-a76e-00e811da6ce9:
-        id: eic_overview_message
-        label: 'EIC Overview Messages'
+      133eb116-55d1-44d7-a7c0-a9ddcdd1b9f9:
+        id: eic_group_overview_message
+        label: 'EIC Group Overview Messages'
         provider: eic_groups
         label_display: '0'
         region: content
-        weight: '0'
+        weight: '-3'
         context_mapping:
           group: '@group.group_route_context:group'
-        custom_id: eic_overview_message
+        custom_id: eic_group_overview_message
         theme: eic_community
         css_class: ''
         unique: 0
         context_id: group_group_homepage
-        uuid: 281d84b0-070f-4a70-a76e-00e811da6ce9
+        uuid: 133eb116-55d1-44d7-a7c0-a9ddcdd1b9f9
     id: blocks
     saved: false
     uuid: db598f5e-00b5-4ba6-b443-bbe6d3ca2c59

--- a/config/sync/context.context.group_group_homepage.yml
+++ b/config/sync/context.context.group_group_homepage.yml
@@ -84,7 +84,7 @@ reactions:
         provider: system
         label_display: '0'
         region: breadcrumbs
-        weight: '0'
+        weight: '-10'
         context_mapping: {  }
         custom_id: system_breadcrumb_block
         theme: eic_community
@@ -124,6 +124,21 @@ reactions:
         unique: 0
         context_id: group_group_homepage
         uuid: f981ffbe-9d2f-455d-af1e-0dde97e7d74d
+      281d84b0-070f-4a70-a76e-00e811da6ce9:
+        id: eic_overview_message
+        label: 'EIC Overview Messages'
+        provider: eic_groups
+        label_display: '0'
+        region: content
+        weight: '0'
+        context_mapping:
+          group: '@group.group_route_context:group'
+        custom_id: eic_overview_message
+        theme: eic_community
+        css_class: ''
+        unique: 0
+        context_id: group_group_homepage
+        uuid: 281d84b0-070f-4a70-a76e-00e811da6ce9
     id: blocks
     saved: false
     uuid: db598f5e-00b5-4ba6-b443-bbe6d3ca2c59

--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -32,6 +32,13 @@ function eic_groups_theme($existing, $type, $theme, $path) {
         'group_values' => NULL,
       ],
     ],
+    'eic_group_moderated_message_box' => [
+      'variables' => [
+        'group' => NULL,
+        'edit_link' => NULL,
+        'delete_link' => NULL,
+      ],
+    ]
   ];
 }
 

--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -38,6 +38,7 @@ function eic_groups_theme($existing, $type, $theme, $path) {
         'edit_link' => NULL,
         'delete_link' => NULL,
         'actions' => NULL,
+        'has_content' => NULl,
       ],
     ]
   ];

--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -37,6 +37,7 @@ function eic_groups_theme($existing, $type, $theme, $path) {
         'group' => NULL,
         'edit_link' => NULL,
         'delete_link' => NULL,
+        'actions' => NULL,
       ],
     ]
   ];

--- a/lib/modules/eic_groups/src/EICGroupsHelper.php
+++ b/lib/modules/eic_groups/src/EICGroupsHelper.php
@@ -252,7 +252,8 @@ class EICGroupsHelper implements EICGroupsHelperInterface {
   ) {
     $permissions = $group_permissions->getPermissions();
     foreach ($role_permissions as $permission) {
-      if (!array_key_exists($role, $permissions) || !in_array($permission, $permissions[$role], TRUE)) {
+      if (!array_key_exists($role, $permissions) || !in_array($permission, $permissions[$role],
+          TRUE)) {
         $permissions[$role][] = $permission;
       }
     }
@@ -270,7 +271,8 @@ class EICGroupsHelper implements EICGroupsHelperInterface {
   ) {
     $permissions = $group_permissions->getPermissions();
     foreach ($role_permissions as $permission) {
-      if (array_key_exists($role, $permissions) || in_array($permission, $permissions[$role], TRUE)) {
+      if (array_key_exists($role, $permissions) || in_array($permission, $permissions[$role],
+          TRUE)) {
         $permissions[$role] = array_diff($permissions[$role], [$permission]);
       }
     }
@@ -298,6 +300,28 @@ class EICGroupsHelper implements EICGroupsHelperInterface {
     $group_permissions->setRevisionCreationTime($this->time->getRequestTime());
     $group_permissions->setRevisionLogMessage('Group permissions updated successfully.');
     $group_permissions->save();
+  }
+
+  /**
+   * Determines if a group has any content.
+   * Considered as content:
+   *  - Every GroupContent entity other than memberships and menus
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *    The group for which the check is.
+   */
+  public function hasContent(GroupInterface $group) {
+    $query = $this->database->select('group_content_field_data', 'gp');
+    $query->condition('gp.type', [
+      'group-group_node-book',
+      'group-group_node-discussion',
+      'group-group_node-document',
+      'group-group_node-wiki_page',
+    ], 'IN');
+    $query->condition('gp.gid', $group->id());
+    $query->fields('gp', ['id']);
+
+    return !empty($query->execute()->fetchAll(\PDO::FETCH_OBJ));
   }
 
 }

--- a/lib/modules/eic_groups/src/EICGroupsHelper.php
+++ b/lib/modules/eic_groups/src/EICGroupsHelper.php
@@ -303,9 +303,11 @@ class EICGroupsHelper implements EICGroupsHelperInterface {
   }
 
   /**
-   * Determines if a group has any content.
+   * Determines if a group has content.
    * Considered as content:
-   *  - Every GroupContent entity other than memberships and menus
+   *  - Discussions
+   *  - Documents
+   *  - Wiki pages
    *
    * @param \Drupal\group\Entity\GroupInterface $group
    *    The group for which the check is.
@@ -313,7 +315,6 @@ class EICGroupsHelper implements EICGroupsHelperInterface {
   public function hasContent(GroupInterface $group) {
     $query = $this->database->select('group_content_field_data', 'gp');
     $query->condition('gp.type', [
-      'group-group_node-book',
       'group-group_node-discussion',
       'group-group_node-document',
       'group-group_node-wiki_page',

--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupOverviewMessageBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupOverviewMessageBlock.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Drupal\eic_groups\Plugin\Block;
+
+use Drupal\content_moderation\ModerationInformationInterface;
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\eic_groups\EICGroupsHelper;
+use Drupal\eic_groups\GroupsModerationHelper;
+use Drupal\group\GroupMembership;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides an EICGroupOverviewMessageBlock block.
+ *
+ * @Block(
+ *   id = "eic_overview_message",
+ *   admin_label = @Translation("EIC Overview Messages"),
+ *   category = @Translation("European Innovation Council"),
+ *   context_definitions = {
+ *     "group" = @ContextDefinition("entity:group")
+ *   }
+ * )
+ */
+class EICGroupOverviewMessageBlock extends BlockBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * @var \Drupal\Core\Session\AccountProxyInterface
+   */
+  private $account;
+
+  /**
+   * @var \Drupal\content_moderation\ModerationInformationInterface
+   */
+  private $moderationInformation;
+
+  /**
+   * EICGroupOverviewMessageBlock constructor.
+   *
+   * @param array $configuration
+   * @param $plugin_id
+   * @param $plugin_definition
+   * @param \Drupal\content_moderation\ModerationInformationInterface $moderation_information
+   * @param \Drupal\Core\Session\AccountProxyInterface $account
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    ModerationInformationInterface $moderation_information,
+    AccountProxyInterface $account
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+
+    $this->moderationInformation = $moderation_information;
+    $this->account = $account;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(
+    ContainerInterface $container,
+    array $configuration,
+    $plugin_id,
+    $plugin_definition
+  ) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('content_moderation.moderation_information'),
+      $container->get('current_user')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $build = [];
+    /** @var \Drupal\group\Entity\GroupInterface $group */
+    if ((!$group = $this->getContextValue('group')) || !$this->account->isAuthenticated()) {
+      return $build;
+    }
+
+    $cacheable_metadata = new CacheableMetadata();
+    $cacheable_metadata->setCacheContexts([
+      'user.group_permissions',
+    ]);
+
+    $required_roles = [EICGroupsHelper::GROUP_OWNER_ROLE];
+    $group_membership = $group->getMember($this->account);
+    $user_group_roles = $group_membership instanceof GroupMembership
+      ? array_keys($group_membership->getRoles())
+      : [];
+
+    // This block is only shown to group admins.
+    if (empty(array_intersect($user_group_roles, $required_roles))) {
+      return $build;
+    }
+
+    $has_group_content = FALSE;
+    if (!$has_group_content && $group->isPublished()) {
+      //TODO return the published without content box
+      return $build;
+    }
+
+    if ($this->moderationInformation->isModeratedEntity($group) && !$group->isPublished()) {
+      $moderation_state = $group->get('moderation_state')->value;
+      if ($moderation_state === GroupsModerationHelper::GROUP_PENDING_STATE
+        || $moderation_state === GroupsModerationHelper::GROUP_DRAFT_STATE
+      ) {
+        $build = [
+          '#theme' => 'eic_group_moderated_message_box',
+          '#group' => $group,
+          '#edit_link' => $group->toUrl('edit-form'),
+          '#delete_link' => $group->toUrl('delete-form'),
+        ];
+      }
+    }
+
+    $cacheable_metadata->applyTo($build);
+
+    return $build;
+  }
+
+}

--- a/lib/modules/eic_groups/templates/eic-group-moderated-message-box.html.twig
+++ b/lib/modules/eic_groups/templates/eic-group-moderated-message-box.html.twig
@@ -1,0 +1,14 @@
+{#
+/**
+ * @file
+ * Default template for a pending/draft group's message box.
+ *
+ * Available variables:
+ * - group: The group being displayed
+ *
+ * @ingroup themeable
+ */
+#}
+
+<p>Edit: {{ edit_link }}</p>
+<p>Delete: {{ delete_link }}</p>

--- a/lib/themes/eic_community/includes/preprocess/blocks/block--eic-group-moderated-message-box.inc
+++ b/lib/themes/eic_community/includes/preprocess/blocks/block--eic-group-moderated-message-box.inc
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Implements hook_preprocess_eic_group_overview_message_block() for eic_group_overview_message
+ * block.
+ */
+function eic_community_preprocess_eic_group_moderated_message_box(array &$variables) {
+  $actions = [];
+  foreach ($variables['actions'] as $link) {
+    if (isset($link['links'])) {
+      $items = [];
+
+      foreach ($link['links'] as $item) {
+        $tmp = [
+          'link' => [
+            'label' => $item['title'],
+            'path' => $item['url'],
+          ],
+        ];
+
+        if (isset($item['action'])) {
+          $tmp = array_merge($tmp, $item['action']);
+        }
+
+        $items[] = $tmp;
+      }
+
+      $actions[] = [
+        'label' => $link['label'],
+        'items' => $items,
+      ];
+    }
+    else {
+      $tmp = [
+        'link' => [
+          'label' => $link['title'],
+          'path' => $link['url'],
+        ],
+      ];
+
+      if (isset($link['action'])) {
+        $tmp = array_merge($tmp, $link['action']);
+      }
+
+      $actions[] = $tmp;
+    }
+  }
+
+  $variables['actions'] = $actions;
+}

--- a/lib/themes/eic_community/templates/blocks/eic-group-moderated-message-box.html.twig
+++ b/lib/themes/eic_community/templates/blocks/eic-group-moderated-message-box.html.twig
@@ -24,3 +24,72 @@
   </ul>
   <p><a href="#">Click here</a> if you need additional help</p>
 {% endif %}
+
+{% if actions is not empty and moderation_state == 'draft' %}
+  <div class="ecl-editorial-header__actions">
+    {% for action in actions %}
+      <div class="ecl-editorial-header__action">
+        {% set trigger = '' %}
+
+        {% if action.items %}
+          {% set trigger %}
+            {% include "@ecl-twig/ec-component-button/ecl-button.html.twig" with {
+              extra_classes: action.extra_classes|default('') ~ 'ecl-button--has-icon-layout',
+              icon: icon_file_path ? action.icon|default({})|merge({
+                path: icon_file_path,
+                size: 's',
+              }),
+              label: action.label|default(action.link.label),
+            } %}
+          {% endset %}
+
+          {% include "@theme/patterns/compositions/collapsible-options.html.twig" with {
+            extra_classes: 'ecl-collapsible-options--aligns-from-right',
+            collapse_label: action.label|default(action.link.label),
+            icon_file_path: icon_file_path,
+            items: action.items,
+            trigger: action.is_compact and icon_file_path ? trigger : NULL,
+          } only %}
+        {% else %}
+          {% if action is not empty %}
+            {% if action.link %}
+              {% include "@ecl-twig/ec-component-link/ecl-link.html.twig" with action|default({})|merge({
+                link: action.link|default({})|merge({
+                  icon_position: 'before',
+                }),
+                icon: icon_file_path ? action.icon|default({})|merge({
+                  path: icon_file_path,
+                  size: 's',
+                }) : {},
+                extra_classes: 'ecl-link--button ecl-link--button-primary' ~ (action.is_compact ? ' ecl-link--button-has-icon-layout ecl-link--action'),
+              }) only %}
+            {% elseif action is not empty %}
+              {% if action.link %}
+                {% include "@ecl-twig/ec-component-link/ecl-link.html.twig" with action|default({})|merge({
+                  link: action.link|merge({
+                    icon_position: 'before',
+                  }),
+                  icon: icon_file_path ? action.icon|default({})|merge({
+                    path: icon_file_path,
+                    size: 's',
+                  }) : {},
+                  extra_classes: (actions[0].items and not loop.first) or loop.first ? 'ecl-link--button ecl-link--button-primary' : 'ecl-link--button ecl-link--button-secondary' ~ (action.is_compact ? 'ecl-link--button-has-icon-layout'),
+                }) only %}
+              {% else %}
+                {% include "@ecl-twig/ec-component-button/ecl-button.html.twig" with action|default({})|merge({
+                  icon_position: 'before',
+                  extra_classes: action.is_compact ? 'ecl-button--has-icon-layout',
+                  variant: (actions[0].items and not loop.first) or loop.first ? 'primary' : 'secondary',
+                  icon: icon_file_path ? action.icon|default({})|merge({
+                    path: icon_file_path,
+                    size: 's',
+                  }) : {},
+                }) only %}
+              {% endif %}
+            {% endif %}
+          {% endif %}
+        {% endif %}
+      </div>
+    {% endfor %}
+  </div>
+{% endif %}

--- a/lib/themes/eic_community/templates/blocks/eic-group-moderated-message-box.html.twig
+++ b/lib/themes/eic_community/templates/blocks/eic-group-moderated-message-box.html.twig
@@ -9,6 +9,18 @@
  * @ingroup themeable
  */
 #}
+{% set moderation_state = group.moderation_state.value %}
 
-<p>This group is pending approval from our community team. We will endeavour to approve the group within 3 days.</p>
-<p>You can still <a href="{{ edit_link }}">manage</a> or <a href="{{ delete_link }}">delete</a> your group</p>
+{% if moderation_state == 'pending' %}
+  <p>This group is pending approval from our community team. We will endeavour to approve the group within 3 days.</p>
+  <p>You can still <a href="{{ edit_link }}">manage</a> or <a href="{{ delete_link }}">delete</a> your group</p>
+{% elseif moderation_state == 'draft' %}
+  <h2>Congratulations! Group approved</h2>
+  <p>We advise these steps to make your group ready:</p>
+  <ul>
+    <li>Configure your group: configure a welcome message for your GM's, configure the content section</li>
+    <li>Create content in the group</li>
+    <li>Publish your group</li>
+  </ul>
+  <p><a href="#">Click here</a> if you need additional help</p>
+{% endif %}

--- a/lib/themes/eic_community/templates/blocks/eic-group-moderated-message-box.html.twig
+++ b/lib/themes/eic_community/templates/blocks/eic-group-moderated-message-box.html.twig
@@ -12,6 +12,7 @@
 {% set moderation_state = group.moderation_state.value %}
 
 {% if moderation_state == 'pending' %}
+  <h2>Awaiting approval</h2>
   <p>This group is pending approval from our community team. We will endeavour to approve the group within 3 days.</p>
   <p>You can still <a href="{{ edit_link }}">manage</a> or <a href="{{ delete_link }}">delete</a> your group</p>
 {% elseif moderation_state == 'draft' %}

--- a/lib/themes/eic_community/templates/blocks/eic-group-moderated-message-box.html.twig
+++ b/lib/themes/eic_community/templates/blocks/eic-group-moderated-message-box.html.twig
@@ -25,7 +25,7 @@
   <p><a href="#">Click here</a> if you need additional help</p>
 {% endif %}
 
-{% if actions is not empty and moderation_state == 'draft' %}
+{% if actions is not empty and moderation_state == 'draft' and has_content == false %}
   <div class="ecl-editorial-header__actions">
     {% for action in actions %}
       <div class="ecl-editorial-header__action">

--- a/lib/themes/eic_community/templates/blocks/eic-group-moderated-message-box.html.twig
+++ b/lib/themes/eic_community/templates/blocks/eic-group-moderated-message-box.html.twig
@@ -1,0 +1,14 @@
+{#
+/**
+ * @file
+ * Default template for a pending/draft group's message box.
+ *
+ * Available variables:
+ * - group: The group being displayed
+ *
+ * @ingroup themeable
+ */
+#}
+
+<p>This group is pending approval from our community team. We will endeavour to approve the group within 3 days.</p>
+<p>You can still <a href="{{ edit_link }}">manage</a> or <a href="{{ delete_link }}">delete</a> your group</p>


### PR DESCRIPTION
Displays messages to the GO on the group homepage when the status is draft or pending. For draft groups, content actions are also added

### To test

- [x] Create a group
- [x] A "waiting approval" message should be displayed on the homepage
- [x] Move it to draft with an SA/SCM account
- [x] A "Group approved" message should be displayed this time
- [x] (If the group has no book, wiki, document, discussion linked) A post content action should appear