### PR TITLE
EICNET-1134: Rename the admin role to "Drupal admin"

### DIFF
--- a/config/sync/group.role.group-a416e6833.yml
+++ b/config/sync/group.role.group-a416e6833.yml
@@ -8,7 +8,7 @@ dependencies:
     config:
       - user.role.administrator
 id: group-a416e6833
-label: Administrator
+label: 'Drupal admin'
 weight: 2
 internal: true
 audience: outsider

--- a/config/sync/user.role.administrator.yml
+++ b/config/sync/user.role.administrator.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: administrator
-label: Administrator
+label: 'Drupal admin'
 weight: -4
 is_admin: true
 permissions: {  }


### PR DESCRIPTION
### Improvements

- Rename drupal admin role to "Drupal admin".