### PR TITLE
EICNET-1070: Improve - validation of URLs of social channels on the user profile

### DIFF
--- a/config/sync/context.context.group_global.yml
+++ b/config/sync/context.context.group_global.yml
@@ -22,7 +22,7 @@ conditions:
       group: '@group.group_route_context:group'
   route:
     id: route
-    routes: entity.user.canonical
+    routes: "entity.user.*\r\nprofile.user_page.*"
     negate: true
     uuid: df5ac6fd-1e86-44f6-9ff6-e46b4cfc36f1
     context_mapping: {  }

--- a/lib/modules/eic_user/src/Hooks/FieldWidgetOperations.php
+++ b/lib/modules/eic_user/src/Hooks/FieldWidgetOperations.php
@@ -54,6 +54,9 @@ class FieldWidgetOperations {
     // validation so that users don't need to figure out how to properly insert
     // their usernames.
     foreach ($form_state_values as $key => $value) {
+      // Make sure full URLs start with "www".
+      $value['link'] = str_replace('https://' . $value['social'], 'https://www.' . $value['social'], $value['link']);
+
       if ($value['social'] === $social_network_name) {
         $form_state_values[$key]['link'] = str_replace($social_network_base_url, '', $value['link']);
         break;


### PR DESCRIPTION
### Improvements

- Improve validation of social channels when "www" is notpresented in the link;
- Fix issue where group header block was shown in the user profile.

### Tests

- [x] Go to the user profile page `/user/1/member`
- [x] Try to copy twitter profile URL from twitter (without www), place in the twitter field and save it
- [x] Go back to the profile page and check if only the full URL go replaced by the username.