### PR TITLE
Bugfix/EICNET-1055: Fix group header flags

### DIFF
--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -301,7 +301,15 @@ function eic_groups_flagging_access(EntityInterface $entity, $operation, Account
         $access = AccessResult::forbidden()
           ->addCacheableDependency($entity)
           ->addCacheableDependency($flagged_entity);
+        break;
       }
+
+      $flag_permission = "$operation {$entity->getFlagId()}";
+
+      // Allow access if user has flag permissions for the current operation.
+      $access = AccessResult::allowedIfHasPermission($account, $flag_permission)
+        ->addCacheableDependency($entity)
+        ->addCacheableDependency($flagged_entity);
       break;
 
   }
@@ -339,7 +347,7 @@ function eic_groups_entity_operation_alter(array &$operations, EntityInterface $
 }
 
 /**
- * Implements hook_preprocess_block__HOOK
+ * Implements hook_preprocess_block__HOOK().
  */
 function eic_groups_preprocess_block__group_content_menu(&$variables) {
   $block_manager = \Drupal::service('plugin.manager.block');

--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
@@ -314,7 +314,7 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
     // access to.
     foreach (array_keys($group->flags) as $flag_name) {
       $flag = $this->flagService->getFlagById(str_replace('flag_', '', $flag_name));
-      $user_flag = $this->flagService->getFlagging($flag, $group, $this->currentUser->getAccount());
+      $user_flag = $this->flagService->getFlagging($flag, $group);
 
       // We need to create a fake flag if the user never flagged the content,
       // otherwise we can't do an access check.


### PR DESCRIPTION
### Fixes

- Fix PHP error when showing group header flags for anonymous users.
- Flagging access check that was preventing users from viewing group flags when group is published.

### Tests

- [ ] Make sure tests from #369 are passing;
- [ ] Create a new public group and publish it;
- [ ] As an anonymous user try to access the group homepage and check if the flag **"Recommend this item"** is shown and you can flag/unflag
- [ ] As an trusted user and non-member, try to access the group homepage and check if the flags **"Follow this item"** and **"Recommend this item"** are shown and you can flag/unflag