### PR TITLE
EICNET-1113: Implement the missing statistics to the group header

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "drupal/core-composer-scaffold": "^9.1",
         "drupal/date_popup": "^1.1",
         "drupal/default_content": "^2.0@alpha",
+        "drupal/entity_usage": "^2.0@beta",
         "drupal/extra_field": "^2.0",
         "drupal/facets": "^1.7",
         "drupal/flag": "^4.0@beta",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9db5828c86555e4beb0ff404e1dc2040",
+    "content-hash": "13f0571a00bbdec615ab05e195c3e9cc",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2974,6 +2974,74 @@
             "homepage": "https://www.drupal.org/project/entity_reference_revisions",
             "support": {
                 "source": "https://git.drupalcode.org/project/entity_reference_revisions"
+            }
+        },
+        {
+            "name": "drupal/entity_usage",
+            "version": "2.0.0-beta3",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/entity_usage.git",
+                "reference": "8.x-2.0-beta3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/entity_usage-8.x-2.0-beta3.zip",
+                "reference": "8.x-2.0-beta3",
+                "shasum": "cc115349eb533013ec672dadbe8cf0cd880bd8c4"
+            },
+            "require": {
+                "drupal/core": "^8.8 || ^9"
+            },
+            "require-dev": {
+                "drupal/block_field": "~1.0",
+                "drupal/dynamic_entity_reference": "~1.0",
+                "drupal/entity_browser": "~2.0",
+                "drupal/entity_browser_block": "~1.0",
+                "drupal/entity_embed": "~1.0",
+                "drupal/entity_reference_revisions": "~1.0",
+                "drupal/inline_entity_form": "^1.0@RC",
+                "drupal/paragraphs": "~1.0",
+                "drupal/webform": "~5.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-2.0-beta3",
+                    "datestamp": "1585145909",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Beta releases are not covered by Drupal security advisories."
+                    }
+                },
+                "drush": {
+                    "services": {
+                        "drush.services.yml": "^9"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "marcoscano",
+                    "homepage": "https://www.drupal.org/user/1288796"
+                },
+                {
+                    "name": "seanB",
+                    "homepage": "https://www.drupal.org/user/545912"
+                }
+            ],
+            "description": "Track usage of entities referenced by other entities",
+            "homepage": "https://www.drupal.org/project/entity_usage",
+            "keywords": [
+                "Drupal"
+            ],
+            "support": {
+                "source": "http://cgit.drupalcode.org/entity_usage",
+                "issues": "http://drupal.org/project/issues/entity_usage"
             }
         },
         {
@@ -6929,12 +6997,6 @@
                 "escaper",
                 "laminas"
             ],
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
             "time": "2021-06-26T14:26:08+00:00"
         },
         {
@@ -7053,12 +7115,6 @@
                 "laminas",
                 "stdlib"
             ],
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
             "time": "2021-06-28T21:37:31+00:00"
         },
         {
@@ -7108,12 +7164,6 @@
                 "autoloading",
                 "laminas",
                 "zf"
-            ],
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
             ],
             "time": "2021-06-24T12:49:22+00:00"
         },
@@ -7379,16 +7429,6 @@
             "keywords": [
                 "enum"
             ],
-            "funding": [
-                {
-                    "url": "https://github.com/mnapoli",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/myclabs/php-enum",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2021-07-05T08:18:36+00:00"
         },
         {
@@ -7467,16 +7507,6 @@
                 "date",
                 "datetime",
                 "time"
-            ],
-            "funding": [
-                {
-                    "url": "https://opencollective.com/Carbon",
-                    "type": "open_collective"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/nesbot/carbon",
-                    "type": "tidelift"
-                }
             ],
             "time": "2021-06-28T22:38:45+00:00"
         },
@@ -8829,20 +8859,6 @@
             ],
             "description": "Eases the creation of beautiful and testable command line interfaces",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2021-06-06T09:12:27+00:00"
         },
         {
@@ -8977,20 +8993,6 @@
             ],
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2021-06-24T08:08:16+00:00"
         },
         {
@@ -9107,20 +9109,6 @@
             ],
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2021-06-24T07:57:22+00:00"
         },
         {
@@ -9322,20 +9310,6 @@
             ],
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2021-06-30T07:12:23+00:00"
         },
         {
@@ -9520,20 +9494,6 @@
             ],
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2021-06-26T21:56:04+00:00"
         },
         {
@@ -9621,20 +9581,6 @@
             ],
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2021-06-30T08:18:06+00:00"
         },
         {
@@ -10383,20 +10329,6 @@
             ],
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2021-06-09T14:57:04+00:00"
         },
         {
@@ -10642,20 +10574,6 @@
             ],
             "description": "Handles serializing and deserializing data structures, including object graphs, into array structures or other formats like XML and JSON.",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2021-06-05T20:22:57+00:00"
         },
         {
@@ -10803,20 +10721,6 @@
             ],
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2021-06-06T08:51:46+00:00"
         },
         {
@@ -10980,20 +10884,6 @@
             ],
             "description": "Provides tools to validate values",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2021-06-30T07:16:09+00:00"
         },
         {
@@ -11065,20 +10955,6 @@
                 "debug",
                 "dump"
             ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2021-06-24T08:13:00+00:00"
         },
         {
@@ -11133,20 +11009,6 @@
             ],
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2021-06-23T19:06:53+00:00"
         },
         {
@@ -15490,20 +15352,6 @@
             ],
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2021-06-21T14:51:25+00:00"
         },
         {
@@ -15696,20 +15544,6 @@
                 "redlock",
                 "semaphore"
             ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2021-06-06T09:12:27+00:00"
         },
         {
@@ -15839,20 +15673,6 @@
             ],
             "description": "Provides utilities for PHPUnit, especially user deprecation notices management",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2021-06-22T16:07:00+00:00"
         },
         {
@@ -16063,6 +15883,7 @@
     "stability-flags": {
         "drupal/context": 10,
         "drupal/default_content": 15,
+        "drupal/entity_usage": 10,
         "drupal/flag": 10,
         "drupal/flag_search_api": 20,
         "drupal/group_flex": 10,

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -42,6 +42,7 @@ module:
   eic_deploy: 0
   eic_flags: 0
   eic_fragment_fact_figure: 0
+  eic_group_statistics: 0
   eic_groups: 0
   eic_homepage: 0
   eic_media: 0
@@ -61,6 +62,7 @@ module:
   entity_browser: 0
   entity_browser_entity_form: 0
   entity_reference_revisions: 0
+  entity_usage: 0
   extra_field: 0
   facets: 0
   facets_summary: 0

--- a/config/sync/entity_usage.settings.yml
+++ b/config/sync/entity_usage.settings.yml
@@ -1,0 +1,14 @@
+track_enabled_base_fields: false
+local_task_enabled_entity_types: {  }
+usage_controller_items_per_page: 25
+_core:
+  default_config_hash: AXUBMTvVtpcNp0jKjDaWjSHqMy6HjuUf7j4yVbXgazI
+track_enabled_source_entity_types:
+  - node
+track_enabled_target_entity_types:
+  - media
+edit_warning_message_entity_types: {  }
+delete_warning_message_entity_types: {  }
+track_enabled_plugins:
+  - entity_reference
+site_domains: {  }

--- a/config/sync/search_api.index.global.yml
+++ b/config/sync/search_api.index.global.yml
@@ -4,24 +4,25 @@ status: true
 dependencies:
   module:
     - search_api_solr
-    - node
     - group
-    - user
+    - node
     - profile
+    - user
     - search_api
-    - flag_search_api
     - address
+    - eic_group_statistics
+    - flag_search_api
     - content_moderation
     - flag
   config:
-    - field.storage.node.field_body
-    - field.storage.node.field_discussion_type
-    - field.storage.node.field_subtitle
-    - field.storage.node.field_vocab_geo
-    - field.storage.node.field_vocab_topics
     - field.storage.group.field_body
     - field.storage.group.field_vocab_geo
     - field.storage.group.field_vocab_topics
+    - field.storage.node.field_body
+    - field.storage.node.field_vocab_geo
+    - field.storage.node.field_subtitle
+    - field.storage.node.field_vocab_topics
+    - field.storage.node.field_discussion_type
     - field.storage.profile.field_body
     - field.storage.profile.field_location_address
     - field.storage.profile.field_vocab_job_title
@@ -269,6 +270,30 @@ field_settings:
     dependencies:
       module:
         - group
+  group_statistic_comments:
+    label: 'Group statistics - Comments'
+    property_path: group_statistic_comments
+    type: integer
+    indexed_locked: true
+    type_locked: true
+  group_statistic_events:
+    label: 'Group statistics - Events'
+    property_path: group_statistic_events
+    type: integer
+    indexed_locked: true
+    type_locked: true
+  group_statistic_files:
+    label: 'Group statistics - Files'
+    property_path: group_statistic_files
+    type: integer
+    indexed_locked: true
+    type_locked: true
+  group_statistic_members:
+    label: 'Group statistics - Members'
+    property_path: group_statistic_members
+    type: integer
+    indexed_locked: true
+    type_locked: true
   group_status:
     label: '[Group] Published'
     datasource_id: 'entity:group'
@@ -432,6 +457,12 @@ processor_settings:
   flag_count_indexer:
     flag_index:
       - recommend_group
+  group_statistics_indexer:
+    group_statistics_index:
+      - members
+      - comments
+      - files
+      - events
   hierarchy:
     fields:
       content_field_vocab_geo: taxonomy_term-parent

--- a/config/sync/search_api.index.global.yml
+++ b/config/sync/search_api.index.global.yml
@@ -261,6 +261,14 @@ field_settings:
     dependencies:
       config:
         - field.storage.group.field_vocab_topics
+  group_id:
+    label: '[Group] ID'
+    datasource_id: 'entity:group'
+    property_path: id
+    type: integer
+    dependencies:
+      module:
+        - group
   group_label:
     label: '[Group] Title'
     datasource_id: 'entity:group'

--- a/lib/modules/eic_groups/eic_groups.info.yml
+++ b/lib/modules/eic_groups/eic_groups.info.yml
@@ -11,3 +11,4 @@ dependencies:
   - ginvite:ginvite
   - eic_user:eic_user
   - eic_content:eic_content_wiki_page
+  - eic_statistics:eic_group_statistics

--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
@@ -10,6 +10,7 @@ use Drupal\Core\Render\Markup;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Url;
+use Drupal\eic_group_statistics\GroupStatisticsHelperInterface;
 use Drupal\eic_groups\EICGroupsHelperInterface;
 use Drupal\flag\FlagServiceInterface;
 use Drupal\group\Entity\GroupInterface;
@@ -73,6 +74,13 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
   protected $flagService;
 
   /**
+   * The group statistics helper service.
+   *
+   * @var \Drupal\eic_group_statistics\GroupStatisticsHelperInterface
+   */
+  protected $groupStatisticsHelper;
+
+  /**
    * Constructs a new EICGroupHeaderBlock instance.
    *
    * @param array $configuration
@@ -96,6 +104,8 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
    *   The current user.
    * @param \Drupal\flag\FlagServiceInterface $flag_service
    *   The flag service.
+   * @param \Drupal\eic_group_statistics\GroupStatisticsHelperInterface $group_statistics_helper
+   *   The group statistics helper service.
    */
   public function __construct(
     array $configuration,
@@ -106,7 +116,8 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
     EntityTypeManagerInterface $entity_type_manager,
     OECGroupFlexHelper $oec_group_flex_helper,
     AccountProxyInterface $current_user,
-    FlagServiceInterface $flag_service
+    FlagServiceInterface $flag_service,
+    GroupStatisticsHelperInterface $group_statistics_helper
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->routeMatch = $route_match;
@@ -115,6 +126,7 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
     $this->oecGroupFlexHelper = $oec_group_flex_helper;
     $this->currentUser = $current_user;
     $this->flagService = $flag_service;
+    $this->groupStatisticsHelper = $group_statistics_helper;
   }
 
   /**
@@ -135,7 +147,8 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
       $container->get('entity_type.manager'),
       $container->get('oec_group_flex.helper'),
       $container->get('current_user'),
-      $container->get('flag')
+      $container->get('flag'),
+      $container->get('eic_group_statistics.helper')
     );
   }
 
@@ -164,6 +177,8 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
       'user.group_permissions',
       'url.path',
     ]);
+    // We also need to add group cache tags.
+    $cacheable_metadata->addCacheTags($group->getCacheTags());
 
     // Get group operation links.
     $group_operation_links = $this->entityTypeManager->getListBuilder($group->getEntityTypeId())->getOperations($group);
@@ -238,6 +253,9 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
     // Get all group flags the user has access to.
     $membership_links = $this->getGroupFlagLinks($group);
 
+    // Load group statistics from SOLR.
+    $group_statistics = $this->groupStatisticsHelper->loadGroupStatisticsFromSearchIndex($group);
+
     $build['content'] = [
       '#theme' => 'eic_group_header_block',
       '#group' => $group,
@@ -248,6 +266,12 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
         'description' => Markup::create($group->get('field_body')->value),
         'operation_links' => array_merge($operation_links, $node_operation_links, $visible_group_operation_links),
         'membership_links' => array_merge($membership_links, $user_operation_links),
+        'group_statistics' => [
+          'members' => $group_statistics->getMembersCount(),
+          'comments' => $group_statistics->getCommentsCount(),
+          'files' => $group_statistics->getFilesCount(),
+          'events' => $group_statistics->getEventsCount(),
+        ],
       ],
     ];
 

--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
@@ -266,7 +266,7 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
         'description' => Markup::create($group->get('field_body')->value),
         'operation_links' => array_merge($operation_links, $node_operation_links, $visible_group_operation_links),
         'membership_links' => array_merge($membership_links, $user_operation_links),
-        'group_statistics' => [
+        'stats' => [
           'members' => $group_statistics->getMembersCount(),
           'comments' => $group_statistics->getCommentsCount(),
           'files' => $group_statistics->getFilesCount(),

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.info.yml
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.info.yml
@@ -1,0 +1,9 @@
+name: EIC Group Statistics
+type: module
+description: Module that provides statistics for EIC Groups.
+package: European Innovation Council
+core: 8.x
+core_version_requirement: ^8 || ^9
+php: 7.3
+dependencies:
+  - group:group

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.install
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.install
@@ -73,3 +73,35 @@ function eic_group_statistics_schema() {
 
   return $schema;
 }
+
+/**
+ * Implements hook_install().
+ */
+function eic_group_statistics_install() {
+  /**
+   * Gets the Group statistics storage.
+   *
+   * @var \Drupal\group\Entity\GroupInterface[] $groups
+   */
+  $group_statistics_storage = \Drupal::service('eic_group_statistics.storage');
+  /**
+   * Loads all groups.
+   *
+   * @var \Drupal\group\Entity\GroupInterface[] $groups
+   */
+  $groups = \Drupal::entityTypeManager()->getStorage('group')->loadMultiple();
+  /**
+   * Initializes array of group statistics.
+   *
+   * @var \Drupal\eic_group_statistics\GroupStatistics[] $groups_statistics
+   */
+  $groups_statistics = [];
+
+  // Calculate statistics for each group.
+  foreach ($groups as $group) {
+    $groups_statistics[] = $group_statistics_storage->calculateGroupStatistics($group);
+  }
+
+  // Update groups statistics.
+  $group_statistics_storage->setMultipleGroupStatistics($groups_statistics);
+}

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.install
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.install
@@ -5,8 +5,6 @@
  * Install, update and uninstall functions for the EIC Group Statistics module.
  */
 
-use Drupal\eic_group_statistics\GroupStatisticsHelper;
-
 /**
  * Implements hook_schema().
  */
@@ -81,6 +79,6 @@ function eic_group_statistics_schema() {
  */
 function eic_group_statistics_install() {
   // Update groups statistics for all groups.
-  \Drupal::classResolver(GroupStatisticsHelper::class)
+  \Drupal::service('eic_group_statistics.helper')
     ->updateAllGroupsStatistics();
 }

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.install
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.install
@@ -5,6 +5,8 @@
  * Install, update and uninstall functions for the EIC Group Statistics module.
  */
 
+use Drupal\eic_group_statistics\GroupStatisticsHelper;
+
 /**
  * Implements hook_schema().
  */
@@ -78,30 +80,7 @@ function eic_group_statistics_schema() {
  * Implements hook_install().
  */
 function eic_group_statistics_install() {
-  /**
-   * Gets the Group statistics storage.
-   *
-   * @var \Drupal\group\Entity\GroupInterface[] $groups
-   */
-  $group_statistics_storage = \Drupal::service('eic_group_statistics.storage');
-  /**
-   * Loads all groups.
-   *
-   * @var \Drupal\group\Entity\GroupInterface[] $groups
-   */
-  $groups = \Drupal::entityTypeManager()->getStorage('group')->loadMultiple();
-  /**
-   * Initializes array of group statistics.
-   *
-   * @var \Drupal\eic_group_statistics\GroupStatistics[] $groups_statistics
-   */
-  $groups_statistics = [];
-
-  // Calculate statistics for each group.
-  foreach ($groups as $group) {
-    $groups_statistics[] = $group_statistics_storage->calculateGroupStatistics($group);
-  }
-
-  // Update groups statistics.
-  $group_statistics_storage->setMultipleGroupStatistics($groups_statistics);
+  // Update groups statistics for all groups.
+  \Drupal::classResolver(GroupStatisticsHelper::class)
+    ->updateAllGroupsStatistics();
 }

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.install
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.install
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for the EIC Group Statistics module.
+ */
+
+/**
+ * Implements hook_schema().
+ */
+function eic_group_statistics_schema() {
+  $schema['eic_group_statistics'] = [
+    'description' => 'Stores group counters information.',
+    'fields' => [
+      'id' => [
+        'type' => 'serial',
+        'not null' => TRUE,
+        'description' => 'Primary Key: Unique record ID.',
+      ],
+      'gid' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'The group ID.',
+      ],
+      'gtype' => [
+        'type' => 'varchar_ascii',
+        'length' => 64,
+        'not null' => TRUE,
+        'default' => '',
+        'description' => 'The Group bundle.',
+      ],
+      'members' => [
+        'description' => 'Number of group members.',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+        'size' => 'medium',
+      ],
+      'comments' => [
+        'description' => 'Number of comments in the group',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+        'size' => 'medium',
+      ],
+      'files' => [
+        'description' => 'Number of files added to the group.',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+        'size' => 'medium',
+      ],
+      'events' => [
+        'description' => 'Number of events.',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+        'size' => 'medium',
+      ],
+    ],
+    'primary key' => ['id', 'gid'],
+    'indexes' => [
+      'gid' => ['gid'],
+      'gtype' => ['gtype'],
+    ],
+  ];
+
+  return $schema;
+}

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.module
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.module
@@ -6,7 +6,7 @@
  */
 
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\eic_group_statistics\GroupStatisticsStorageInterface;
+use Drupal\eic_group_statistics\GroupStatisticTypes;
 use Drupal\eic_group_statistics\Hooks\EntityOperations;
 use Drupal\group\Entity\GroupContent;
 
@@ -88,7 +88,7 @@ function eic_group_statistics_comment_insert(EntityInterface $entity) {
   $group_content = reset($group_contents);
 
   // Increments group comments statistic counter.
-  \Drupal::service('eic_group_statistics.storage')->increment($group_content->getGroup(), GroupStatisticsStorageInterface::STAT_TYPE_COMMENTS);
+  \Drupal::service('eic_group_statistics.storage')->increment($group_content->getGroup(), GroupStatisticTypes::STAT_TYPE_COMMENTS);
 
   // Re-index group statistics.
   \Drupal::service('eic_group_statistics.search_api.reindex')->reindexItem($group_content->getGroup());
@@ -110,7 +110,7 @@ function eic_group_statistics_comment_delete(EntityInterface $entity) {
   $group_content = reset($group_contents);
 
   // Decrements group comments statistic counter.
-  \Drupal::service('eic_group_statistics.storage')->decrement($group_content->getGroup(), GroupStatisticsStorageInterface::STAT_TYPE_COMMENTS);
+  \Drupal::service('eic_group_statistics.storage')->decrement($group_content->getGroup(), GroupStatisticTypes::STAT_TYPE_COMMENTS);
 
   // Re-index group statistics.
   \Drupal::service('eic_group_statistics.search_api.reindex')->reindexItem($group_content->getGroup());

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.module
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.module
@@ -26,6 +26,10 @@ function eic_group_statistics_group_content_insert(EntityInterface $entity) {
       \Drupal::service('eic_group_statistics.storage')->increment($group, GroupStatisticsStorageInterface::STAT_TYPE_MEMBERS);
       break;
 
+    case 'group-group_node-document':
+      \Drupal::service('eic_group_statistics.storage')->increment($group, GroupStatisticsStorageInterface::STAT_TYPE_FILES);
+      break;
+
   }
 }
 
@@ -38,6 +42,10 @@ function eic_group_statistics_group_content_delete(EntityInterface $entity) {
   switch ($entity->bundle()) {
     case 'group-group_membership':
       \Drupal::service('eic_group_statistics.storage')->decrement($group, GroupStatisticsStorageInterface::STAT_TYPE_MEMBERS);
+      break;
+
+    case 'group-group_node-document':
+      \Drupal::service('eic_group_statistics.storage')->decrement($group, GroupStatisticsStorageInterface::STAT_TYPE_FILES);
       break;
 
   }

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.module
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.module
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\eic_group_statistics\GroupStatisticsStorageInterface;
+use Drupal\group\Entity\GroupContent;
 
 /**
  * Implements hook_ENTITY_TYPE_delete().
@@ -49,4 +50,42 @@ function eic_group_statistics_group_content_delete(EntityInterface $entity) {
       break;
 
   }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_insert().
+ */
+function eic_group_statistics_comment_insert(EntityInterface $entity) {
+  $commented_entity = $entity->getCommentedEntity();
+
+  // We need to make sure the comment belongs to a group content, otherwise we
+  // don't need to update any group statistics.
+  $group_contents = GroupContent::loadByEntity($commented_entity);
+  if (!$group_contents) {
+    return;
+  }
+
+  $group_content = reset($group_contents);
+
+  // Increments group comments statistic counter.
+  \Drupal::service('eic_group_statistics.storage')->increment($group_content->getGroup(), GroupStatisticsStorageInterface::STAT_TYPE_COMMENTS);
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_delete().
+ */
+function eic_group_statistics_comment_delete(EntityInterface $entity) {
+  $commented_entity = $entity->getCommentedEntity();
+
+  // We need to make sure the comment belongs to a group content, otherwise we
+  // don't need to update any group statistics.
+  $group_contents = GroupContent::loadByEntity($commented_entity);
+  if (!$group_contents) {
+    return;
+  }
+
+  $group_content = reset($group_contents);
+
+  // Decrements group comments statistic counter.
+  \Drupal::service('eic_group_statistics.storage')->decrement($group_content->getGroup(), GroupStatisticsStorageInterface::STAT_TYPE_COMMENTS);
 }

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.module
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.module
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\eic_group_statistics\GroupStatisticsStorageInterface;
+use Drupal\eic_group_statistics\Hooks\EntityOperations;
 use Drupal\group\Entity\GroupContent;
 
 /**
@@ -20,62 +21,28 @@ function eic_group_statistics_group_delete(EntityInterface $entity) {
  * Implements hook_ENTITY_TYPE_insert().
  */
 function eic_group_statistics_group_content_insert(EntityInterface $entity) {
-  $group = $entity->getGroup();
-
-  $re_index = TRUE;
-
   switch ($entity->bundle()) {
     case 'group-group_membership':
-      \Drupal::service('eic_group_statistics.storage')->increment($group, GroupStatisticsStorageInterface::STAT_TYPE_MEMBERS);
-      break;
-
     case 'group-group_node-document':
-      \Drupal::service('eic_group_statistics.storage')->increment($group, GroupStatisticsStorageInterface::STAT_TYPE_FILES);
-      break;
-
-    default:
-      $re_index = FALSE;
+      \Drupal::classResolver(EntityOperations::class)
+        ->groupContentInsert($entity);
       break;
 
   }
-
-  if (!$re_index) {
-    return;
-  }
-
-  // Re-index group statistics.
-  \Drupal::service('eic_group_statistics.search_api.reindex')->reindexItem($group);
 }
 
 /**
  * Implements hook_ENTITY_TYPE_delete().
  */
 function eic_group_statistics_group_content_delete(EntityInterface $entity) {
-  $group = $entity->getGroup();
-
-  $re_index = TRUE;
-
   switch ($entity->bundle()) {
     case 'group-group_membership':
-      \Drupal::service('eic_group_statistics.storage')->decrement($group, GroupStatisticsStorageInterface::STAT_TYPE_MEMBERS);
-      break;
-
     case 'group-group_node-document':
-      \Drupal::service('eic_group_statistics.storage')->decrement($group, GroupStatisticsStorageInterface::STAT_TYPE_FILES);
-      break;
-
-    default:
-      $re_index = FALSE;
+      \Drupal::classResolver(EntityOperations::class)
+        ->groupContentDelete($entity);
       break;
 
   }
-
-  if (!$re_index) {
-    return;
-  }
-
-  // Re-index group statistics.
-  \Drupal::service('eic_group_statistics.search_api.reindex')->reindexItem($group);
 }
 
 /**

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.module
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.module
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @file
+ * Primary module hooks for EIC Group Statistics module.
+ */
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\eic_group_statistics\GroupStatisticsStorageInterface;
+
+/**
+ * Implements hook_ENTITY_TYPE_delete().
+ */
+function eic_group_statistics_group_delete(EntityInterface $entity) {
+  \Drupal::service('eic_group_statistics.storage')->deleteGroupStatistics($entity);
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_insert().
+ */
+function eic_group_statistics_group_content_insert(EntityInterface $entity) {
+  $group = $entity->getGroup();
+
+  switch ($entity->bundle()) {
+    case 'group-group_membership':
+      \Drupal::service('eic_group_statistics.storage')->increment($group, GroupStatisticsStorageInterface::STAT_TYPE_MEMBERS);
+      break;
+
+  }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_delete().
+ */
+function eic_group_statistics_group_content_delete(EntityInterface $entity) {
+  $group = $entity->getGroup();
+
+  switch ($entity->bundle()) {
+    case 'group-group_membership':
+      \Drupal::service('eic_group_statistics.storage')->decrement($group, GroupStatisticsStorageInterface::STAT_TYPE_MEMBERS);
+      break;
+
+  }
+}

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.module
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.module
@@ -25,8 +25,8 @@ function eic_group_statistics_group_content_insert(EntityInterface $entity) {
     case 'group-group_membership':
     case 'group-group_node-discussion':
     case 'group-group_node-document':
-    case 'group-group_node-wiki_page':
     case 'group-group_node-gallery':
+    case 'group-group_node-wiki_page':
       \Drupal::classResolver(EntityOperations::class)
         ->groupContentInsert($entity);
       break;
@@ -54,8 +54,8 @@ function eic_group_statistics_node_delete(EntityInterface $entity) {
   switch ($entity->bundle()) {
     case 'discussion':
     case 'document':
-    case 'wiki_page':
     case 'gallery':
+    case 'wiki_page':
       // We need to make sure the node belongs to a group content, otherwise we
       // don't need to update any group statistics.
       $group_contents = GroupContent::loadByEntity($entity);
@@ -121,9 +121,10 @@ function eic_group_statistics_comment_delete(EntityInterface $entity) {
  */
 function eic_group_statistics_node_update(EntityInterface $entity) {
   switch ($entity->bundle()) {
+    case 'discussion':
     case 'document':
-    case 'wiki_page':
     case 'gallery':
+    case 'wiki_page':
       // We need to make sure the node belongs to a group content, otherwise we
       // don't need to update any group statistics.
       $group_contents = GroupContent::loadByEntity($entity);

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.module
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.module
@@ -113,3 +113,27 @@ function eic_group_statistics_comment_delete(EntityInterface $entity) {
   // Re-index group statistics.
   \Drupal::service('eic_group_statistics.search_api.reindex')->reindexItem($group_content->getGroup());
 }
+
+/**
+ * Implements hook_ENTITY_TYPE_update().
+ */
+function eic_group_statistics_node_update(EntityInterface $entity) {
+  switch ($entity->bundle()) {
+    case 'document':
+    case 'wiki_page':
+    case 'gallery':
+      // We need to make sure the node belongs to a group content, otherwise we
+      // don't need to update any group statistics.
+      $group_contents = GroupContent::loadByEntity($entity);
+      if (!$group_contents) {
+        return;
+      }
+
+      $group_content = reset($group_contents);
+
+      \Drupal::classResolver(EntityOperations::class)
+        ->groupContentNodeUpdate($entity, $group_content);
+      break;
+
+  }
+}

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.module
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.module
@@ -24,6 +24,8 @@ function eic_group_statistics_group_content_insert(EntityInterface $entity) {
   switch ($entity->bundle()) {
     case 'group-group_membership':
     case 'group-group_node-document':
+    case 'group-group_node-wiki_page':
+    case 'group-group_node-gallery':
       \Drupal::classResolver(EntityOperations::class)
         ->groupContentInsert($entity);
       break;
@@ -37,7 +39,6 @@ function eic_group_statistics_group_content_insert(EntityInterface $entity) {
 function eic_group_statistics_group_content_delete(EntityInterface $entity) {
   switch ($entity->bundle()) {
     case 'group-group_membership':
-    case 'group-group_node-document':
       \Drupal::classResolver(EntityOperations::class)
         ->groupContentDelete($entity);
       break;
@@ -51,6 +52,8 @@ function eic_group_statistics_group_content_delete(EntityInterface $entity) {
 function eic_group_statistics_node_delete(EntityInterface $entity) {
   switch ($entity->bundle()) {
     case 'document':
+    case 'wiki_page':
+    case 'gallery':
       // We need to make sure the node belongs to a group content, otherwise we
       // don't need to update any group statistics.
       $group_contents = GroupContent::loadByEntity($entity);

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.module
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.module
@@ -23,6 +23,7 @@ function eic_group_statistics_group_delete(EntityInterface $entity) {
 function eic_group_statistics_group_content_insert(EntityInterface $entity) {
   switch ($entity->bundle()) {
     case 'group-group_membership':
+    case 'group-group_node-discussion':
     case 'group-group_node-document':
     case 'group-group_node-wiki_page':
     case 'group-group_node-gallery':
@@ -51,6 +52,7 @@ function eic_group_statistics_group_content_delete(EntityInterface $entity) {
  */
 function eic_group_statistics_node_delete(EntityInterface $entity) {
   switch ($entity->bundle()) {
+    case 'discussion':
     case 'document':
     case 'wiki_page':
     case 'gallery':

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.module
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.module
@@ -46,6 +46,28 @@ function eic_group_statistics_group_content_delete(EntityInterface $entity) {
 }
 
 /**
+ * Implements hook_ENTITY_TYPE_delete().
+ */
+function eic_group_statistics_node_delete(EntityInterface $entity) {
+  switch ($entity->bundle()) {
+    case 'document':
+      // We need to make sure the node belongs to a group content, otherwise we
+      // don't need to update any group statistics.
+      $group_contents = GroupContent::loadByEntity($entity);
+      if (!$group_contents) {
+        return;
+      }
+
+      $group_content = reset($group_contents);
+
+      \Drupal::classResolver(EntityOperations::class)
+        ->groupContentNodeDelete($entity, $group_content);
+      break;
+
+  }
+}
+
+/**
  * Implements hook_ENTITY_TYPE_insert().
  */
 function eic_group_statistics_comment_insert(EntityInterface $entity) {

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.module
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.module
@@ -22,6 +22,8 @@ function eic_group_statistics_group_delete(EntityInterface $entity) {
 function eic_group_statistics_group_content_insert(EntityInterface $entity) {
   $group = $entity->getGroup();
 
+  $re_index = TRUE;
+
   switch ($entity->bundle()) {
     case 'group-group_membership':
       \Drupal::service('eic_group_statistics.storage')->increment($group, GroupStatisticsStorageInterface::STAT_TYPE_MEMBERS);
@@ -31,7 +33,18 @@ function eic_group_statistics_group_content_insert(EntityInterface $entity) {
       \Drupal::service('eic_group_statistics.storage')->increment($group, GroupStatisticsStorageInterface::STAT_TYPE_FILES);
       break;
 
+    default:
+      $re_index = FALSE;
+      break;
+
   }
+
+  if (!$re_index) {
+    return;
+  }
+
+  // Re-index group statistics.
+  \Drupal::service('eic_group_statistics.search_api.reindex')->reindexItem($group);
 }
 
 /**
@@ -39,6 +52,8 @@ function eic_group_statistics_group_content_insert(EntityInterface $entity) {
  */
 function eic_group_statistics_group_content_delete(EntityInterface $entity) {
   $group = $entity->getGroup();
+
+  $re_index = TRUE;
 
   switch ($entity->bundle()) {
     case 'group-group_membership':
@@ -49,7 +64,18 @@ function eic_group_statistics_group_content_delete(EntityInterface $entity) {
       \Drupal::service('eic_group_statistics.storage')->decrement($group, GroupStatisticsStorageInterface::STAT_TYPE_FILES);
       break;
 
+    default:
+      $re_index = FALSE;
+      break;
+
   }
+
+  if (!$re_index) {
+    return;
+  }
+
+  // Re-index group statistics.
+  \Drupal::service('eic_group_statistics.search_api.reindex')->reindexItem($group);
 }
 
 /**
@@ -69,6 +95,9 @@ function eic_group_statistics_comment_insert(EntityInterface $entity) {
 
   // Increments group comments statistic counter.
   \Drupal::service('eic_group_statistics.storage')->increment($group_content->getGroup(), GroupStatisticsStorageInterface::STAT_TYPE_COMMENTS);
+
+  // Re-index group statistics.
+  \Drupal::service('eic_group_statistics.search_api.reindex')->reindexItem($group_content->getGroup());
 }
 
 /**
@@ -88,4 +117,7 @@ function eic_group_statistics_comment_delete(EntityInterface $entity) {
 
   // Decrements group comments statistic counter.
   \Drupal::service('eic_group_statistics.storage')->decrement($group_content->getGroup(), GroupStatisticsStorageInterface::STAT_TYPE_COMMENTS);
+
+  // Re-index group statistics.
+  \Drupal::service('eic_group_statistics.search_api.reindex')->reindexItem($group_content->getGroup());
 }

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.services.yml
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.services.yml
@@ -7,4 +7,4 @@ services:
     arguments: ['@eic_group_statistics.storage']
   eic_group_statistics.helper:
     class: Drupal\eic_group_statistics\GroupStatisticsHelper
-    arguments: ['@eic_group_statistics.storage']
+    arguments: ['@entity_type.manager', '@eic_group_statistics.storage']

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.services.yml
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.services.yml
@@ -1,0 +1,4 @@
+services:
+  eic_group_statistics.storage:
+    class: Drupal\eic_group_statistics\GroupStatisticsStorage
+    arguments: ['@database']

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.services.yml
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.services.yml
@@ -5,3 +5,6 @@ services:
   eic_group_statistics.search_api.reindex:
     class: Drupal\eic_group_statistics\GroupStatisticsSearchApiReindex
     arguments: ['@eic_group_statistics.storage']
+  eic_group_statistics.helper:
+    class: Drupal\eic_group_statistics\GroupStatisticsHelper
+    arguments: ['@eic_group_statistics.storage']

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.services.yml
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.services.yml
@@ -2,3 +2,6 @@ services:
   eic_group_statistics.storage:
     class: Drupal\eic_group_statistics\GroupStatisticsStorage
     arguments: ['@database']
+  eic_group_statistics.search_api.reindex:
+    class: Drupal\eic_group_statistics\GroupStatisticsSearchApiReindex
+    arguments: ['@eic_group_statistics.storage']

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatistic.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatistic.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Drupal\eic_group_statistics;
+
+use Drupal\group\Entity\Group;
+
+/**
+ * Value object for passing group statistic results.
+ */
+class GroupStatistic {
+
+  /**
+   * The group entity ID.
+   *
+   * @var int
+   */
+  protected $groupId;
+
+  /**
+   * Statistic - members counter.
+   *
+   * @var int
+   */
+  protected $membersCount;
+
+  /**
+   * Statistic - comments counter.
+   *
+   * @var int
+   */
+  protected $commentsCount;
+
+  /**
+   * Statistic - files counter.
+   *
+   * @var int
+   */
+  protected $filesCount;
+
+  /**
+   * Statistic - events counter.
+   *
+   * @var int
+   */
+  protected $eventsCount;
+
+  /**
+   * Constructs a new GroupStatistic object.
+   *
+   * @param int $group_id
+   *   The group entity ID.
+   * @param int $members_count
+   *   The number of members.
+   * @param int $comments_count
+   *   The number of comments.
+   * @param int $files_count
+   *   The number of files.
+   * @param int $events_count
+   *   The number of events.
+   */
+  public function __construct(
+    $group_id,
+    $members_count = 1,
+    $comments_count = 0,
+    $files_count = 0,
+    $events_count = 0
+  ) {
+    $this->groupId = $group_id;
+    $this->membersCount = (int) $members_count;
+    $this->commentsCount = (int) $comments_count;
+    $this->filesCount = (int) $files_count;
+    $this->eventsCount = (int) $events_count;
+  }
+
+  /**
+   * Gets the group entity object.
+   *
+   * @return \Drupal\group\Entity\GroupInterface
+   *   The group entity.
+   */
+  public function getGroup() {
+    return Group::load($this->groupId);
+  }
+
+  /**
+   * Gets the group entity ID.
+   *
+   * @return int
+   *   The group entity ID.
+   */
+  public function getGroupId() {
+    return $this->groupId;
+  }
+
+  /**
+   * Gets the number of group members.
+   *
+   * @return int
+   *   The number of members.
+   */
+  public function getMembersCount() {
+    return $this->membersCount;
+  }
+
+  /**
+   * Gets the total number of comments in the group.
+   *
+   * @return int
+   *   The number of comments.
+   */
+  public function getCommentsCount() {
+    return $this->commentsCount;
+  }
+
+  /**
+   * Gets the total number of files in the group.
+   *
+   * @return int
+   *   The number of files.
+   */
+  public function getFilesCount() {
+    return $this->filesCount;
+  }
+
+  /**
+   * Gets the total number of events in the group.
+   *
+   * @return int
+   *   The number of evenets.
+   */
+  public function getEventsCount() {
+    return $this->eventsCount;
+  }
+
+}

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticTypes.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticTypes.php
@@ -30,7 +30,7 @@ final class GroupStatisticTypes {
   const STAT_TYPE_EVENTS = 'events';
 
   /**
-   * Returns an options array with all custom types.
+   * Returns an options array with all statistic types.
    *
    * @return array
    *   An array containing all the types with machine name as key and label as
@@ -38,10 +38,10 @@ final class GroupStatisticTypes {
    */
   public static function getOptionsArray() {
     return [
-      self::STREAM => t('Activity stream'),
-      self::NOTIFICATION => t('Notification'),
-      self::SUBSCRIPTION => t('Subscription'),
-      self::LOG => t('Log'),
+      self::STAT_TYPE_MEMBERS => t('Members'),
+      self::STAT_TYPE_COMMENTS => t('Comments'),
+      self::STAT_TYPE_FILES => t('Files'),
+      self::STAT_TYPE_EVENTS => t('Events'),
     ];
   }
 

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticTypes.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticTypes.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Drupal\eic_group_statistics;
+
+/**
+ * Provides statistic types to use in group statistics.
+ *
+ * @package Drupal\eic_group_statistics
+ */
+final class GroupStatisticTypes {
+
+  /**
+   * Database column name for group members counter.
+   */
+  const STAT_TYPE_MEMBERS = 'members';
+
+  /**
+   * Database column name for group comments counter.
+   */
+  const STAT_TYPE_COMMENTS = 'comments';
+
+  /**
+   * Database column name for group files counter.
+   */
+  const STAT_TYPE_FILES = 'files';
+
+  /**
+   * Database column name for group events counter.
+   */
+  const STAT_TYPE_EVENTS = 'events';
+
+  /**
+   * Returns an options array with all custom types.
+   *
+   * @return array
+   *   An array containing all the types with machine name as key and label as
+   *   value.
+   */
+  public static function getOptionsArray() {
+    return [
+      self::STREAM => t('Activity stream'),
+      self::NOTIFICATION => t('Notification'),
+      self::SUBSCRIPTION => t('Subscription'),
+      self::LOG => t('Log'),
+    ];
+  }
+
+}

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatistics.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatistics.php
@@ -5,9 +5,9 @@ namespace Drupal\eic_group_statistics;
 use Drupal\group\Entity\Group;
 
 /**
- * Value object for passing group statistic results.
+ * Value object for passing group statistics results.
  */
-class GroupStatistic {
+class GroupStatistics {
 
   /**
    * The group entity ID.
@@ -45,7 +45,7 @@ class GroupStatistic {
   protected $eventsCount;
 
   /**
-   * Constructs a new GroupStatistic object.
+   * Constructs a new GroupStatistics object.
    *
    * @param int $group_id
    *   The group entity ID.

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsHelper.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsHelper.php
@@ -66,15 +66,16 @@ class GroupStatisticsHelper implements GroupStatisticsHelperInterface {
       return new GroupStatistics($group->id());
     }
 
-    // Get first result item found.
-    $item = reset($results->getResultItems());
+    // Gets first result item found.
+    $items = $results->getResultItems();
+    $item = reset($items);
 
     return new GroupStatistics(
-      $group->id(),
-      reset($item->getField('group_statistic_members')->getValues()),
-      reset($item->getField('group_statistic_comments')->getValues()),
-      reset($item->getField('group_statistic_files')->getValues()),
-      reset($item->getField('group_statistic_events')->getValues()),
+      (int) $group->id(),
+      $item->getField('group_statistic_members')->getValues()[0],
+      $item->getField('group_statistic_comments')->getValues()[0],
+      $item->getField('group_statistic_files')->getValues()[0],
+      $item->getField('group_statistic_events')->getValues()[0],
     );
   }
 

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsHelper.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsHelper.php
@@ -41,8 +41,7 @@ class GroupStatisticsHelper implements GroupStatisticsHelperInterface {
    * {@inheritdoc}
    */
   public function loadGroupStatistics(GroupInterface $group) {
-    $group_statistics = $this->groupStatisticsStorage->load($group);
-    return $group_statistics;
+    return $this->groupStatisticsStorage->load($group);
   }
 
   /**
@@ -77,6 +76,32 @@ class GroupStatisticsHelper implements GroupStatisticsHelperInterface {
       $item->getField('group_statistic_files')->getValues()[0],
       $item->getField('group_statistic_events')->getValues()[0],
     );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function updateAllGroupsStatistics() {
+    /**
+     * Loads all groups.
+     *
+     * @var \Drupal\group\Entity\GroupInterface[] $groups
+     */
+    $groups = $this->entityTypeManager->getStorage('group')->loadMultiple();
+    /**
+     * Initializes array of group statistics.
+     *
+     * @var \Drupal\eic_group_statistics\GroupStatistics[] $groups_statistics
+     */
+    $groups_statistics = [];
+
+    // Calculate statistics for each group.
+    foreach ($groups as $group) {
+      $groups_statistics[] = $this->groupStatisticsStorage->calculateGroupStatistics($group);
+    }
+
+    // Update groups statistics.
+    $this->groupStatisticsStorage->setMultipleGroupStatistics($groups_statistics);
   }
 
 }

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsHelper.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsHelper.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Drupal\eic_group_statistics;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\group\Entity\GroupInterface;
+
+/**
+ * Service that provides helper functions for groups statistics.
+ */
+class GroupStatisticsHelper implements GroupStatisticsHelperInterface {
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The Group statistics storage service.
+   *
+   * @var \Drupal\eic_group_statistics\GroupStatisticsStorageInterface
+   */
+  protected $groupStatisticsStorage;
+
+  /**
+   * Constructs a GroupStatisticsHelper object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager service.
+   * @param \Drupal\eic_group_statistics\GroupStatisticsStorageInterface $group_statistics_storage
+   *   The Group statistics storage service.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, GroupStatisticsStorageInterface $group_statistics_storage) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->groupStatisticsStorage = $group_statistics_storage;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function loadGroupStatistics(GroupInterface $group) {
+    $group_statistics = $this->groupStatisticsStorage->load($group);
+    return $group_statistics;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function loadGroupStatisticsFromSearchIndex(GroupInterface $group) {
+    /** @var \Drupal\search_api\IndexInterface $search_api_index */
+    $search_api_index = $this->entityTypeManager->getStorage('search_api_index')->load('global');
+
+    // Create the query.
+    $query = $search_api_index->query();
+    // Filter by group ID.
+    $query->addCondition('group_id', $group->id());
+    // Limit query to 1 result.
+    $query->range(0, 1);
+
+    $results = $query->execute();
+
+    // If there are no results we return empty group statistics.
+    if (!$results->getResultCount()) {
+      return new GroupStatistics($group->id());
+    }
+
+    // Get first result item found.
+    $item = reset($results->getResultItems());
+
+    return new GroupStatistics(
+      $group->id(),
+      reset($item->getField('group_statistic_members')->getValues()),
+      reset($item->getField('group_statistic_comments')->getValues()),
+      reset($item->getField('group_statistic_files')->getValues()),
+      reset($item->getField('group_statistic_events')->getValues()),
+    );
+  }
+
+}

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsHelperInterface.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsHelperInterface.php
@@ -31,4 +31,12 @@ interface GroupStatisticsHelperInterface {
    */
   public function loadGroupStatisticsFromSearchIndex(GroupInterface $group);
 
+  /**
+   * Updates group statistics for all groups.
+   *
+   * This is a very exhaustive process and may take some time to finish
+   * depending on the number of groups and group content entities in the DB.
+   */
+  public function updateAllGroupsStatistics();
+
 }

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsHelperInterface.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsHelperInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Drupal\eic_group_statistics;
+
+use Drupal\group\Entity\GroupInterface;
+
+/**
+ * Interface to implement in GroupStatisticsHelper.
+ */
+interface GroupStatisticsHelperInterface {
+
+  /**
+   * Loads a group statistics from database.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group entity.
+   *
+   * @return \Drupal\eic_group_statistics\GroupStatistics
+   *   The group statistics object.
+   */
+  public function loadGroupStatistics(GroupInterface $group);
+
+  /**
+   * Loads a group statistics from SOLR index.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group entity.
+   *
+   * @return \Drupal\eic_group_statistics\GroupStatistics
+   *   The group statistics object.
+   */
+  public function loadGroupStatisticsFromSearchIndex(GroupInterface $group);
+
+}

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsSearchApiReindex.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsSearchApiReindex.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Drupal\eic_group_statistics;
+
+use Drupal\group\Entity\GroupInterface;
+use Drupal\search_api\Plugin\search_api\datasource\ContentEntity;
+
+/**
+ * Provides a service class to re-index group statistics in Search API index.
+ */
+class GroupStatisticsSearchApiReindex {
+
+  /**
+   * The Group statistics storage service.
+   *
+   * @var \Drupal\eic_group_statistics\GroupStatisticsStorageInterface
+   */
+  protected $groupStatisticsStorage;
+
+  /**
+   * Constructs a GroupStatisticsSearchApiReindex object.
+   *
+   * @param \Drupal\eic_group_statistics\GroupStatisticsStorageInterface $group_statistics_storage
+   *   The Group statistics storage service.
+   */
+  public function __construct(GroupStatisticsStorageInterface $group_statistics_storage) {
+    $this->groupStatisticsStorage = $group_statistics_storage;
+  }
+
+  /**
+   * Re-index group statistics for a given group.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The Group entity object.
+   */
+  public function reindexItem(GroupInterface $group) {
+    $datasource_id = 'entity:group';
+    $indexes = ContentEntity::getIndexesForEntity($group);
+
+    $updated_item_ids = $group->getTranslationLanguages();
+    foreach (array_keys($updated_item_ids) as $langcode) {
+      $inserted_item_ids[] = $langcode;
+    }
+
+    $entity_id = $group->id();
+
+    $combine_id = function ($langcode) use ($entity_id) {
+      return $entity_id . ':' . $langcode;
+    };
+
+    $updated_item_ids = array_map($combine_id, array_keys($updated_item_ids));
+    foreach ($indexes as $index) {
+      if ($updated_item_ids) {
+        $index->trackItemsUpdated($datasource_id, $updated_item_ids);
+      }
+    }
+  }
+
+}

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorage.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorage.php
@@ -97,7 +97,7 @@ class GroupStatisticsStorage implements GroupStatisticsStorageInterface {
       ->execute()->fetchAssoc();
 
     if (empty($result)) {
-      return FALSE;
+      return new GroupStatistics($result['gid']);
     }
 
     return new GroupStatistics(

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorage.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorage.php
@@ -251,6 +251,9 @@ class GroupStatisticsStorage implements GroupStatisticsStorageInterface {
     // Array of media fields per group content where we want to count file
     // statistics. Keyed by group content bundle.
     $files_group_content_types = [
+      "{$group->bundle()}-group_node-discussion" => [
+        'field_related_documents',
+      ],
       "{$group->bundle()}-group_node-document" => [
         'field_document_media',
       ],

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorage.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorage.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Drupal\eic_group_statistics;
+
+use Drupal\Core\Database\Connection;
+use Drupal\group\Entity\GroupInterface;
+
+/**
+ * Provides the default storage backend for Group statistics.
+ */
+class GroupStatisticsStorage implements GroupStatisticsStorageInterface {
+
+  /**
+   * The current active database's master connection.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected $connection;
+
+  /**
+   * Constructs a new GroupStatisticsStorage object.
+   *
+   * @return \Drupal\Core\Database\Connection
+   *   The current active database's master connection.
+   */
+  public function __construct(Connection $connection) {
+    $this->connection = $connection;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function increment(GroupInterface $group, $statistic_type, $count = 1) {
+    $query = $this->connection->merge('eic_group_statistics')
+      ->keys([
+        'gid' => $group->id(),
+      ])
+      ->fields([
+        'gtype' => $group->bundle(),
+      ]);
+
+    switch ($statistic_type) {
+      case GroupStatisticsStorageInterface::STAT_TYPE_MEMBERS:
+        $query->fields(['members' => 1])
+          ->expression('members', '[members] + 1')
+          ->execute();
+        break;
+
+      case GroupStatisticsStorageInterface::STAT_TYPE_COMMENTS:
+        $query->fields(['comments' => 1])
+          ->expression('comments', '[comments] + 1')
+          ->execute();
+        break;
+
+      case GroupStatisticsStorageInterface::STAT_TYPE_FILES:
+        $query->fields(['files' => 1])
+          ->expression('files', '[files] + 1')
+          ->execute();
+        break;
+
+      case GroupStatisticsStorageInterface::STAT_TYPE_EVENTS:
+        $query->fields(['events' => 1])
+          ->expression('events', '[events] + 1')
+          ->execute();
+        break;
+
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function decrement(GroupInterface $group, $statistic_type, $count = 1) {
+    $query = $this->connection->merge('eic_group_statistics')
+      ->keys([
+        'gid' => $group->id(),
+      ])
+      ->fields([
+        'gtype' => $group->bundle(),
+      ]);
+
+    switch ($statistic_type) {
+      case GroupStatisticsStorageInterface::STAT_TYPE_MEMBERS:
+        $query->fields(['members' => 1])
+          ->expression('members', '[members] - 1')
+          ->execute();
+        break;
+
+      case GroupStatisticsStorageInterface::STAT_TYPE_COMMENTS:
+        $query->fields(['comments' => 1])
+          ->expression('comments', '[comments] - 1')
+          ->execute();
+        break;
+
+      case GroupStatisticsStorageInterface::STAT_TYPE_FILES:
+        $query->fields(['files' => 1])
+          ->expression('files', '[files] - 1')
+          ->execute();
+        break;
+
+      case GroupStatisticsStorageInterface::STAT_TYPE_EVENTS:
+        $query->fields(['events' => 1])
+          ->expression('events', '[events] - 1')
+          ->execute();
+        break;
+
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function deleteGroupStatistics(GroupInterface $group) {
+    $this->connection->delete('eic_group_statistics')
+      ->condition('gid', $group->id())
+      ->execute();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function load(GroupInterface $group) {
+    $result = $this->connection->select('eic_group_statistics')
+      ->fields('eic_group_statistics')
+      ->condition('gid', $group->id())
+      ->range(0, 1)
+      ->execute()->fetchAssoc();
+
+    if (empty($result)) {
+      return FALSE;
+    }
+
+    return $result;
+  }
+
+}

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorage.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorage.php
@@ -41,26 +41,11 @@ class GroupStatisticsStorage implements GroupStatisticsStorageInterface {
 
     switch ($statistic_type) {
       case GroupStatisticsStorageInterface::STAT_TYPE_MEMBERS:
-        $query->fields(['members' => 1])
-          ->expression('members', '[members] + 1')
-          ->execute();
-        break;
-
       case GroupStatisticsStorageInterface::STAT_TYPE_COMMENTS:
-        $query->fields(['comments' => 1])
-          ->expression('comments', '[comments] + 1')
-          ->execute();
-        break;
-
       case GroupStatisticsStorageInterface::STAT_TYPE_FILES:
-        $query->fields(['files' => 1])
-          ->expression('files', '[files] + 1')
-          ->execute();
-        break;
-
       case GroupStatisticsStorageInterface::STAT_TYPE_EVENTS:
-        $query->fields(['events' => 1])
-          ->expression('events', '[events] + 1')
+        $query->fields([$statistic_type => 1])
+          ->expression($statistic_type, "[$statistic_type] + :count", [':count' => $count])
           ->execute();
         break;
 
@@ -81,26 +66,11 @@ class GroupStatisticsStorage implements GroupStatisticsStorageInterface {
 
     switch ($statistic_type) {
       case GroupStatisticsStorageInterface::STAT_TYPE_MEMBERS:
-        $query->fields(['members' => 1])
-          ->expression('members', '[members] - 1')
-          ->execute();
-        break;
-
       case GroupStatisticsStorageInterface::STAT_TYPE_COMMENTS:
-        $query->fields(['comments' => 1])
-          ->expression('comments', '[comments] - 1')
-          ->execute();
-        break;
-
       case GroupStatisticsStorageInterface::STAT_TYPE_FILES:
-        $query->fields(['files' => 1])
-          ->expression('files', '[files] - 1')
-          ->execute();
-        break;
-
       case GroupStatisticsStorageInterface::STAT_TYPE_EVENTS:
-        $query->fields(['events' => 1])
-          ->expression('events', '[events] - 1')
+        $query->fields([$statistic_type => 1])
+          ->expression($statistic_type, "[$statistic_type] - :count", [':count' => $count])
           ->execute();
         break;
 
@@ -130,7 +100,13 @@ class GroupStatisticsStorage implements GroupStatisticsStorageInterface {
       return FALSE;
     }
 
-    return $result;
+    return new GroupStatistic(
+      $result['gid'],
+      $result['members'],
+      $result['comments'],
+      $result['files'],
+      $result['events'],
+    );
   }
 
 }

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorage.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorage.php
@@ -41,10 +41,10 @@ class GroupStatisticsStorage implements GroupStatisticsStorageInterface {
       ]);
 
     switch ($statistic_type) {
-      case GroupStatisticsStorageInterface::STAT_TYPE_MEMBERS:
-      case GroupStatisticsStorageInterface::STAT_TYPE_COMMENTS:
-      case GroupStatisticsStorageInterface::STAT_TYPE_FILES:
-      case GroupStatisticsStorageInterface::STAT_TYPE_EVENTS:
+      case GroupStatisticTypes::STAT_TYPE_MEMBERS:
+      case GroupStatisticTypes::STAT_TYPE_COMMENTS:
+      case GroupStatisticTypes::STAT_TYPE_FILES:
+      case GroupStatisticTypes::STAT_TYPE_EVENTS:
         $query->fields([$statistic_type => 1])
           ->expression($statistic_type, "[$statistic_type] + :count", [':count' => $count])
           ->execute();
@@ -69,10 +69,10 @@ class GroupStatisticsStorage implements GroupStatisticsStorageInterface {
       ]);
 
     switch ($statistic_type) {
-      case GroupStatisticsStorageInterface::STAT_TYPE_MEMBERS:
-      case GroupStatisticsStorageInterface::STAT_TYPE_COMMENTS:
-      case GroupStatisticsStorageInterface::STAT_TYPE_FILES:
-      case GroupStatisticsStorageInterface::STAT_TYPE_EVENTS:
+      case GroupStatisticTypes::STAT_TYPE_MEMBERS:
+      case GroupStatisticTypes::STAT_TYPE_COMMENTS:
+      case GroupStatisticTypes::STAT_TYPE_FILES:
+      case GroupStatisticTypes::STAT_TYPE_EVENTS:
         $query->fields([$statistic_type => 1])
           ->expression($statistic_type, "[$statistic_type] - :count", [':count' => $count])
           ->execute();

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorage.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorage.php
@@ -119,4 +119,158 @@ class GroupStatisticsStorage implements GroupStatisticsStorageInterface {
     );
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function setGroupStatistics(GroupStatistics $group_statistics) {
+    $this->connection->merge('eic_group_statistics')
+      ->key('gid', $group_statistics->getGroupId())
+      ->fields([
+        'members' => $group_statistics->getMembersCount(),
+        'comments' => $group_statistics->getCommentsCount(),
+        'file' => $group_statistics->getFilesCount(),
+        'events' => $group_statistics->getEventsCount(),
+      ])
+      ->execute();
+
+    // Invalidate group cache tags.
+    Cache::invalidateTags(['group:' . $group_statistics->getGroupId()]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function calculateGroupStatistics(GroupInterface $group) {
+    $members_count = $this->calculateGroupMembersStatistics($group);
+    $comments_count = $this->calculateGroupCommentsStatistics($group);
+    $files_count = $this->calculateGroupFilesStatistics($group);
+    $events_count = $this->calculateGroupEventsStatistics($group);
+
+    return new GroupStatistics(
+      (int) $group->id(),
+      (int) $members_count,
+      (int) $comments_count,
+      (int) $files_count,
+      (int) $events_count
+    );
+  }
+
+  /**
+   * Calculates number of group members to add to the statistics.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The Group entity.
+   *
+   * @return int
+   *   The number of group members.
+   */
+  private function calculateGroupMembersStatistics(GroupInterface $group) {
+    // Query to count number of members.
+    $query_members = $this->connection->select('group_content_field_data', 'gc_fd')
+      ->fields('gc_fd', ['gid'])
+      ->condition('gc_fd.gid', $group->id())
+      ->condition('gc_fd.type', "{$group->bundle()}-group_membership");
+    $query_members->addExpression('COUNT(gc_fd.entity_id)', 'count');
+    return $query_members->execute()->fetchAssoc()['count'];
+  }
+
+  /**
+   * Calculates number of group comments to add to the statistics.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The Group entity.
+   *
+   * @return int
+   *   The number of comments in the group.
+   */
+  private function calculateGroupCommentsStatistics(GroupInterface $group) {
+    $comment_ctypes = [
+      "{$group->bundle()}-group_node-discussion",
+      "{$group->bundle()}-group_node-document",
+      "{$group->bundle()}-group_node-gallery",
+      "{$group->bundle()}-group_node-wiki_page",
+    ];
+    // Query to count number of comments.
+    $query_comments = $this->connection->select('group_content_field_data', 'gc_fd')
+      ->fields('gc_fd', ['gid'])
+      ->condition('gc_fd.gid', $group->id())
+      ->condition('gc_fd.type', $comment_ctypes, 'IN');
+    $query_comments->join('comment_field_data', 'c_fd', 'gc_fd.entity_id = c_fd.entity_id');
+    $query_comments->addExpression('COUNT(c_fd.entity_id)', 'count');
+    return $query_comments->execute()->fetchAssoc()['count'];
+  }
+
+  /**
+   * Calculates number of group files to add to the statistics.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The Group entity.
+   *
+   * @return int
+   *   The number of files in the group.
+   */
+  private function calculateGroupFilesStatistics(GroupInterface $group) {
+    // Initialize array of media target ids that will be used to count the
+    // number of files in group.
+    $media_target_ids = [];
+    // Array of media fields per group content where we want to count file
+    // statistics. Keyed by group content bundle.
+    $files_group_content_types = [
+      "{$group->bundle()}-group_node-document" => [
+        'field_document_media',
+      ],
+      "{$group->bundle()}-group_node-gallery" => [
+        'field_photos',
+      ],
+      "{$group->bundle()}-group_node-wiki_page" => [
+        'field_related_downloads',
+      ],
+    ];
+    // We want to count the number of files for each group content that
+    // contains media files. Note that we take into account multiple media
+    // reference fields.
+    foreach ($files_group_content_types as $ctype => $fields) {
+      foreach ($fields as $field_name) {
+        // Query to count number of files per group content + media fields.
+        $query_files = $this->connection->select('group_content_field_data', 'gc_fd')
+          ->fields('n_field', ["{$field_name}_target_id"])
+          ->condition('gc_fd.gid', $group->id())
+          ->condition('gc_fd.type', $ctype, 'IN');
+
+        // We discard medias that already been counted.
+        if (!empty($media_target_ids)) {
+          $query_files->condition("n_field.{$field_name}_target_id", $media_target_ids, 'NOT IN');
+        }
+
+        $query_files->join("node__{$field_name}", 'n_field', 'gc_fd.entity_id = n_field.entity_id');
+        $query_files->groupBy("n_field.{$field_name}_target_id");
+        $target_ids = $query_files->execute()->fetchAll();
+
+        // We save the media target ids returned by the query so we skip those
+        // in the next queries.
+        if (!empty($target_ids)) {
+          foreach ($target_ids as $target_id) {
+            $field_name_target_id = "{$field_name}_target_id";
+            $media_target_ids[] = $target_id->$field_name_target_id;
+          }
+        }
+      }
+    }
+    return count($media_target_ids);
+  }
+
+  /**
+   * Calculates number of group events to add to the statistics.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The Group entity.
+   *
+   * @return int
+   *   The number of comments in the group.
+   */
+  private function calculateGroupEventsStatistics(GroupInterface $group) {
+    // @todo Implement logic once we have the group type Event available.
+    return 0;
+  }
+
 }

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorage.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorage.php
@@ -100,7 +100,7 @@ class GroupStatisticsStorage implements GroupStatisticsStorageInterface {
       return FALSE;
     }
 
-    return new GroupStatistic(
+    return new GroupStatistics(
       $result['gid'],
       $result['members'],
       $result['comments'],

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorage.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorage.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\eic_group_statistics;
 
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Database\Connection;
 use Drupal\group\Entity\GroupInterface;
 
@@ -47,6 +48,9 @@ class GroupStatisticsStorage implements GroupStatisticsStorageInterface {
         $query->fields([$statistic_type => 1])
           ->expression($statistic_type, "[$statistic_type] + :count", [':count' => $count])
           ->execute();
+
+        // Invalidate group cache tags.
+        Cache::invalidateTags($group->getCacheTagsToInvalidate());
         break;
 
     }
@@ -72,6 +76,9 @@ class GroupStatisticsStorage implements GroupStatisticsStorageInterface {
         $query->fields([$statistic_type => 1])
           ->expression($statistic_type, "[$statistic_type] - :count", [':count' => $count])
           ->execute();
+
+        // Invalidate group cache tags.
+        Cache::invalidateTags($group->getCacheTagsToInvalidate());
         break;
 
     }
@@ -84,6 +91,9 @@ class GroupStatisticsStorage implements GroupStatisticsStorageInterface {
     $this->connection->delete('eic_group_statistics')
       ->condition('gid', $group->id())
       ->execute();
+
+    // Invalidate group cache tags.
+    Cache::invalidateTags($group->getCacheTagsToInvalidate());
   }
 
   /**

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorageInterface.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorageInterface.php
@@ -67,8 +67,8 @@ interface GroupStatisticsStorageInterface {
    * @param \Drupal\group\Entity\GroupInterface $group
    *   The Group entity.
    *
-   * @return \Drupal\eic_group_statistics\GroupStatistic|bool
-   *   The GroupStatistic object or FALSE if not found.
+   * @return \Drupal\eic_group_statistics\GroupStatistics|bool
+   *   The GroupStatistics object or FALSE if not found.
    */
   public function load(GroupInterface $group);
 

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorageInterface.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorageInterface.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Drupal\eic_group_statistics;
+
+use Drupal\group\Entity\GroupInterface;
+
+/**
+ * Provides an interface defining Group Statistics Storage.
+ */
+interface GroupStatisticsStorageInterface {
+
+  /**
+   * Database column name for group members counter.
+   */
+  const STAT_TYPE_MEMBERS = 'members';
+
+  /**
+   * Database column name for group comments counter.
+   */
+  const STAT_TYPE_COMMENTS = 'comments';
+
+  /**
+   * Database column name for group files counter.
+   */
+  const STAT_TYPE_FILES = 'files';
+
+  /**
+   * Database column name for group events counter.
+   */
+  const STAT_TYPE_EVENTS = 'events';
+
+  /**
+   * Increments counter for a certain statistic type.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The Group entity.
+   * @param string $statistic_type
+   *   The type of statistic to increment the counter.
+   * @param int $count
+   *   (optional) The increment number to add to the statistic. Defaults to 1.
+   */
+  public function increment(GroupInterface $group, $statistic_type, $count = 1);
+
+  /**
+   * Decrements counter for a certain statistic type.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The Group entity.
+   * @param string $statistic_type
+   *   The type of statistic to increment the counter.
+   * @param int $count
+   *   (optional) The increment number to add to the statistic. Defaults to 1.
+   */
+  public function decrement(GroupInterface $group, $statistic_type, $count = 1);
+
+  /**
+   * Delete all statistics for a given group.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The Group entity.
+   */
+  public function deleteGroupStatistics(GroupInterface $group);
+
+  /**
+   * Loads statistics of a given group.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The Group entity.
+   */
+  public function load(GroupInterface $group);
+
+}

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorageInterface.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorageInterface.php
@@ -67,8 +67,8 @@ interface GroupStatisticsStorageInterface {
    * @param \Drupal\group\Entity\GroupInterface $group
    *   The Group entity.
    *
-   * @return \Drupal\eic_group_statistics\GroupStatistics|bool
-   *   The GroupStatistics object or FALSE if not found.
+   * @return \Drupal\eic_group_statistics\GroupStatistics
+   *   A GroupStatistics object containing all the group statistics.
    */
   public function load(GroupInterface $group);
 

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorageInterface.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorageInterface.php
@@ -72,4 +72,23 @@ interface GroupStatisticsStorageInterface {
    */
   public function load(GroupInterface $group);
 
+  /**
+   * Sets group statistics given a GroupStatistics object.
+   *
+   * @param \Drupal\eic_group_statistics\GroupStatistics $group_statistics
+   *   The GroupStatistics object.
+   */
+  public function setGroupStatistics(GroupStatistics $group_statistics);
+
+  /**
+   * Calculates all statistics for a given group.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The Group entity.
+   *
+   * @return \Drupal\eic_group_statistics\GroupStatistics
+   *   A GroupStatistics object containing all the group statistics.
+   */
+  public function calculateGroupStatistics(GroupInterface $group);
+
 }

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorageInterface.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorageInterface.php
@@ -10,26 +10,6 @@ use Drupal\group\Entity\GroupInterface;
 interface GroupStatisticsStorageInterface {
 
   /**
-   * Database column name for group members counter.
-   */
-  const STAT_TYPE_MEMBERS = 'members';
-
-  /**
-   * Database column name for group comments counter.
-   */
-  const STAT_TYPE_COMMENTS = 'comments';
-
-  /**
-   * Database column name for group files counter.
-   */
-  const STAT_TYPE_FILES = 'files';
-
-  /**
-   * Database column name for group events counter.
-   */
-  const STAT_TYPE_EVENTS = 'events';
-
-  /**
    * Increments counter for a certain statistic type.
    *
    * @param \Drupal\group\Entity\GroupInterface $group

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorageInterface.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorageInterface.php
@@ -66,6 +66,9 @@ interface GroupStatisticsStorageInterface {
    *
    * @param \Drupal\group\Entity\GroupInterface $group
    *   The Group entity.
+   *
+   * @return \Drupal\eic_group_statistics\GroupStatistic|bool
+   *   The GroupStatistic object or FALSE if not found.
    */
   public function load(GroupInterface $group);
 

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorageInterface.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorageInterface.php
@@ -81,6 +81,14 @@ interface GroupStatisticsStorageInterface {
   public function setGroupStatistics(GroupStatistics $group_statistics);
 
   /**
+   * Sets group statistics given multiple GroupStatistics objects.
+   *
+   * @param \Drupal\eic_group_statistics\GroupStatistics[] $groups_statistics
+   *   The array of GroupStatistics objects.
+   */
+  public function setMultipleGroupStatistics(array $groups_statistics);
+
+  /**
    * Calculates all statistics for a given group.
    *
    * @param \Drupal\group\Entity\GroupInterface $group

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/Hooks/EntityOperations.php
@@ -111,6 +111,8 @@ class EntityOperations implements ContainerInjectionInterface {
 
         $medias = [];
 
+        // @todo In the future we should consider configuring which fields to
+        // use via config entity and using an administration form.
         $media_fields = [
           'field_document_media',
           'field_photos',
@@ -215,6 +217,8 @@ class EntityOperations implements ContainerInjectionInterface {
       case 'gallery':
         $medias = [];
 
+        // @todo In the future we should consider configuring which fields to
+        // use via config entity and using an administration form.
         $media_fields = [
           'field_document_media',
           'field_photos',
@@ -284,6 +288,8 @@ class EntityOperations implements ContainerInjectionInterface {
         $old_medias = [];
         $medias = [];
 
+        // @todo In the future we should consider configuring which fields to
+        // use via config entity and using an administration form.
         $media_fields = [
           'field_document_media',
           'field_photos',

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/Hooks/EntityOperations.php
@@ -269,8 +269,8 @@ class EntityOperations implements ContainerInjectionInterface {
         }
       }
 
-      // At this point, it means the media is not being referenced more than
-      // once which means we can increment the counter.
+      // At this point, it means the media is not being referenced anywhere
+      // which means we can increment the counter.
       $count_updates++;
     }
 

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/Hooks/EntityOperations.php
@@ -101,6 +101,7 @@ class EntityOperations implements ContainerInjectionInterface {
         $this->groupStatisticsStorage->increment($group, GroupStatisticsStorageInterface::STAT_TYPE_MEMBERS);
         break;
 
+      case 'group-group_node-discussion':
       case 'group-group_node-document':
       case 'group-group_node-wiki_page':
       case 'group-group_node-gallery':
@@ -111,8 +112,9 @@ class EntityOperations implements ContainerInjectionInterface {
 
         $media_fields = [
           'field_document_media',
-          'field_related_downloads',
           'field_photos',
+          'field_related_downloads',
+          'field_related_documents',
         ];
         foreach ($media_fields as $field_name) {
           if ($node->hasField($field_name)) {
@@ -206,6 +208,7 @@ class EntityOperations implements ContainerInjectionInterface {
     $re_index = TRUE;
 
     switch ($entity->bundle()) {
+      case 'discussion':
       case 'document':
       case 'wiki_page':
       case 'gallery':
@@ -213,8 +216,9 @@ class EntityOperations implements ContainerInjectionInterface {
 
         $media_fields = [
           'field_document_media',
-          'field_related_downloads',
           'field_photos',
+          'field_related_downloads',
+          'field_related_documents',
         ];
         foreach ($media_fields as $field_name) {
           if ($entity->hasField($field_name)) {
@@ -272,6 +276,7 @@ class EntityOperations implements ContainerInjectionInterface {
     $re_index = TRUE;
 
     switch ($entity->bundle()) {
+      case 'discussion':
       case 'document':
       case 'wiki_page':
       case 'gallery':
@@ -280,8 +285,9 @@ class EntityOperations implements ContainerInjectionInterface {
 
         $media_fields = [
           'field_document_media',
-          'field_related_downloads',
           'field_photos',
+          'field_related_downloads',
+          'field_related_documents',
         ];
         foreach ($media_fields as $field_name) {
           if ($entity->hasField($field_name)) {

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/Hooks/EntityOperations.php
@@ -1,0 +1,241 @@
+<?php
+
+namespace Drupal\eic_group_statistics\Hooks;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\eic_group_statistics\GroupStatisticsSearchApiReindex;
+use Drupal\eic_group_statistics\GroupStatisticsStorageInterface;
+use Drupal\group\Entity\GroupInterface;
+use Drupal\node\NodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class EntityOperations.
+ *
+ * Implementations of entity hooks.
+ */
+class EntityOperations implements ContainerInjectionInterface {
+
+  /**
+   * The Group statistics storage.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The Group statistics storage.
+   *
+   * @var \Drupal\eic_group_statistics\GroupStatisticsStorageInterface
+   */
+  protected $groupStatisticsStorage;
+
+  /**
+   * The Group statistics search API Reindex service.
+   *
+   * @var \Drupal\eic_group_statistics\GroupStatisticsSearchApiReindex
+   */
+  protected $groupStatisticsSearchApiReindex;
+
+  /**
+   * Constructs a EntityOperation object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\eic_group_statistics\GroupStatisticsStorageInterface $group_statistics_storage
+   *   The Group statistics storage service.
+   * @param \Drupal\eic_group_statistics\GroupStatisticsSearchApiReindex $group_statistics_sear_api_reindex
+   *   The Group statistics search API Reindex service.
+   */
+  public function __construct(
+    EntityTypeManagerInterface $entity_type_manager,
+    GroupStatisticsStorageInterface $group_statistics_storage,
+    GroupStatisticsSearchApiReindex $group_statistics_sear_api_reindex
+  ) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->groupStatisticsStorage = $group_statistics_storage;
+    $this->groupStatisticsSearchApiReindex = $group_statistics_sear_api_reindex;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('eic_group_statistics.storage'),
+      $container->get('eic_group_statistics.search_api.reindex')
+    );
+  }
+
+  /**
+   * Implements hook_ENTITY_TYPE_insert() for group_content entities.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The group content entity object.
+   */
+  public function groupContentInsert(EntityInterface $entity) {
+    $group = $entity->getGroup();
+
+    $re_index = TRUE;
+
+    switch ($entity->bundle()) {
+      case 'group-group_membership':
+        $this->groupStatisticsStorage->increment($group, GroupStatisticsStorageInterface::STAT_TYPE_MEMBERS);
+        break;
+
+      case 'group-group_node-document':
+        /** @var \Drupal\node\NodeInterface $node */
+        $node = $entity->getEntity();
+
+        /** @var \Drupal\media\MediaInterface[] $medias */
+        $medias = $node->get('field_document_media')->referencedEntities();
+
+        // Update group file statistics.
+        if (!$this->updateGroupFileStatistics($group, $node, $medias)) {
+          $re_index = FALSE;
+        }
+        break;
+
+      default:
+        $re_index = FALSE;
+        break;
+
+    }
+
+    if (!$re_index) {
+      return;
+    }
+
+    // Re-index group statistics.
+    $this->groupStatisticsSearchApiReindex->reindexItem($group);
+  }
+
+  /**
+   * Implements hook_ENTITY_TYPE_delete() for group_content entities.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The group content entity object.
+   */
+  public function groupContentDelete(EntityInterface $entity) {
+    $group = $entity->getGroup();
+
+    $re_index = TRUE;
+
+    switch ($entity->bundle()) {
+      case 'group-group_membership':
+        $this->groupStatisticsStorage->decrement($group, GroupStatisticsStorageInterface::STAT_TYPE_MEMBERS);
+        break;
+
+      case 'group-group_node-document':
+        // @todo Decrement group file counter if there are no references.
+        break;
+
+      default:
+        $re_index = FALSE;
+        break;
+
+    }
+
+    if (!$re_index) {
+      return;
+    }
+
+    // Re-index group statistics.
+    $this->groupStatisticsSearchApiReindex->reindexItem($group);
+  }
+
+  /**
+   * Increments/decrements group file statistics for a given node.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group entity for which we want to increment file statistics.
+   * @param \Drupal\node\NodeInterface $node
+   *   The node entity that belongs to the group.
+   * @param \Drupal\media\MediaInterface[] $medias
+   *   Array of media entities that belong to the node.
+   * @param string $update_type
+   *   The update type: either "increment" or "decrement".
+   *
+   * @return bool
+   *   TRUE if the counter has been updated.
+   */
+  private function updateGroupFileStatistics(GroupInterface $group, NodeInterface $node, array $medias = [], $update_type = 'increment') {
+    $counter_updated = FALSE;
+
+    if (!in_array($update_type, ['increment', 'decrement'])) {
+      return $counter_updated;
+    }
+
+    if (!$medias) {
+      return $counter_updated;
+    }
+
+    foreach ($medias as $media) {
+      // @todo Replace \Drupal::service() with proper dependency injection.
+      $media_usage = \Drupal::service('entity_usage.usage')->listSources($media);
+
+      // If there is no media usage, we don't update file statistics.
+      if (!isset($media_usage['node'])) {
+        continue;
+      }
+
+      // If media is being referenced elsewhere, then we need to make sure it
+      // hasn't been referenced in this group before updating the file
+      // statistics.
+      if (count($media_usage['node']) > 1) {
+
+        // We discard the current node from the usage. We just want to know
+        // if the media is referenced in other nodes.
+        unset($media_usage['node'][$node->id()]);
+
+        // Load the source nodes.
+        $source_nodes = $this->entityTypeManager->getStorage('node')->loadMultiple(array_keys($media_usage['node']));
+
+        $duplicated_media = FALSE;
+
+        foreach ($source_nodes as $source_node) {
+          $group_contents = $this->entityTypeManager->getStorage('group_content')->loadByEntity($source_node);
+          $group_content = reset($group_contents);
+
+          // If the source node doesn't have any group content associated, we
+          // skip this one and check the remaining ones.
+          if (!$group_content) {
+            continue;
+          }
+
+          // If the source node belongs to the group, then we know this media
+          // is a duplicated one and we don't need to update the counter.
+          if ($group_content->getGroup()->id() === $group->id()) {
+            $duplicated_media = TRUE;
+            break;
+          }
+        }
+
+        if ($duplicated_media) {
+          continue;
+        }
+      }
+
+      // At this point, it means the media is not being referenced more than
+      // once which means we can update the counter.
+      switch ($update_type) {
+        case 'increment':
+          $this->groupStatisticsStorage->increment($group, GroupStatisticsStorageInterface::STAT_TYPE_FILES);
+          break;
+
+        case 'decrement':
+          $this->groupStatisticsStorage->decrement($group, GroupStatisticsStorageInterface::STAT_TYPE_FILES);
+          break;
+
+      }
+
+      $counter_updated = TRUE;
+    }
+
+    return $counter_updated;
+  }
+
+}

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/Hooks/EntityOperations.php
@@ -7,6 +7,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\eic_group_statistics\GroupStatisticsSearchApiReindex;
 use Drupal\eic_group_statistics\GroupStatisticsStorageInterface;
+use Drupal\eic_group_statistics\GroupStatisticTypes;
 use Drupal\entity_usage\EntityUsageInterface;
 use Drupal\group\Entity\GroupContentInterface;
 use Drupal\group\Entity\GroupInterface;
@@ -98,7 +99,7 @@ class EntityOperations implements ContainerInjectionInterface {
     switch ($entity->bundle()) {
       case 'group-group_membership':
         // Increments number of members in the group statistics.
-        $this->groupStatisticsStorage->increment($group, GroupStatisticsStorageInterface::STAT_TYPE_MEMBERS);
+        $this->groupStatisticsStorage->increment($group, GroupStatisticTypes::STAT_TYPE_MEMBERS);
         break;
 
       case 'group-group_node-discussion':
@@ -141,7 +142,7 @@ class EntityOperations implements ContainerInjectionInterface {
         }
 
         // Update group file statistics.
-        $this->groupStatisticsStorage->increment($group, GroupStatisticsStorageInterface::STAT_TYPE_FILES, $count);
+        $this->groupStatisticsStorage->increment($group, GroupStatisticTypes::STAT_TYPE_FILES, $count);
         break;
 
       default:
@@ -172,7 +173,7 @@ class EntityOperations implements ContainerInjectionInterface {
     switch ($entity->bundle()) {
       case 'group-group_membership':
         // Decrements number of members in the group statistics.
-        $this->groupStatisticsStorage->decrement($group, GroupStatisticsStorageInterface::STAT_TYPE_MEMBERS);
+        $this->groupStatisticsStorage->decrement($group, GroupStatisticTypes::STAT_TYPE_MEMBERS);
         break;
 
       default:
@@ -245,7 +246,7 @@ class EntityOperations implements ContainerInjectionInterface {
         }
 
         // Update group file statistics.
-        $this->groupStatisticsStorage->decrement($group, GroupStatisticsStorageInterface::STAT_TYPE_FILES, $count);
+        $this->groupStatisticsStorage->decrement($group, GroupStatisticTypes::STAT_TYPE_FILES, $count);
         break;
 
       default:
@@ -337,12 +338,12 @@ class EntityOperations implements ContainerInjectionInterface {
 
         // Increments group file statistics.
         if ($increment_count) {
-          $this->groupStatisticsStorage->increment($group, GroupStatisticsStorageInterface::STAT_TYPE_FILES, $increment_count);
+          $this->groupStatisticsStorage->increment($group, GroupStatisticTypes::STAT_TYPE_FILES, $increment_count);
         }
 
         // Decrements group file statistics.
         if ($decrement_count) {
-          $this->groupStatisticsStorage->decrement($group, GroupStatisticsStorageInterface::STAT_TYPE_FILES, $decrement_count);
+          $this->groupStatisticsStorage->decrement($group, GroupStatisticTypes::STAT_TYPE_FILES, $decrement_count);
         }
         break;
 

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/Plugin/search_api/processor/GroupStatisticsIndexer.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/Plugin/search_api/processor/GroupStatisticsIndexer.php
@@ -1,0 +1,242 @@
+<?php
+
+namespace Drupal\eic_group_statistics\Plugin\search_api\processor;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Plugin\PluginFormInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\eic_group_statistics\GroupStatistic;
+use Drupal\eic_group_statistics\GroupStatisticsStorageInterface;
+use Drupal\search_api\Datasource\DatasourceInterface;
+use Drupal\search_api\IndexInterface;
+use Drupal\search_api\Processor\ProcessorPluginBase;
+use Drupal\search_api\Processor\ProcessorProperty;
+use Drupal\search_api\SearchApiException;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\search_api\Item\ItemInterface;
+
+/**
+ * Search API Processor for indexing group statistics.
+ *
+ * @SearchApiProcessor(
+ *   id = "group_statistics_indexer",
+ *   label = @Translation("Group statistics indexing"),
+ *   description = @Translation("Switching on will enable indexing group
+ *   statistics"), stages = {
+ *     "add_properties" = 1,
+ *     "pre_index_save" = -10
+ *   }
+ * )
+ */
+class GroupStatisticsIndexer extends ProcessorPluginBase implements PluginFormInterface, ContainerFactoryPluginInterface {
+
+  /**
+   * Group statistics storage.
+   *
+   * @var \Drupal\eic_group_statistics\GroupStatisticsStorageInterface
+   */
+  protected $groupStatisticsStorage;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('eic_group_statistics.storage')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, array $plugin_definition, GroupStatisticsStorageInterface $group_statistics_storage) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->groupStatisticsStorage = $group_statistics_storage;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return [
+      'group_statistics_index' => [],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function supportsIndex(IndexInterface $index) {
+    foreach ($index->getDatasources() as $datasource) {
+      if ($datasource->getEntityTypeId() === 'group') {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * Get group statistic types.
+   *
+   * @return array
+   *   Array containing the type of group statistics group.
+   */
+  public function getGroupStatisticTypes() {
+    return [
+      GroupStatisticsStorageInterface::STAT_TYPE_MEMBERS => $this->t('Members'),
+      GroupStatisticsStorageInterface::STAT_TYPE_COMMENTS => $this->t('Comments'),
+      GroupStatisticsStorageInterface::STAT_TYPE_FILES => $this->t('Files'),
+      GroupStatisticsStorageInterface::STAT_TYPE_EVENTS => $this->t('Events'),
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $options = [];
+
+    $statistic_types = $this->getGroupStatisticTypes();
+    foreach ($statistic_types as $statistic_type => $statistic_label) {
+      $options[$statistic_type] = $statistic_label;
+    }
+
+    $form['group_statistics_index'] = [
+      '#type' => 'checkboxes',
+      '#title' => $this->t('Enable these group statistics on this index'),
+      '#description' => $this->t('This will index group statistics for every group'),
+      '#options' => $options,
+      '#default_value' => isset($this->configuration['group_statistics_index']) ? $this->configuration['group_statistics_index'] : [],
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateConfigurationForm(array &$form, FormStateInterface $form_state) {
+    $fields = array_filter($form_state->getValues()['group_statistics_index']);
+    if ($fields) {
+      $fields = array_keys($fields);
+    }
+    $form_state->setValue('group_statistics_index', $fields);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+    $this->setConfiguration($form_state->getValues());
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPropertyDefinitions(DatasourceInterface $datasource = NULL) {
+    $properties = [];
+
+    if (!$datasource) {
+      // Ensure that our fields are defined.
+      $fields = $this->getFieldsDefinition();
+
+      foreach ($fields as $field_id => $field_definition) {
+        $properties[$field_id] = new ProcessorProperty($field_definition);
+      }
+    }
+    return $properties;
+  }
+
+  /**
+   * Helper function for defining our group statistic fields.
+   */
+  protected function getFieldsDefinition() {
+    $config = $this->configuration['group_statistics_index'];
+    $fields = [];
+    foreach ($config as $statistic_type) {
+      $label = $this->getGroupStatisticTypes()[$statistic_type];
+      $fields['group_statistic_' . $statistic_type] = [
+        'label' => $label,
+        'description' => $label,
+        'type' => 'integer',
+        'processor_id' => $this->getPluginId(),
+      ];
+    }
+    return $fields;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function addFieldValues(ItemInterface $item) {
+    $config = $this->configuration['group_statistics_index'];
+    $group_statistics = $this->getGroupStatisticTypes();
+
+    try {
+      $entity = $item->getOriginalObject()->getValue();
+
+      if ($entity->getEntityTypeId() !== 'group') {
+        return;
+      }
+
+      $group_statistics = $this->groupStatisticsStorage->load($entity);
+
+      if (!$group_statistics) {
+        $group_statistics = new GroupStatistic($entity->id());
+      }
+
+      foreach ($config as $statistic_type) {
+        $fields = $this
+          ->getFieldsHelper()
+          ->filterForPropertyPath($item->getFields(), NULL, 'group_statistic_' . $statistic_type);
+
+        foreach ($fields as $group_statistic_field) {
+          switch (str_replace('group_statistic_', '', $group_statistic_field->getFieldIdentifier())) {
+            case GroupStatisticsStorageInterface::STAT_TYPE_MEMBERS:
+              // Adds number of group members to the indexed field.
+              $group_statistic_field->addValue($group_statistics->getMembersCount());
+              break;
+
+            case GroupStatisticsStorageInterface::STAT_TYPE_COMMENTS:
+              // Adds number of group comments to the indexed field.
+              $group_statistic_field->addValue($group_statistics->getCommentsCount());
+              break;
+
+            case GroupStatisticsStorageInterface::STAT_TYPE_FILES:
+              // Adds number of group files to the indexed field.
+              $group_statistic_field->addValue($group_statistics->getFilesCount());
+              break;
+
+            case GroupStatisticsStorageInterface::STAT_TYPE_EVENTS:
+              // Adds number of group events to the indexed field.
+              $group_statistic_field->addValue($group_statistics->getEventsCount());
+              break;
+
+          }
+        }
+      }
+    }
+    catch (SearchApiException $exception) {
+      $this->logger->error($exception->getMessage());
+    }
+
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function preIndexSave() {
+    foreach ($this->getFieldsDefinition() as $field_id => $field_definition) {
+      try {
+        $this->ensureField(NULL, $field_id, $field_definition['type']);
+      }
+      catch (SearchApiException $exception) {
+        $this->logger->error($exception->getMessage());
+      }
+    }
+  }
+
+}

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/Plugin/search_api/processor/GroupStatisticsIndexer.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/Plugin/search_api/processor/GroupStatisticsIndexer.php
@@ -5,7 +5,6 @@ namespace Drupal\eic_group_statistics\Plugin\search_api\processor;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Plugin\PluginFormInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\eic_group_statistics\GroupStatistics;
 use Drupal\eic_group_statistics\GroupStatisticsStorageInterface;
 use Drupal\search_api\Datasource\DatasourceInterface;
 use Drupal\search_api\IndexInterface;
@@ -183,10 +182,6 @@ class GroupStatisticsIndexer extends ProcessorPluginBase implements PluginFormIn
       }
 
       $group_statistics = $this->groupStatisticsStorage->load($entity);
-
-      if (!$group_statistics) {
-        $group_statistics = new GroupStatistics($entity->id());
-      }
 
       foreach ($config as $statistic_type) {
         $fields = $this

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/Plugin/search_api/processor/GroupStatisticsIndexer.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/Plugin/search_api/processor/GroupStatisticsIndexer.php
@@ -6,6 +6,7 @@ use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Plugin\PluginFormInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\eic_group_statistics\GroupStatisticsStorageInterface;
+use Drupal\eic_group_statistics\GroupStatisticTypes;
 use Drupal\search_api\Datasource\DatasourceInterface;
 use Drupal\search_api\IndexInterface;
 use Drupal\search_api\Processor\ProcessorPluginBase;
@@ -85,10 +86,10 @@ class GroupStatisticsIndexer extends ProcessorPluginBase implements PluginFormIn
    */
   public function getGroupStatisticTypes() {
     return [
-      GroupStatisticsStorageInterface::STAT_TYPE_MEMBERS => $this->t('Members'),
-      GroupStatisticsStorageInterface::STAT_TYPE_COMMENTS => $this->t('Comments'),
-      GroupStatisticsStorageInterface::STAT_TYPE_FILES => $this->t('Files'),
-      GroupStatisticsStorageInterface::STAT_TYPE_EVENTS => $this->t('Events'),
+      GroupStatisticTypes::STAT_TYPE_MEMBERS => $this->t('Members'),
+      GroupStatisticTypes::STAT_TYPE_COMMENTS => $this->t('Comments'),
+      GroupStatisticTypes::STAT_TYPE_FILES => $this->t('Files'),
+      GroupStatisticTypes::STAT_TYPE_EVENTS => $this->t('Events'),
     ];
   }
 
@@ -190,22 +191,22 @@ class GroupStatisticsIndexer extends ProcessorPluginBase implements PluginFormIn
 
         foreach ($fields as $group_statistic_field) {
           switch (str_replace('group_statistic_', '', $group_statistic_field->getFieldIdentifier())) {
-            case GroupStatisticsStorageInterface::STAT_TYPE_MEMBERS:
+            case GroupStatisticTypes::STAT_TYPE_MEMBERS:
               // Adds number of group members to the indexed field.
               $group_statistic_field->addValue($group_statistics->getMembersCount());
               break;
 
-            case GroupStatisticsStorageInterface::STAT_TYPE_COMMENTS:
+            case GroupStatisticTypes::STAT_TYPE_COMMENTS:
               // Adds number of group comments to the indexed field.
               $group_statistic_field->addValue($group_statistics->getCommentsCount());
               break;
 
-            case GroupStatisticsStorageInterface::STAT_TYPE_FILES:
+            case GroupStatisticTypes::STAT_TYPE_FILES:
               // Adds number of group files to the indexed field.
               $group_statistic_field->addValue($group_statistics->getFilesCount());
               break;
 
-            case GroupStatisticsStorageInterface::STAT_TYPE_EVENTS:
+            case GroupStatisticTypes::STAT_TYPE_EVENTS:
               // Adds number of group events to the indexed field.
               $group_statistic_field->addValue($group_statistics->getEventsCount());
               break;

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/Plugin/search_api/processor/GroupStatisticsIndexer.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/Plugin/search_api/processor/GroupStatisticsIndexer.php
@@ -85,12 +85,7 @@ class GroupStatisticsIndexer extends ProcessorPluginBase implements PluginFormIn
    *   Array containing the type of group statistics group.
    */
   public function getGroupStatisticTypes() {
-    return [
-      GroupStatisticTypes::STAT_TYPE_MEMBERS => $this->t('Members'),
-      GroupStatisticTypes::STAT_TYPE_COMMENTS => $this->t('Comments'),
-      GroupStatisticTypes::STAT_TYPE_FILES => $this->t('Files'),
-      GroupStatisticTypes::STAT_TYPE_EVENTS => $this->t('Events'),
-    ];
+    return GroupStatisticTypes::getOptionsArray();
   }
 
   /**

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/Plugin/search_api/processor/GroupStatisticsIndexer.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/Plugin/search_api/processor/GroupStatisticsIndexer.php
@@ -5,7 +5,7 @@ namespace Drupal\eic_group_statistics\Plugin\search_api\processor;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Plugin\PluginFormInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\eic_group_statistics\GroupStatistic;
+use Drupal\eic_group_statistics\GroupStatistics;
 use Drupal\eic_group_statistics\GroupStatisticsStorageInterface;
 use Drupal\search_api\Datasource\DatasourceInterface;
 use Drupal\search_api\IndexInterface;
@@ -185,7 +185,7 @@ class GroupStatisticsIndexer extends ProcessorPluginBase implements PluginFormIn
       $group_statistics = $this->groupStatisticsStorage->load($entity);
 
       if (!$group_statistics) {
-        $group_statistics = new GroupStatistic($entity->id());
+        $group_statistics = new GroupStatistics($entity->id());
       }
 
       foreach ($config as $statistic_type) {

--- a/lib/themes/eic_community/includes/preprocess/blocks/block--eic-group-header-block.inc
+++ b/lib/themes/eic_community/includes/preprocess/blocks/block--eic-group-header-block.inc
@@ -39,7 +39,7 @@ function eic_community_preprocess_eic_group_header_block(array &$variables) {
   }
 
   foreach ($variables['group_values']['operation_links'] as $link) {
-    if(isset($link['links'])) {
+    if (isset($link['links'])) {
       $items = [];
 
       foreach ($link['links'] as $item) {
@@ -59,14 +59,15 @@ function eic_community_preprocess_eic_group_header_block(array &$variables) {
 
       $actions[] = [
         'label' => $link['label'],
-        'items' => $items
+        'items' => $items,
       ];
-    }else{
+    }
+    else {
       $tmp = [
         'link' => [
           'label' => $link['title'],
           'path' => $link['url'],
-        ]
+        ],
       ];
 
       if (isset($link['action'])) {
@@ -82,9 +83,10 @@ function eic_community_preprocess_eic_group_header_block(array &$variables) {
   $flags = [];
 
   foreach ($variables['group_values']['membership_links'] as $action) {
-    if(isset($action['#lazy_builder'])) {
+    if (isset($action['#lazy_builder'])) {
       $flag = ['content' => $action];
-    }else {
+    }
+    else {
       $icon_name = '';
 
       switch ($action['url']->getRouteName()) {
@@ -122,41 +124,49 @@ function eic_community_preprocess_eic_group_header_block(array &$variables) {
   }
 
   $variables['group_values']['flags'] = $flags;
-  // @todo Make statistics dynamic.
-  $variables['group_values']['stats'] = [
-    [
+
+  // Prepare group statistics values to send to the template.
+  $stats = [];
+  foreach ($variables['group_values']['stats'] as $stat_type => $statistic) {
+    switch ($stat_type) {
+      case 'members':
+        $icon_name = 'user';
+        $label = t('Users');
+        break;
+
+      case 'comments':
+        $icon_name = 'comment';
+        $label = t('Comments');
+        break;
+
+      case 'files':
+        $icon_name = 'documents';
+        $label = t('Documents');
+        break;
+
+      case 'events':
+        $icon_name = 'calendar';
+        $label = t('Calendar');
+        break;
+
+      default:
+        $icon_name = '';
+        $label = '';
+        break;
+
+    }
+
+    $stats[] = [
       'icon' => [
-        'name' => 'user',
+        'name' => $icon_name,
         'type' => 'custom',
       ],
-      'label' => 'user',
-      'value' => 0,
-    ],
-    [
-      'icon' => [
-        'name' => 'comment',
-        'type' => 'custom',
-      ],
-      'label' => 'comment',
-      'value' => 0,
-    ],
-    [
-      'icon' => [
-        'name' => 'documents',
-        'type' => 'custom',
-      ],
-      'label' => 'documents',
-      'value' => 0,
-    ],
-    [
-      'icon' => [
-        'name' => 'calendar',
-        'type' => 'custom',
-      ],
-      'label' => 'calendar',
-      'value' => 0,
-    ],
-  ];
+      'label' => $label,
+      'value' => $statistic,
+    ];
+  }
+
+  $variables['group_values']['stats'] = $stats;
 
   $group_visibility = \Drupal::service('oec_group_flex.helper')->getGroupVisibilitySettings($group);
   $tag = strpos($group_visibility['plugin_id'], '_') !== FALSE ? strstr($group_visibility['plugin_id'], '_', TRUE) : $group_visibility['plugin_id'];


### PR DESCRIPTION
### Features

- Instal module entity_usage;
- Create module eic_group_statistics;
- Create new custom schema for saving group statistics;
- Implement statistics counter for group members, comments and files (discussion, document, wiki page and gallery files);
- Delete group statistics when group is deleted;
- Update group statistics when installing the module.
- Index group statistics in SOLR.

### Tests

- [x] Create a new group and publish it
- [x] Check there is only 1 member in the group statistics
- [x] Add a discussion and insert multiple comments.
- [x] Check if the number of comments match the ones shown in the group header;
- [x] Create 2 documents with the same media;
- [x] Create another document with a different media from the previous ones.
- [x] Check if the number of documents shown in the group header is 2 (because 2 documents use the same media so we count as 1)
- [x] Change the last created document and reference the same media used in the other 2.
- [x] Check the group statistics in the group header and make sure the number of files is 1.

### Missing

- Create a cron job to update all group statistics everyday.