### PR TITLE
EICNET-1102: Limit the max depth of the wiki pages to 3 levels

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -38,6 +38,7 @@ module:
   eic_content_book: 0
   eic_content_discussion: 0
   eic_content_story: 0
+  eic_content_wiki_page: 0
   eic_deploy: 0
   eic_flags: 0
   eic_fragment_fact_figure: 0

--- a/lib/modules/eic_content/modules/eic_content_wiki_page/eic_content_wiki_page.info.yml
+++ b/lib/modules/eic_content/modules/eic_content_wiki_page/eic_content_wiki_page.info.yml
@@ -1,0 +1,9 @@
+name: EIC Content Wiki Page
+type: module
+description: Provides extra logic for CT Wiki Page.
+package: European Innovation Council
+core: 8.x
+core_version_requirement: ^8 || ^9
+php: 7.3
+dependencies:
+  - eic_content:eic_content

--- a/lib/modules/eic_content/modules/eic_content_wiki_page/eic_content_wiki_page.module
+++ b/lib/modules/eic_content/modules/eic_content_wiki_page/eic_content_wiki_page.module
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @file
+ * Primary module hooks for EIC Content Wiki Page module.
+ */
+
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook_form_alter().
+ */
+function eic_content_wiki_page_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  switch ($form_id) {
+    case 'node_wiki_page_form':
+    case 'node_wiki_page_edit_form':
+      $node = $form_state->getFormObject()->getEntity();
+      // We use our custom book manager service in order to change the maximum
+      // depth of the wiki page book tree.
+      $form['book']['pid'] = \Drupal::service('eic_content_wiki_page.book.manager')->addWikiPageParentSelectFormElements($node->book);
+      break;
+
+  }
+}

--- a/lib/modules/eic_content/modules/eic_content_wiki_page/eic_content_wiki_page.services.yml
+++ b/lib/modules/eic_content/modules/eic_content_wiki_page/eic_content_wiki_page.services.yml
@@ -1,0 +1,4 @@
+services:
+  eic_content_wiki_page.book.manager:
+    class: \Drupal\eic_content_wiki_page\WikiPageBookManager
+    arguments: ['@entity_type.manager', '@string_translation', '@config.factory', '@book.outline_storage', '@renderer', '@language_manager', '@entity.repository']

--- a/lib/modules/eic_content/modules/eic_content_wiki_page/src/WikiPageBookManager.php
+++ b/lib/modules/eic_content/modules/eic_content_wiki_page/src/WikiPageBookManager.php
@@ -12,7 +12,7 @@ class WikiPageBookManager extends BookManager {
   /**
    * Overrides the maximum supported depth of the book tree.
    */
-  const BOOK_MAX_DEPTH = 4;
+  const BOOK_MAX_DEPTH = 3;
 
   /**
    * Builds the parent selection form element for the node form or outline tab.

--- a/lib/modules/eic_content/modules/eic_content_wiki_page/src/WikiPageBookManager.php
+++ b/lib/modules/eic_content/modules/eic_content_wiki_page/src/WikiPageBookManager.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Drupal\eic_content_wiki_page;
+
+use Drupal\book\BookManager;
+
+/**
+ * Extends a book manager service with custom logic for wiki pages.
+ */
+class WikiPageBookManager extends BookManager {
+
+  /**
+   * Overrides the maximum supported depth of the book tree.
+   */
+  const BOOK_MAX_DEPTH = 4;
+
+  /**
+   * Builds the parent selection form element for the node form or outline tab.
+   *
+   * This function is also called when generating a new set of options during
+   * the Ajax callback, so an array is returned that can be used to replace an
+   * existing form element.
+   *
+   * @param array $book_link
+   *   A fully loaded book link that is part of the book hierarchy.
+   *
+   * @return array
+   *   A parent selection form element.
+   */
+  public function addWikiPageParentSelectFormElements(array $book_link) {
+    $book_link['parent_depth_limit'] = self::BOOK_MAX_DEPTH;
+    return $this->addParentSelectFormElements($book_link);
+  }
+
+}

--- a/lib/modules/eic_groups/eic_groups.info.yml
+++ b/lib/modules/eic_groups/eic_groups.info.yml
@@ -10,3 +10,4 @@ dependencies:
   - oec_group_flex:oec_group_flex
   - ginvite:ginvite
   - eic_user:eic_user
+  - eic_content:eic_content_wiki_page

--- a/lib/modules/eic_groups/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_groups/src/Hooks/EntityOperations.php
@@ -11,6 +11,7 @@ use Drupal\Core\Link;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Url;
+use Drupal\eic_content_wiki_page\WikiPageBookManager;
 use Drupal\eic_groups\EICGroupsHelperInterface;
 use Drupal\eic_user\UserHelper;
 use Drupal\group\Entity\GroupContent;
@@ -204,8 +205,13 @@ class EntityOperations implements ContainerInjectionInterface {
             $build['link_add_current_level_wiki_page'] = $add_wiki_page_urls['add_current_level_wiki_page']->toString();
             $build['link_add_current_level_wiki_page_renderable'] = Link::fromTextAndUrl($this->t('Add a new page on the current level'), $add_wiki_page_urls['add_current_level_wiki_page'])->toRenderable();
             $build['link_add_current_level_wiki_page_renderable']['#suffix'] = '<br>';
-            $build['link_add_child_wiki_page'] = $add_wiki_page_urls['add_child_wiki_page']->toString();
-            $build['link_add_child_wiki_page_renderable'] = Link::fromTextAndUrl($this->t('Add a new wiki page below this page'), $add_wiki_page_urls['add_child_wiki_page'])->toRenderable();
+
+            // If the wiki page depth doesn't reach the maximum limit, then we
+            // can show the button to add a new child wiki page.
+            if (!$entity->book['p' . (WikiPageBookManager::BOOK_MAX_DEPTH + 1)]) {
+              $build['link_add_child_wiki_page'] = $add_wiki_page_urls['add_child_wiki_page']->toString();
+              $build['link_add_child_wiki_page_renderable'] = Link::fromTextAndUrl($this->t('Add a new wiki page below this page'), $add_wiki_page_urls['add_child_wiki_page'])->toRenderable();
+            }
           }
         }
         break;

--- a/lib/modules/eic_groups/src/Hooks/FormOperations.php
+++ b/lib/modules/eic_groups/src/Hooks/FormOperations.php
@@ -143,17 +143,17 @@ class FormOperations implements ContainerInjectionInterface {
       return;
     }
 
-    // We accept parents until the 4th level, otherwise it will keep the top
+    // We accept parents until the 3th level, otherwise it will keep the top
     // level book page NID as default.
     if ($query->has('parent') && is_numeric($query->get('parent'))) {
       $wiki_page = Node::load($query->get('parent'));
 
-      if ($wiki_page->bundle() === 'wiki_page') {
+      if ($wiki_page && $wiki_page->bundle() === 'wiki_page') {
         // If the book ID of the parent wiki page is the right book page NID
         // of the group and the parent wiki page depth doesn't reach the
         // maximum defined, then we accept the parent wiki page.
         if ($wiki_page->book['bid'] === $parent_nid && !$wiki_page->book['p' . (WikiPageBookManager::BOOK_MAX_DEPTH + 1)]) {
-          $parent_nid = $wiki_page->id();
+          return;
         }
       }
     }

--- a/lib/modules/eic_groups/src/Hooks/FormOperations.php
+++ b/lib/modules/eic_groups/src/Hooks/FormOperations.php
@@ -8,8 +8,10 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Url;
+use Drupal\eic_content_wiki_page\WikiPageBookManager;
 use Drupal\eic_groups\EICGroupsHelperInterface;
 use Drupal\group\Entity\Group;
+use Drupal\node\Entity\Node;
 use Drupal\oec_group_features\GroupFeaturePluginManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -129,19 +131,35 @@ class FormOperations implements ContainerInjectionInterface {
     }
 
     // Get the NID of the book page that belong to the group.
-    if (!($book_nid = $this->eicGroupsHelper->getGroupBookPage($group))) {
+    if (!($parent_nid = $this->eicGroupsHelper->getGroupBookPage($group))) {
       return;
     }
 
     $query = $this->requestStack->getCurrentRequest()->query;
+
     // If the key "parent" is presented in the request query and it corresponds
-    // to right book page NID, then we don't need to do any redirection.
-    if ($query->has('parent') && (is_numeric($query->get('parent')) && $query->get('parent') === $book_nid)) {
+    // to the right book page NID, then we don't need to do any redirection.
+    if ($query->has('parent') && (is_numeric($query->get('parent')) && $query->get('parent') === $parent_nid)) {
       return;
     }
 
-    // Update "parent" key with the right book page NID.
-    $query->set('parent', $book_nid);
+    // We accept parents until the 4th level, otherwise it will keep the top
+    // level book page NID as default.
+    if ($query->has('parent') && is_numeric($query->get('parent'))) {
+      $wiki_page = Node::load($query->get('parent'));
+
+      if ($wiki_page->bundle() === 'wiki_page') {
+        // If the book ID of the parent wiki page is the right book page NID
+        // of the group and the parent wiki page depth doesn't reach the
+        // maximum defined, then we accept the parent wiki page.
+        if ($wiki_page->book['bid'] === $parent_nid && !$wiki_page->book['p' . (WikiPageBookManager::BOOK_MAX_DEPTH + 1)]) {
+          $parent_nid = $wiki_page->id();
+        }
+      }
+    }
+
+    // Update "parent" key with the right book or wiki page NID.
+    $query->set('parent', $parent_nid);
 
     // Generate a new url for the current form with the correct query
     // parameters and redirect the user. This will let the book module set the


### PR DESCRIPTION
### Improvements

- Create custom module "eic_content_wiki_page" that provides extra logic for Content Type Wiki page;
- Override book manager service in order to change the maximum depth of the wiki page book tree;
- Add "eic_content_wiki_page" module dependency in eic_groups module;
- Fix issue where child wiki pages were not being set as parent when we create a wiki page bellow the current level.
- Hide link **"Add a new wiki page below this page"** when we reached the maximum wiki page depth.

### Tests

- [ ] Create a new group
- [ ] Go to the group wiki section and start creating some wiki pages;
- [ ] Make sure when creating a new wiki page you can only select parents until the 3th level;
- [ ] Make sure when clicking on **"Add a new wiki page below this page"** the selected parent is the right one (there was an issue that was forcing the top level book page to always be the parent and this is wrong);
- [ ] Navigate to a 3rd level wiki page and make sure the link **"Add a new wiki page below this page"** is not presented.