### PR TITLE
EICNET-963: Remove "add book page" from options to post content inside a group

### DIFF
--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
@@ -21,6 +22,7 @@ use Drupal\eic_groups\Hooks\GroupTokens;
 use Drupal\eic_groups\Hooks\FormOperations;
 use Drupal\eic_groups\Hooks\Pathauto;
 use Drupal\eic_groups\Hooks\Preprocess;
+use Drupal\group\Entity\GroupContent;
 use Drupal\group\Entity\GroupInterface;
 
 /**
@@ -352,4 +354,27 @@ function eic_groups_preprocess_block__group_content_menu(&$variables) {
   $block_manager = \Drupal::service('plugin.manager.block');
   $plugin_block = $block_manager->createInstance('eic_groups_search_menu_group', []);
   $variables['search_block'] = $plugin_block->build();
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_delete().
+ */
+function eic_groups_node_delete(EntityInterface $entity) {
+  switch ($entity->bundle()) {
+    case 'book':
+      // We need to invalidate group tags otherwise the "Add book page" link
+      // will not be shown in the group header until we clear all cache
+      // manually. But first, we need to make sure this book node
+      // belongs to a group.
+      $group_contents = GroupContent::loadByEntity($entity);
+      if (!$group_contents) {
+        return;
+      }
+
+      $group_content = reset($group_contents);
+
+      Cache::invalidateTags($group_content->getGroup()->getCacheTags());
+      break;
+
+  }
 }

--- a/lib/modules/eic_groups/eic_groups.services.yml
+++ b/lib/modules/eic_groups/eic_groups.services.yml
@@ -40,7 +40,7 @@ services:
     decorates: access_check.group_content.create_entity
     decoration_priority: 1
     public: true
-    arguments: ['@eic_groups.access_check.group_content.create_entity.decorator.inner', '@eic_user.helper']
+    arguments: ['@eic_groups.access_check.group_content.create_entity.decorator.inner', '@eic_user.helper', '@eic_groups.helper', '@entity_type.manager']
   eic_groups.publish_group.access_checker:
     class: Drupal\eic_groups\Access\PublishGroupAccessChecker
     arguments: ['@eic_user.helper']


### PR DESCRIPTION
### Improvements

- Deny access to create book pages inside groups for all users including admins and user 1.
- Show "Add book page" link if for some reason the Drupal admin removed the book page manually.

### Tests

- [x] As a Drupal admin or user 1, create a new group
- [x] Make sure the link "Add book page" is not shown in the group header
- [x] Go to `/admin/content` and delete the book page of the group
- [x] Go to the group homepage and Make sure the link "Add book page" is now visible