### PR TITLE
[EICNET-1150] Backend - Empty Contributor paragraph added by default

### DIFF
--- a/config/sync/core.entity_form_display.node.story.default.yml
+++ b/config/sync/core.entity_form_display.node.story.default.yml
@@ -121,7 +121,7 @@ content:
       edit_mode: open
       add_mode: dropdown
       form_display_mode: default
-      default_paragraph_type: ''
+      default_paragraph_type: _none
     third_party_settings: {  }
     region: content
   field_video:


### PR DESCRIPTION
### To Test

- [x]  Go to /node/add/story
- [x] Fill in required fields and save
- [x] You should not have an empty contributors block in the sidebar