### PR TITLE
EICNET-1106: Hide comment reply button when link is not present.

### DIFF
--- a/lib/themes/eic_community/patterns/compositions/comment/comment-base.html.twig
+++ b/lib/themes/eic_community/patterns/compositions/comment/comment-base.html.twig
@@ -174,6 +174,7 @@
         {% if user and comment_id %}
           <div class="ecl-comment__actions-wrapper">
             <div class="ecl-comment__actions">
+              {% if reply_path %}
               <div class="ecl-comment__action">
                 {% include "@ecl-twig/ec-component-link/ecl-link.html.twig" with {
                   link: {
@@ -184,6 +185,7 @@
                   extra_attributes: action_attributes,
                 } %}
               </div>
+              {% endif %}
               <div class="ecl-comment__action">
                 {{ flag_link }}
               </div>


### PR DESCRIPTION
Test:

* Login with admin
* Create group
* Publish the group
* Create topic and region taxonomy term
* Go to the group
* Create a discussion with a comment
* **You should see a reply link on the comment**
* Create a user with the role; trusted user
* Switch to the user
* Go to the group discussion
* **You should see no reply link on the comment**

