### PR TITLE
Bugfix/EICNET-1055: Fix regressions

### DIFF
--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
@@ -314,7 +314,7 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
     // access to.
     foreach (array_keys($group->flags) as $flag_name) {
       $flag = $this->flagService->getFlagById(str_replace('flag_', '', $flag_name));
-      $user_flag = $this->flagService->getFlagging($flag, $group, $this->currentUser->getAccount());
+      $user_flag = $this->flagService->getFlagging($flag, $group);
 
       // We need to create a fake flag if the user never flagged the content,
       // otherwise we can't do an access check.


### PR DESCRIPTION
### Regressions

- Fix PHP error when showing group header flags for anonymous users.

### Tests

- [ ] Create a new public group and publish it;
- [ ]  As an anonymous user try to access the group homepage and check if the flag "Recommend this item" is shown and you can flag/unflag
- [ ]  As an trusted user and non-member, try to access the group homepage and check if the flags "Follow this item" and "Recommend this item" are shown and you can flag/unflag