### PR TITLE
[EICNET-1137] fix: add a cache tag for group content

### DIFF
--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -41,8 +41,9 @@ function eic_groups_theme($existing, $type, $theme, $path) {
         'edit_link' => NULL,
         'delete_link' => NULL,
         'invite_link' => NULL,
-        'actions' => NULL,
+        'actions' => [],
         'has_content' => NULL,
+        'has_member' => FALSE,
       ],
     ],
     'eic_group_search_menu_block_form' => [

--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupOverviewMessageBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupOverviewMessageBlock.php
@@ -100,6 +100,9 @@ class EICGroupOverviewMessageBlock extends BlockBase implements ContainerFactory
     $cacheable_metadata->setCacheContexts([
       'user.group_permissions',
     ]);
+    $cacheable_metadata->addCacheTags([
+      'group_content_list:group:' . $group->id(),
+    ]);
 
     $required_roles = [EICGroupsHelper::GROUP_OWNER_ROLE];
     $group_membership = $group->getMember($this->account);


### PR DESCRIPTION
### To test

- [ ] Create a group and make it published
- [ ] Invite a member with role admin or member
- [ ] The first block telling you to invite someone shouldn't be visible after