### PR TITLE
Feature/eicnet 1143 activity stream checkbox node edit form

### DIFF
--- a/config/sync/core.entity_form_display.node.discussion.default.yml
+++ b/config/sync/core.entity_form_display.node.discussion.default.yml
@@ -27,12 +27,12 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 11
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
   field_body:
-    weight: 2
+    weight: 4
     settings:
       rows: 5
       placeholder: ''
@@ -40,20 +40,25 @@ content:
     type: text_textarea
     region: content
   field_comments:
-    weight: 101
+    weight: 20
     settings: {  }
     third_party_settings: {  }
     type: comment_default
     region: content
   field_discussion_type:
-    weight: 3
+    weight: 5
     settings: {  }
     third_party_settings: {  }
     type: options_select
     region: content
+  field_post_activity:
+    weight: 22
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_related_contributors:
     type: entity_reference_paragraphs
-    weight: 102
+    weight: 21
     settings:
       title: Paragraph
       title_plural: Paragraphs
@@ -64,7 +69,7 @@ content:
     third_party_settings: {  }
     region: content
   field_related_documents:
-    weight: 6
+    weight: 8
     settings:
       match_operator: CONTAINS
       match_limit: 10
@@ -74,7 +79,7 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_vocab_geo:
-    weight: 5
+    weight: 7
     settings:
       match_operator: CONTAINS
       match_limit: 10
@@ -84,7 +89,7 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_vocab_topics:
-    weight: 4
+    weight: 6
     settings:
       match_operator: CONTAINS
       match_limit: 10
@@ -95,20 +100,20 @@ content:
     region: content
   langcode:
     type: language_select
-    weight: 2
+    weight: 3
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 100
+    weight: 19
     settings: {  }
     region: content
     third_party_settings: {  }
   path:
     type: path
-    weight: 1
+    weight: 2
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -123,24 +128,24 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 8
+    weight: 10
     region: content
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 30
+    weight: 18
     region: content
     settings: {  }
     third_party_settings: {  }
   publish_state:
     type: scheduler_moderation
-    weight: 30
+    weight: 17
     region: content
     settings: {  }
     third_party_settings: {  }
   published_at:
     type: publication_date_timestamp
-    weight: 10
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -148,14 +153,14 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 7
+    weight: 9
     region: content
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 9
+    weight: 11
     region: content
     third_party_settings: {  }
   title:
@@ -168,7 +173,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 10
+    weight: 12
     settings:
       match_operator: CONTAINS
       size: 60
@@ -178,13 +183,13 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 30
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
   unpublish_state:
     type: scheduler_moderation
-    weight: 30
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.node.document.default.yml
+++ b/config/sync/core.entity_form_display.node.document.default.yml
@@ -23,12 +23,12 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 6
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
   field_body:
-    weight: 2
+    weight: 3
     settings:
       rows: 5
       placeholder: ''
@@ -36,13 +36,13 @@ content:
     type: text_textarea
     region: content
   field_comments:
-    weight: 101
+    weight: 18
     settings: {  }
     third_party_settings: {  }
     type: comment_default
     region: content
   field_document_media:
-    weight: 4
+    weight: 5
     settings:
       match_operator: CONTAINS
       match_limit: 10
@@ -51,8 +51,13 @@ content:
     third_party_settings: {  }
     type: entity_reference_autocomplete
     region: content
+  field_post_activity:
+    weight: 19
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_vocab_topics:
-    weight: 3
+    weight: 4
     settings: {  }
     third_party_settings: {  }
     type: options_select
@@ -66,13 +71,13 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 100
+    weight: 17
     settings: {  }
     region: content
     third_party_settings: {  }
   path:
     type: path
-    weight: 9
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -87,24 +92,24 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 7
+    weight: 8
     region: content
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 30
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }
   publish_state:
     type: scheduler_moderation
-    weight: 30
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
   published_at:
     type: publication_date_timestamp
-    weight: 10
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -112,14 +117,14 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 10
+    weight: 12
     region: content
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 8
+    weight: 9
     region: content
     third_party_settings: {  }
   title:
@@ -132,7 +137,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 6
     settings:
       match_operator: CONTAINS
       size: 60
@@ -142,13 +147,13 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 30
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }
   unpublish_state:
     type: scheduler_moderation
-    weight: 30
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.node.gallery.default.yml
+++ b/config/sync/core.entity_form_display.node.gallery.default.yml
@@ -25,12 +25,12 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 7
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
   field_body:
-    weight: 1
+    weight: 2
     settings:
       rows: 5
       placeholder: ''
@@ -38,20 +38,25 @@ content:
     type: text_textarea
     region: content
   field_comments:
-    weight: 18
+    weight: 19
     settings: {  }
     third_party_settings: {  }
     type: comment_default
     region: content
   field_photos:
     type: media_library_widget
-    weight: 4
+    weight: 5
     settings:
       media_types: {  }
     third_party_settings: {  }
     region: content
+  field_post_activity:
+    weight: 20
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_vocab_geo:
-    weight: 3
+    weight: 4
     settings:
       match_operator: CONTAINS
       match_limit: 10
@@ -61,7 +66,7 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_vocab_topics:
-    weight: 2
+    weight: 3
     settings:
       match_operator: CONTAINS
       match_limit: 10
@@ -72,20 +77,20 @@ content:
     region: content
   langcode:
     type: language_select
-    weight: 5
+    weight: 6
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 16
+    weight: 17
     settings: {  }
     region: content
     third_party_settings: {  }
   path:
     type: path
-    weight: 15
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -100,24 +105,24 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 9
+    weight: 10
     region: content
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 13
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
   publish_state:
     type: scheduler_moderation
-    weight: 11
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
   published_at:
     type: publication_date_timestamp
-    weight: 8
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -125,14 +130,14 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 17
+    weight: 18
     region: content
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 10
+    weight: 11
     region: content
     third_party_settings: {  }
   title:
@@ -145,7 +150,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 6
+    weight: 7
     settings:
       match_operator: CONTAINS
       size: 60
@@ -155,13 +160,13 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 14
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
   unpublish_state:
     type: scheduler_moderation
-    weight: 12
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.node.wiki_page.default.yml
+++ b/config/sync/core.entity_form_display.node.wiki_page.default.yml
@@ -24,12 +24,12 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 4
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
   field_body:
-    weight: 1
+    weight: 2
     settings:
       rows: 5
       placeholder: ''
@@ -37,41 +37,46 @@ content:
     type: text_textarea
     region: content
   field_comments:
-    weight: 101
+    weight: 18
     settings: {  }
     third_party_settings: {  }
     type: comment_default
     region: content
+  field_post_activity:
+    weight: 19
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_related_downloads:
     type: media_library_widget
-    weight: 3
+    weight: 5
     settings:
       media_types: {  }
     third_party_settings: {  }
     region: content
   field_related_media:
     type: media_library_widget
-    weight: 2
+    weight: 4
     settings:
       media_types: {  }
     third_party_settings: {  }
     region: content
   langcode:
     type: language_select
-    weight: 2
+    weight: 3
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 100
+    weight: 17
     settings: {  }
     region: content
     third_party_settings: {  }
   path:
     type: path
-    weight: 8
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -86,24 +91,24 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 6
+    weight: 8
     region: content
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 30
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }
   publish_state:
     type: scheduler_moderation
-    weight: 30
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
   published_at:
     type: publication_date_timestamp
-    weight: 10
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -111,14 +116,14 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 9
+    weight: 11
     region: content
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 7
+    weight: 9
     region: content
     third_party_settings: {  }
   title:
@@ -131,7 +136,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 7
     settings:
       match_operator: CONTAINS
       size: 60
@@ -141,13 +146,13 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 30
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }
   unpublish_state:
     type: scheduler_moderation
-    weight: 30
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/lib/modules/eic_messages/eic_messages.module
+++ b/lib/modules/eic_messages/eic_messages.module
@@ -23,7 +23,7 @@ use Drupal\node\Entity\NodeType;
  * Implements hook_ENTITY_TYPE_insert().
  */
 function eic_messages_group_insert(EntityInterface $entity) {
-  /** @var GroupMessageCreator $class */
+  /** @var Drupal\eic_messages\Hooks\GroupMessageCreator $class */
   $class = \Drupal::classResolver(GroupMessageCreator::class);
   $class->groupInsert($entity);
 }
@@ -32,7 +32,7 @@ function eic_messages_group_insert(EntityInterface $entity) {
  * Implements hook_ENTITY_TYPE_update().
  */
 function eic_messages_group_update(EntityInterface $entity) {
-  /** @var GroupMessageCreator $class */
+  /** @var Drupal\eic_messages\Hooks\GroupMessageCreator $class */
   $class = \Drupal::classResolver(GroupMessageCreator::class);
   $class->groupUpdate($entity);
 }
@@ -41,7 +41,7 @@ function eic_messages_group_update(EntityInterface $entity) {
  * Implements hook_ENTITY_TYPE_insert().
  */
 function eic_messages_group_content_insert(EntityInterface $entity) {
-  /** @var GroupContentMessageCreator $class */
+  /** @var Drupal\eic_messages\Hooks\GroupContentMessageCreator $class */
   $class = \Drupal::classResolver(GroupContentMessageCreator::class);
   $class->groupContentInsert($entity);
 }
@@ -58,7 +58,7 @@ function eic_messages_message_insert(EntityInterface $entity) {
  * Implements hook_entity_update().
  */
 function eic_messages_entity_update(EntityInterface $entity) {
-  /** @var EntityOperations $class */
+  /** @var Drupal\eic_messages\Hooks\EntityOperations $class */
   $class = \Drupal::classResolver(EntityOperations::class);
   $class->entityUpdate($entity);
 }
@@ -71,7 +71,7 @@ function eic_messages_request_insert(
   ContentEntityInterface $entity,
   string $type
 ) {
-  /** @var RequestMessageCreator $class */
+  /** @var Drupal\eic_messages\Hooks\RequestMessageCreator $class */
   $class = \Drupal::classResolver(RequestMessageCreator::class);
   $class->requestInsert($flag, $entity, $type);
 }
@@ -84,7 +84,7 @@ function eic_messages_request_close(
   ContentEntityInterface $entity,
   string $type
 ) {
-  /** @var RequestMessageCreator $class */
+  /** @var Drupal\eic_messages\Hooks\RequestMessageCreator $class */
   $class = \Drupal::classResolver(RequestMessageCreator::class);
   $class->requestClose($flag, $entity, $type);
 }

--- a/lib/modules/eic_messages/eic_messages.module
+++ b/lib/modules/eic_messages/eic_messages.module
@@ -8,7 +8,7 @@
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Render\BubbleableMetadata;
-use Drupal\eic_messages\Hooks\EntityUpdate;
+use Drupal\eic_messages\Hooks\EntityOperations;
 use Drupal\eic_messages\Hooks\LogMessageRenderer;
 use Drupal\eic_messages\Hooks\MessageTokens;
 use Drupal\eic_messages\Hooks\RequestMessageCreator;
@@ -55,8 +55,8 @@ function eic_messages_message_insert(EntityInterface $entity) {
  * Implements hook_entity_update().
  */
 function eic_messages_entity_update(EntityInterface $entity) {
-  /** @var EntityUpdate $class */
-  $class = \Drupal::classResolver(EntityUpdate::class);
+  /** @var EntityOperations $class */
+  $class = \Drupal::classResolver(EntityOperations::class);
   $class->entityUpdate($entity);
 }
 

--- a/lib/modules/eic_messages/eic_messages.module
+++ b/lib/modules/eic_messages/eic_messages.module
@@ -23,8 +23,8 @@ use Drupal\node\Entity\NodeType;
  * Implements hook_ENTITY_TYPE_insert().
  */
 function eic_messages_group_insert(EntityInterface $entity) {
-  /** @var Drupal\eic_messages\Hooks\GroupMessageCreator $class */
-  $class = \Drupal::classResolver(GroupMessageCreator::class);
+  /** @var Drupal\eic_messages\Service\GroupMessageCreator $class */
+  $class = \Drupal::service('eic_messages.message_creator.group');
   $class->groupInsert($entity);
 }
 
@@ -32,8 +32,8 @@ function eic_messages_group_insert(EntityInterface $entity) {
  * Implements hook_ENTITY_TYPE_update().
  */
 function eic_messages_group_update(EntityInterface $entity) {
-  /** @var Drupal\eic_messages\Hooks\GroupMessageCreator $class */
-  $class = \Drupal::classResolver(GroupMessageCreator::class);
+  /** @var Drupal\eic_messages\Service\GroupMessageCreator $class */
+  $class = \Drupal::service('eic_messages.message_creator.group');
   $class->groupUpdate($entity);
 }
 
@@ -41,8 +41,8 @@ function eic_messages_group_update(EntityInterface $entity) {
  * Implements hook_ENTITY_TYPE_insert().
  */
 function eic_messages_group_content_insert(EntityInterface $entity) {
-  /** @var Drupal\eic_messages\Hooks\GroupContentMessageCreator $class */
-  $class = \Drupal::classResolver(GroupContentMessageCreator::class);
+  /** @var Drupal\eic_messages\Service\GroupContentMessageCreator $class */
+  $class = \Drupal::service('eic_messages.message_creator.group_content');
   $class->groupContentInsert($entity);
 }
 
@@ -71,8 +71,8 @@ function eic_messages_request_insert(
   ContentEntityInterface $entity,
   string $type
 ) {
-  /** @var Drupal\eic_messages\Hooks\RequestMessageCreator $class */
-  $class = \Drupal::classResolver(RequestMessageCreator::class);
+  /** @var Drupal\eic_messages\Service\RequestMessageCreator $class */
+  $class = \Drupal::service('eic_messages.message_creator.request');
   $class->requestInsert($flag, $entity, $type);
 }
 
@@ -84,8 +84,8 @@ function eic_messages_request_close(
   ContentEntityInterface $entity,
   string $type
 ) {
-  /** @var Drupal\eic_messages\Hooks\RequestMessageCreator $class */
-  $class = \Drupal::classResolver(RequestMessageCreator::class);
+  /** @var Drupal\eic_messages\Service\RequestMessageCreator $class */
+  $class = \Drupal::service('eic_messages.message_creator.request');
   $class->requestClose($flag, $entity, $type);
 }
 

--- a/lib/modules/eic_messages/eic_messages.module
+++ b/lib/modules/eic_messages/eic_messages.module
@@ -7,14 +7,17 @@
 
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\eic_messages\Hooks\EntityOperations;
+use Drupal\eic_messages\Hooks\FormOperations;
+use Drupal\eic_messages\Hooks\GroupContentMessageCreator;
+use Drupal\eic_messages\Hooks\GroupMessageCreator;
 use Drupal\eic_messages\Hooks\LogMessageRenderer;
 use Drupal\eic_messages\Hooks\MessageTokens;
 use Drupal\eic_messages\Hooks\RequestMessageCreator;
-use Drupal\eic_messages\Hooks\GroupContentMessageCreator;
-use Drupal\eic_messages\Hooks\GroupMessageCreator;
 use Drupal\flag\FlaggingInterface;
+use Drupal\node\Entity\NodeType;
 
 /**
  * Implements hook_ENTITY_TYPE_insert().
@@ -84,6 +87,33 @@ function eic_messages_request_close(
   /** @var RequestMessageCreator $class */
   $class = \Drupal::classResolver(RequestMessageCreator::class);
   $class->requestClose($flag, $entity, $type);
+}
+
+/**
+ * Implements hook_entity_extra_field_info().
+ */
+function eic_messages_entity_extra_field_info() {
+  $extra = [];
+
+  // We add the extra field for all content types. The display will be handled
+  // in the hook_form_BASE_FORM_ID_alter() function.
+  foreach (NodeType::loadMultiple() as $bundle) {
+    $extra['node'][$bundle->id()]['form']['field_post_activity'] = [
+      'label' => t('Post message in the activity stream'),
+      'description' => '',
+      'visible' => TRUE,
+    ];
+  }
+
+  return $extra;
+}
+
+/**
+ * Implements hook_form_BASE_FORM_ID_alter().
+ */
+function eic_messages_form_node_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  \Drupal::classResolver(FormOperations::class)
+    ->formNodeFormAlter($form, $form_state, $form_id);
 }
 
 /**

--- a/lib/modules/eic_messages/eic_messages.services.yml
+++ b/lib/modules/eic_messages/eic_messages.services.yml
@@ -5,11 +5,11 @@ services:
 
   # Message creator services
   eic_messages.message_creator.group:
-    class: Drupal\eic_messages\Hooks\GroupMessageCreator
+    class: Drupal\eic_messages\Service\GroupMessageCreator
     arguments: ['@entity_type.manager', '@eic_messages.helper', '@eic_user.helper']
   eic_messages.message_creator.group_content:
-    class: Drupal\eic_messages\Hooks\GroupContentMessageCreator
+    class: Drupal\eic_messages\Service\GroupContentMessageCreator
     arguments: ['@entity_type.manager', '@eic_messages.helper', '@eic_user.helper']
   eic_messages.message_creator.request:
-    class: Drupal\eic_messages\Hooks\RequestMessageCreator
-    arguments: ['@entity_type.manager', '@eic_messages.helper', '@eic_user.helper']
+    class: Drupal\eic_messages\Service\RequestMessageCreator
+    arguments: ['@entity_type.manager', '@eic_messages.helper', '@eic_user.helper', '@eic_flags.handler_collector', '@renderer']

--- a/lib/modules/eic_messages/eic_messages.services.yml
+++ b/lib/modules/eic_messages/eic_messages.services.yml
@@ -2,3 +2,14 @@ services:
   eic_messages.helper:
     class: Drupal\eic_messages\MessageHelper
     arguments: ['@queue']
+
+  # Message creator services
+  eic_messages.message_creator.group:
+    class: Drupal\eic_messages\Hooks\GroupMessageCreator
+    arguments: ['@entity_type.manager', '@eic_messages.helper', '@eic_user.helper']
+  eic_messages.message_creator.group_content:
+    class: Drupal\eic_messages\Hooks\GroupContentMessageCreator
+    arguments: ['@entity_type.manager', '@eic_messages.helper', '@eic_user.helper']
+  eic_messages.message_creator.request:
+    class: Drupal\eic_messages\Hooks\RequestMessageCreator
+    arguments: ['@entity_type.manager', '@eic_messages.helper', '@eic_user.helper']

--- a/lib/modules/eic_messages/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_messages/src/Hooks/EntityOperations.php
@@ -2,12 +2,13 @@
 
 namespace Drupal\eic_messages\Hooks;
 
-use Drupal\content_moderation\ModerationInformationInterface;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\content_moderation\ModerationInformationInterface;
 use Drupal\eic_messages\MessageHelper;
+use Drupal\eic_messages\Service\MessageCreatorBase;
 use Drupal\eic_user\UserHelper;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/lib/modules/eic_messages/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_messages/src/Hooks/EntityOperations.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @package Drupal\eic_messages\Hooks
  */
-class EntityUpdate extends MessageCreatorBase implements ContainerInjectionInterface {
+class EntityOperations extends MessageCreatorBase implements ContainerInjectionInterface {
 
   use StringTranslationTrait;
 

--- a/lib/modules/eic_messages/src/Hooks/FormOperations.php
+++ b/lib/modules/eic_messages/src/Hooks/FormOperations.php
@@ -7,6 +7,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\eic_content\EICContentHelper;
+use Drupal\eic_messages\Service\GroupContentMessageCreator;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -35,7 +36,7 @@ class FormOperations implements ContainerInjectionInterface {
   /**
    * The EIC content helper service.
    *
-   * @var \Drupal\eic_messages\Hooks\GroupContentMessageCreator
+   * @var \Drupal\eic_messages\Service\GroupContentMessageCreator
    */
   protected $groupContentMessageCreator;
 
@@ -46,8 +47,8 @@ class FormOperations implements ContainerInjectionInterface {
    *   The current route match service.
    * @param \Drupal\eic_content\EICContentHelper $content_helper
    *   The EIC content helper service.
-   * @param \Drupal\eic_messages\Hooks\GroupContentMessageCreator $group_content_message_creator
-   *   The EIC content helper service.
+   * @param \Drupal\eic_messages\Service\GroupContentMessageCreator $group_content_message_creator
+   *   The GroupContent Message Creator service.
    */
   public function __construct(RouteMatchInterface $route_match, EICContentHelper $content_helper, GroupContentMessageCreator $group_content_message_creator) {
     $this->routeMatch = $route_match;

--- a/lib/modules/eic_messages/src/Hooks/FormOperations.php
+++ b/lib/modules/eic_messages/src/Hooks/FormOperations.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Drupal\eic_messages\Hooks;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\eic_content\EICContentHelper;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class FormAlter.
+ *
+ * Implementations for entity hooks.
+ */
+class FormOperations implements ContainerInjectionInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The current route match service.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
+   * The EIC content helper service.
+   *
+   * @var \Drupal\eic_content\EICContentHelper
+   */
+  protected $eicContentHelper;
+
+  /**
+   * Constructs a new EntityOperations object.
+   *
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The current route match service.
+   * @param \Drupal\eic_content\EICContentHelper $content_helper
+   *   The EIC content helper service.
+   */
+  public function __construct(RouteMatchInterface $route_match, EICContentHelper $content_helper) {
+    $this->routeMatch = $route_match;
+    $this->eicContentHelper = $content_helper;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('current_route_match'),
+      $container->get('eic_content.helper')
+    );
+  }
+
+  /**
+   * Implements hook_form_BASE_FORM_ID_alter().
+   */
+  public function formNodeFormAlter(&$form, FormStateInterface $form_state, $form_id) {
+    $this->handleFieldPostActivity($form, $form_state, $form_id);
+  }
+
+  /**
+   * Handles the field_post_activity.
+   *
+   * @param array $form
+   *   The form array.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The FormState object.
+   * @param string $form_id
+   *   The form ID.
+   */
+  protected function handleFieldPostActivity(array &$form, FormStateInterface $form_state, string $form_id) {
+    $is_group_content = FALSE;
+    $is_new_content = FALSE;
+
+    // Check if we are adding a content into a group.
+    if ($this->routeMatch->getRouteName() == 'entity.group_content.create_form') {
+      $is_group_content = TRUE;
+      $is_new_content = TRUE;
+    }
+    // Check we are updating a node which has an associated GroupContent entity.
+    elseif ($node = $form_state->getFormObject()->getEntity()) {
+      if (!$node->isNew() && $this->eicContentHelper->getGroupContentByEntity($node)) {
+        $is_group_content = TRUE;
+      }
+    }
+
+    // Test if we are creating or editing a group content.
+    if ($is_group_content && $form_state->get('form_display')->getComponent('field_post_activity')) {
+      $form['field_post_activity'] = [
+        '#title' => $this->t('Post message in the activity stream'),
+        '#type' => 'checkbox',
+        '#default_value' => $is_new_content,
+      ];
+    }
+  }
+
+}

--- a/lib/modules/eic_messages/src/Hooks/GroupContentMessageCreator.php
+++ b/lib/modules/eic_messages/src/Hooks/GroupContentMessageCreator.php
@@ -19,6 +19,8 @@ class GroupContentMessageCreator extends MessageCreatorBase {
 
     /** @var \Drupal\group\Entity\GroupContent $entity */
     $group_content_type = $entity->getGroupContentType();
+
+    // New member joined notification.
     if ($group_content_type->get('content_plugin') === 'group_membership') {
       $relatedUser = $entity->getEntity();
       $relatedGroup = $entity->getGroup();
@@ -34,8 +36,7 @@ class GroupContentMessageCreator extends MessageCreatorBase {
       $messages[] = $message;
     }
 
-    /** @var \Drupal\group\Entity\GroupContent $entity */
-    $group_content_type = $entity->getGroupContentType();
+    // User requested membership notification.
     if ($group_content_type->get('content_plugin') === 'group_membership_request') {
       $relatedUser = $entity->getEntity();
       $relatedGroup = $entity->getGroup();
@@ -52,6 +53,41 @@ class GroupContentMessageCreator extends MessageCreatorBase {
     }
 
     $this->processMessages($messages);
+  }
+
+  /**
+   * Creates an activity stream message for an entity inside a group.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity object.
+   */
+  public function createGroupContentActivity(EntityInterface $entity) {
+    $messages = [];
+
+    switch ($entity->getEntityTypeId()) {
+      case 'node':
+        switch ($entity->bundle()) {
+          case 'discussion':
+            // @todo Handle all activity messages with correct values.
+            $messages[] = \Drupal::entityTypeManager()->getStorage('message')->create([
+              'template' => 'stream_discussion_insert_update',
+            ]);
+            break;
+        }
+        break;
+    }
+
+    // Save all messages.
+    foreach ($messages as $message) {
+      try {
+        $message->save();
+      }
+      catch (\Exception $e) {
+        $logger = $this->getLogger('eic_messages');
+        $logger->error($e->getMessage());
+      }
+    }
+
   }
 
 }

--- a/lib/modules/eic_messages/src/Service/GroupContentMessageCreator.php
+++ b/lib/modules/eic_messages/src/Service/GroupContentMessageCreator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\eic_messages\Hooks;
+namespace Drupal\eic_messages\Service;
 
 use Drupal\Core\Entity\EntityInterface;
 

--- a/lib/modules/eic_messages/src/Service/GroupMessageCreator.php
+++ b/lib/modules/eic_messages/src/Service/GroupMessageCreator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\eic_messages\Hooks;
+namespace Drupal\eic_messages\Service;
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\eic_groups\GroupsModerationHelper;

--- a/lib/modules/eic_messages/src/Service/MessageCreatorBase.php
+++ b/lib/modules/eic_messages/src/Service/MessageCreatorBase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\eic_messages\Hooks;
+namespace Drupal\eic_messages\Service;
 
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityInterface;

--- a/lib/modules/eic_messages/src/Service/RequestMessageCreator.php
+++ b/lib/modules/eic_messages/src/Service/RequestMessageCreator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\eic_messages\Hooks;
+namespace Drupal\eic_messages\Service;
 
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;


### PR DESCRIPTION
### Tests

- [x] Create a discussion inside a group
- [x] You should have the "Post message in the activity stream" checkbox enabled by default
- [x] Save => you should have a "stream_discussion_insert_update" message created (check the message table in the db since we don't have an activity stream yet)
- [x] Edit the discussion
- [x] You should have the "Post message in the activity stream" checkbox disabled by default
- [x] Save => no message should be created

### Remarks

- We don't have the activity stream yet, so you need to check the created messages directly in the DB
- MessageCreator classes have been turned into services
- For now only the message for discussions is created
- The content of the activity stream message is not handled yet