### PR TITLE
[EICNET-962] chore: As a GO I want to choose a URL alias for my group

### DIFF
--- a/config/sync/core.entity_form_display.group.group.default.yml
+++ b/config/sync/core.entity_form_display.group.group.default.yml
@@ -17,6 +17,7 @@ dependencies:
   module:
     - content_moderation
     - media_library
+    - path
     - text
 id: group.group.default
 targetEntityType: group
@@ -26,11 +27,11 @@ content:
   features:
     type: options_buttons
     settings: {  }
-    weight: 12
+    weight: 11
     region: content
     third_party_settings: {  }
   field_body:
-    weight: 5
+    weight: 4
     settings:
       rows: 5
       placeholder: ''
@@ -39,13 +40,13 @@ content:
     region: content
   field_hero:
     type: media_library_widget
-    weight: 4
+    weight: 3
     settings:
       media_types: {  }
     third_party_settings: {  }
     region: content
   field_message_to_site_admin:
-    weight: 10
+    weight: 9
     settings:
       rows: 5
       placeholder: ''
@@ -53,7 +54,7 @@ content:
     type: text_textarea
     region: content
   field_related_groups:
-    weight: 6
+    weight: 5
     settings:
       match_operator: CONTAINS
       match_limit: 10
@@ -63,7 +64,7 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_related_news_stories:
-    weight: 7
+    weight: 6
     settings:
       match_operator: CONTAINS
       match_limit: 10
@@ -74,22 +75,12 @@ content:
     region: content
   field_thumbnail:
     type: media_library_widget
-    weight: 3
+    weight: 2
     settings:
       media_types: {  }
     third_party_settings: {  }
     region: content
   field_vocab_geo:
-    weight: 9
-    settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
-  field_vocab_topics:
     weight: 8
     settings:
       match_operator: CONTAINS
@@ -99,8 +90,18 @@ content:
     third_party_settings: {  }
     type: entity_reference_autocomplete
     region: content
+  field_vocab_topics:
+    weight: 7
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
   field_welcome_message:
-    weight: 11
+    weight: 10
     settings:
       rows: 5
       placeholder: ''
@@ -122,24 +123,29 @@ content:
     third_party_settings: {  }
   langcode:
     type: language_select
-    weight: 2
+    weight: 1
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 14
+    weight: 12
     settings: {  }
     region: content
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 13
+    region: content
+    settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 15
+    weight: 14
     region: content
     third_party_settings: {  }
 hidden:
-  path: true
   uid: true


### PR DESCRIPTION
Enable the URL alias field for groups in the form display to use the already existing config

### To Test

- [ ] Go to the edit form of a group
- [ ] You should see the 'URL alias' tab below revisions
