### PR TITLE
[EICNET-580]feature: As a group member I want to view the group member overview

### DIFF
--- a/lib/modules/eic_search/src/Plugin/Block/SearchOverviewBlock.php
+++ b/lib/modules/eic_search/src/Plugin/Block/SearchOverviewBlock.php
@@ -162,7 +162,7 @@ class SearchOverviewBlock extends BlockBase implements ContainerFactoryPluginInt
       '#enable_search' => $this->configuration['enable_search'],
       '#url' => Url::fromRoute('eic_groups.solr_search')->toString(),
       '#isAnonymous' => \Drupal::currentUser()->isAnonymous(),
-      '#currentGroup' => $current_group_route,
+      '#currentGroup' => $current_group_route->id(),
       '#translations' => [
         'public' => $this->t('Public', [], ['context' => 'eic_group']),
         'private' => $this->t('Private', [], ['context' => 'eic_group']),
@@ -216,6 +216,10 @@ class SearchOverviewBlock extends BlockBase implements ContainerFactoryPluginInt
   public function blockSubmit($form, FormStateInterface $form_state) {
     parent::blockSubmit($form, $form_state);
     $values = $form_state->getValues();
+
+    if (!array_key_exists('search', $values)) {
+      return;
+    }
 
     //First reset values
     $this->configuration['facets'] = [];
@@ -324,15 +328,15 @@ class SearchOverviewBlock extends BlockBase implements ContainerFactoryPluginInt
           ],
         ],
       ];
-    }
 
-    if ($source->ableToPrefilteredByGroup()) {
-      $form['search']['configuration']['prefilter_group'] = [
-        '#type' => 'checkbox',
-        '#default_value' => $this->configuration['prefilter_group'],
-        '#title' => $this->t('Prefilter the overview by group', [], ['context' => 'eic_search']),
-        '#description' => $this->t('It will prefiltered the overview with the current group from page', [], ['context' => 'eic_search']),
-      ];
+      if ($source->ableToPrefilteredByGroup()) {
+        $form['search']['configuration']['prefilter_group'] = [
+          '#type' => 'checkbox',
+          '#default_value' => $this->configuration['prefilter_group'],
+          '#title' => $this->t('Prefilter the overview by group', [], ['context' => 'eic_search']),
+          '#description' => $this->t('It will prefiltered the overview with the current group from page', [], ['context' => 'eic_search']),
+        ];
+      }
     }
   }
 

--- a/lib/modules/eic_search/src/Plugin/Block/SearchOverviewBlock.php
+++ b/lib/modules/eic_search/src/Plugin/Block/SearchOverviewBlock.php
@@ -13,6 +13,7 @@ use Drupal\eic_groups\EICGroupsHelper;
 use Drupal\eic_search\Collector\SourcesCollector;
 use Drupal\eic_search\Search\Sources\GroupSourceType;
 use Drupal\eic_search\Search\Sources\SourceTypeInterface;
+use Drupal\group\Entity\GroupInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -162,7 +163,7 @@ class SearchOverviewBlock extends BlockBase implements ContainerFactoryPluginInt
       '#enable_search' => $this->configuration['enable_search'],
       '#url' => Url::fromRoute('eic_groups.solr_search')->toString(),
       '#isAnonymous' => \Drupal::currentUser()->isAnonymous(),
-      '#currentGroup' => $current_group_route->id(),
+      '#currentGroup' => $current_group_route instanceof GroupInterface ? $current_group_route->id() : NULL,
       '#translations' => [
         'public' => $this->t('Public', [], ['context' => 'eic_group']),
         'private' => $this->t('Private', [], ['context' => 'eic_group']),

--- a/lib/modules/eic_search/src/Search/Sources/GroupSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/GroupSourceType.php
@@ -81,7 +81,7 @@ class GroupSourceType implements SourceTypeInterface {
    * @inheritDoc
    */
   public function getLayoutTheme(): string {
-    return self::LAYOUT_COMPACT;
+    return self::LAYOUT_COLUMNS_COMPACT;
   }
 
   /**

--- a/lib/modules/eic_search/src/Search/Sources/SourceTypeInterface.php
+++ b/lib/modules/eic_search/src/Search/Sources/SourceTypeInterface.php
@@ -13,6 +13,8 @@ interface SourceTypeInterface {
 
   const LAYOUT_COLUMNS = 'columns';
 
+  const LAYOUT_COLUMNS_COMPACT = 'columns_compact';
+
   const LAYOUT_GLOBAL = 'global';
 
   /**

--- a/lib/themes/eic_community/react/components/Block/Overview/index.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/index.js
@@ -106,11 +106,15 @@ class Overview extends React.Component {
     let layoutClass = 'ecl-teaser-overview';
 
     if (this.props.layout === 'compact') {
-      layoutClass = 'ecl-teaser-overview ecl-teaser-overview--has-compact-layout group--';
+      layoutClass = 'ecl-teaser-overview ecl-teaser-overview--has-compact-layout';
     }
 
     if (this.props.layout === 'columns') {
       layoutClass = 'ecl-teaser-overview ecl-teaser-overview--has-columns';
+    }
+
+    if (this.props.layout === 'columns_compact') {
+      layoutClass = 'ecl-teaser-overview ecl-teaser-overview--has-compact-layout ecl-teaser-overview--has-columns';
     }
 
     return (

--- a/lib/themes/eic_community/react/components/Block/Overview/index.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/index.js
@@ -106,7 +106,7 @@ class Overview extends React.Component {
     let layoutClass = 'ecl-teaser-overview';
 
     if (this.props.layout === 'compact') {
-      layoutClass = 'ecl-teaser-overview--has-compact-layout group--';
+      layoutClass = 'ecl-teaser-overview ecl-teaser-overview--has-compact-layout group--';
     }
 
     if (this.props.layout === 'columns') {


### PR DESCRIPTION
Integrate a new configuration to handle the group context via the current route

How to test it :

- [x] Go to context page settings (/admin/structure/context)
- [x] Go to Group - Global and add the block EIC Search Overview
- [x] On the block configuration, select the member_list or member_gallery source and check the "prefilter group" (facets/sorts as you wish)
- [x] Go into a detail group
- [x] You will have your search with prefiltered content by the current group