### PR TITLE
EICNET-1060: Show correct label when choosing a story/news article in the related news section of a group

### DIFF
--- a/config/sync/views.view.group_related_news_stories.yml
+++ b/config/sync/views.view.group_related_news_stories.yml
@@ -612,7 +612,7 @@ display:
           type: boolean
           settings:
             format: custom
-            format_custom_true: (Private)
+            format_custom_true: '(For community members only)'
             format_custom_false: (Public)
           group_column: value
           group_columns: {  }


### PR DESCRIPTION
### Improvements

- Show correct label when selecting private related Stories/News in groups.

### Tests

- [ ] Go to the group add form `http://eic.europa.eu/admin/group` and try to reference some related Stories/News
- [ ] Make sure private stories/news are shown in the autocomplete with the correct label -> `Story title | Story (For community members only)` or `News title | News (For community members only)`