### PR TITLE
EICNET-1130: Remove the helptext shown on the LinkedIn field on a member profile

### DIFF
--- a/lib/modules/eic_user/src/Hooks/FieldWidgetOperations.php
+++ b/lib/modules/eic_user/src/Hooks/FieldWidgetOperations.php
@@ -3,7 +3,6 @@
 namespace Drupal\eic_user\Hooks;
 
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\StringTranslation\StringTranslationTrait;
 
 /**
  * Class FieldWidgetOperations.
@@ -12,8 +11,6 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
  */
 class FieldWidgetOperations {
 
-  use StringTranslationTrait;
-
   /**
    * Implements hook_field_widget_social_links_form_alter().
    */
@@ -21,14 +18,6 @@ class FieldWidgetOperations {
     $form_build_info = $form_state->getBuildInfo();
 
     if ($form_build_info['base_form_id'] === 'profile_form') {
-      $selected_network = $element['social']['#default_value'];
-
-      // Adds custom helper texts needed to describe how to fill in certain
-      // social networks.
-      if (isset($this->getSocialLinksFieldDescriptions()[$selected_network])) {
-        $element['link']['#description'] = $this->getSocialLinksFieldDescriptions()[$selected_network];
-      }
-
       // Adds custom element validation to fix the social network links when
       // the user inserts the full url from the social network platform.
       $element['#element_validate'] = [
@@ -56,23 +45,18 @@ class FieldWidgetOperations {
     foreach ($form_state_values as $key => $value) {
       if ($value['social'] === $social_network_name) {
         $form_state_values[$key]['link'] = str_replace($social_network_base_url, '', $value['link']);
+
+        // Exception for LinkedIn since we need to prepend "in/" if missing.
+        if ($social_network_name === 'linkedin') {
+          if (substr($social_network_name, 0, 3) !== 'in/') {
+            $form_state_values[$key]['link'] = 'in/' . $form_state_values[$key]['link'];
+          }
+        }
         break;
       }
     }
 
     $form_state->setValue($field_name, $form_state_values);
-  }
-
-  /**
-   * Gets array of helper texts to help users fill in the social links field.
-   *
-   * @return array
-   *   Array of helper texts keyed by social network type.
-   */
-  public function getSocialLinksFieldDescriptions() {
-    return [
-      'linkedin' => $this->t('Insert your LinkedIn username in the following format: in/example-user-name.'),
-    ];
   }
 
 }

--- a/lib/modules/eic_user/src/Hooks/FieldWidgetOperations.php
+++ b/lib/modules/eic_user/src/Hooks/FieldWidgetOperations.php
@@ -45,11 +45,17 @@ class FieldWidgetOperations {
     foreach ($form_state_values as $key => $value) {
       if ($value['social'] === $social_network_name) {
         $form_state_values[$key]['link'] = str_replace($social_network_base_url, '', $value['link']);
+        $new_url = $form_state_values[$key]['link'];
 
         // Exception for LinkedIn since we need to prepend "in/" if missing.
         if ($social_network_name === 'linkedin') {
-          if (substr($form_state_values[$key]['link'], 0, 3) !== 'in/') {
-            $form_state_values[$key]['link'] = 'in/' . $form_state_values[$key]['link'];
+          // Remove backslash from the beginning if exists.
+          if (substr($form_state_values[$key]['link'], 0, 1) === '/') {
+            $new_url = substr($form_state_values[$key]['link'], 1);
+          }
+
+          if (substr($new_url, 0, 3) !== 'in/') {
+            $form_state_values[$key]['link'] = 'in/' . $new_url;
           }
         }
         break;

--- a/lib/modules/eic_user/src/Hooks/FieldWidgetOperations.php
+++ b/lib/modules/eic_user/src/Hooks/FieldWidgetOperations.php
@@ -48,7 +48,7 @@ class FieldWidgetOperations {
 
         // Exception for LinkedIn since we need to prepend "in/" if missing.
         if ($social_network_name === 'linkedin') {
-          if (substr($social_network_name, 0, 3) !== 'in/') {
+          if (substr($form_state_values[$key]['link'], 0, 3) !== 'in/') {
             $form_state_values[$key]['link'] = 'in/' . $form_state_values[$key]['link'];
           }
         }


### PR DESCRIPTION
### Improvements

Remove helper text from LinkedIn field and prepend string "in/" if missing from the values.

### Tests

- [ ] Go to the profile form of the user 1 -> `/user/1/member`;
- [ ] Make sure the LinkedIn field doesn't have any helper text;
- [ ] Try to add a LinkedIn profile without the "in/" like `https://www.linkedin.com/bernardo-paulino-425954ab`. Save it, go back to the form and make sure the value is shown as `in/bernardo-paulino-425954ab`