### PR TITLE
[EICNET-984]feature: Add into search the possibility to filter by interests and group/contents

### DIFF
--- a/config/sync/search_api.index.global.yml
+++ b/config/sync/search_api.index.global.yml
@@ -235,6 +235,16 @@ field_settings:
     dependencies:
       module:
         - node
+  content_uid:
+    label: uid
+    datasource_id: 'entity:node'
+    property_path: uid
+    type: integer
+    indexed_locked: true
+    type_locked: true
+    dependencies:
+      module:
+        - node
   group_content_entity_id:
     label: '[Group content] Content'
     datasource_id: 'entity:group_content'
@@ -457,16 +467,6 @@ field_settings:
     dependencies:
       module:
         - user
-  uid:
-    label: uid
-    datasource_id: 'entity:node'
-    property_path: uid
-    type: integer
-    indexed_locked: true
-    type_locked: true
-    dependencies:
-      module:
-        - node
   url:
     label: URI
     property_path: search_api_url
@@ -692,6 +692,9 @@ datasource_settings:
 processor_settings:
   add_url: {  }
   address_abbreviations_to_full_form:
+    user_profile_city_string:
+      enable: 0
+      concat: 0
     user_profile_field_location_address_country_code:
       enable: 1
       concat: 0
@@ -704,6 +707,7 @@ processor_settings:
   content_access:
     weights:
       preprocess_query: -30
+  entity_status: {  }
   group_content_access:
     weights:
       preprocess_query: -30

--- a/lib/modules/eic_search/eic_search.module
+++ b/lib/modules/eic_search/eic_search.module
@@ -28,6 +28,8 @@ function eic_search_theme($existing, $type, $theme, $path) {
         'enable_search' => TRUE,
         'source_class' => '',
         'search_string' => '',
+        'enable_facet_interests' => FALSE,
+        'enable_facet_my_groups' => FALSE,
       ],
     ],
   ];
@@ -74,18 +76,21 @@ function eic_search_search_api_solr_documents_alter(array &$documents, \Drupal\s
         $type = $fields['ss_content_type'];
         $date = $fields['ds_content_created'];
         $fullname = $fields['ss_content_first_name'] . ' ' . $fields['ss_content_last_name'];
+        $topics = $fields['itm_content_field_vocab_topics'];
         break;
       case 'entity:group':
         $title = $fields['ss_group_label_string'];
         $type = 'group';
         $date = $fields['ds_group_created'];
         $fullname = $fields['ss_group_user_fullname'];
+        $topics = $fields['itm_group_field_vocab_topics'];
         break;
       default:
         $title = '';
         $type = '';
         $date = '';
         $fullname = '';
+        $topics = [];
         break;
     }
 
@@ -94,6 +99,7 @@ function eic_search_search_api_solr_documents_alter(array &$documents, \Drupal\s
     $document->addField('ss_global_content_type', $type);
     $document->addField('ss_global_created_date', $date);
     $document->addField('ss_global_fullname', $fullname);
+    $document->addField('ss_global_topics', $topics);
 
     $group_parent_label = '';
 
@@ -105,10 +111,14 @@ function eic_search_search_api_solr_documents_alter(array &$documents, \Drupal\s
       $group_parent_url = $group_content_entity->getGroup() instanceof \Drupal\group\Entity\GroupInterface ?
         $group_content_entity->getGroup()->toUrl()->toString()
         : '';
+      $group_parent_id = $group_content_entity->getGroup() instanceof \Drupal\group\Entity\GroupInterface ?
+        $group_content_entity->getGroup()->id()
+        : '';
     }
 
     $document->addField('ss_global_group_parent_label', $group_parent_label);
     $document->addField('ss_global_group_parent_url', $group_parent_url);
+    $document->addField('ss_global_group_parent_id', $group_parent_id);
 
     if ($fields['ss_search_api_datasource'] === 'entity:user') {
       $profile = \Drupal\profile\Entity\Profile::load($fields['its_user_profile']);

--- a/lib/modules/eic_search/src/Controller/SolrSearchController.php
+++ b/lib/modules/eic_search/src/Controller/SolrSearchController.php
@@ -155,10 +155,14 @@ class SolrSearchController extends ControllerBase {
   }
 
   /**
-   * @param $fq
-   * @param $interests
+   * Generate query for user interests matching by their topics
+   *
+   * @param string $fq
+   *  The field query stringify to send to SOLR
+   * @param array $interests
+   *  Values of interests facet
    */
-  private function generateQueryInterests(&$fq, $interests) {
+  private function generateQueryInterests(string &$fq, array $interests) {
     if (
       empty($interests) ||
       !array_key_exists('my_interests', $interests) ||
@@ -185,10 +189,14 @@ class SolrSearchController extends ControllerBase {
   }
 
   /**
-   * @param $fq
-   * @param $interests
+   * Generate query for user's groups and content
+   *
+   * @param string $fq
+   *  The field query stringify to send to SOLR
+   * @param array $interests
+   *  Values of interests facet
    */
-  private function generateQueryUserGroupsAndContents(&$fq, $interests) {
+  private function generateQueryUserGroupsAndContents(string &$fq, array $interests) {
     if (
       empty($interests) ||
       !array_key_exists('my_groups', $interests) ||

--- a/lib/modules/eic_search/src/Plugin/Block/SearchOverviewBlock.php
+++ b/lib/modules/eic_search/src/Plugin/Block/SearchOverviewBlock.php
@@ -164,6 +164,8 @@ class SearchOverviewBlock extends BlockBase implements ContainerFactoryPluginInt
       '#url' => Url::fromRoute('eic_groups.solr_search')->toString(),
       '#isAnonymous' => \Drupal::currentUser()->isAnonymous(),
       '#currentGroup' => $current_group_route instanceof GroupInterface ? $current_group_route->id() : NULL,
+      '#enable_facet_interests' => $this->configuration['add_facet_interests'],
+      '#enable_facet_my_groups' => $this->configuration['add_facet_my_groups'],
       '#translations' => [
         'public' => $this->t('Public', [], ['context' => 'eic_group']),
         'private' => $this->t('Private', [], ['context' => 'eic_group']),
@@ -234,6 +236,8 @@ class SearchOverviewBlock extends BlockBase implements ContainerFactoryPluginInt
     $this->configuration['enable_search'] = $values['search']['configuration']['enable_search'];
     $this->configuration['page_options'] = $values['search']['configuration']['pagination']['page_options'];
     $this->configuration['prefilter_group'] = $values['search']['configuration']['prefilter_group'];
+    $this->configuration['add_facet_interests'] = $values['search']['configuration']['add_facet_interests'];
+    $this->configuration['add_facet_my_groups'] = $values['search']['configuration']['add_facet_my_groups'];
   }
 
   /**
@@ -339,6 +343,20 @@ class SearchOverviewBlock extends BlockBase implements ContainerFactoryPluginInt
         ];
       }
     }
+
+    $form['search']['configuration']['add_facet_my_groups'] = [
+      '#type' => 'checkbox',
+      '#default_value' => $this->configuration['add_facet_my_groups'],
+      '#title' => $this->t('Add filter for my groups/contents', [], ['context' => 'eic_search']),
+      '#description' => $this->t('Add new checkbox on the sidebar to filter only user groups/contents', [], ['context' => 'eic_search']),
+    ];
+
+    $form['search']['configuration']['add_facet_interests'] = [
+      '#type' => 'checkbox',
+      '#default_value' => $this->configuration['add_facet_interests'],
+      '#title' => $this->t('Add filter for my topics of interests', [], ['context' => 'eic_search']),
+      '#description' => $this->t('Add new checkbox on the sidebar to filter only topics of interests from user', [], ['context' => 'eic_search']),
+    ];
   }
 
   /**

--- a/lib/modules/eic_search/templates/search-overview-block.html.twig
+++ b/lib/modules/eic_search/templates/search-overview-block.html.twig
@@ -14,4 +14,6 @@
   data-source-bundle="{{ bundle }}"
   data-source-layout="{{ layout }}"
   data-current-group="{{ currentGroup }}"
+  data-enable-facet-my-groups="{{ enable_facet_my_groups }}"
+  data-enable-facet-interests="{{ enable_facet_interests }}"
 ></div>

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/Field/CheckboxSpecialField.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/Field/CheckboxSpecialField.js
@@ -1,0 +1,38 @@
+import React from 'react';
+
+class CheckboxSpecialField extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.onChange = this.onChange.bind(this);
+  }
+
+  onChange(e, value) {
+    if (this.props.value[1] === 0) {
+      return
+    }
+
+    const checked = !this.props.checked;
+    this.props.updateFacet(value, checked, this.props.facet);
+  }
+
+  render() {
+    return (
+      <div className="ecl-filter-sidebar__item-field facet-item">
+        <fieldset className="ecl-form-group">
+          <div onClick={e => this.onChange(e, this.props.value)} className="ecl-checkbox">
+            <input readOnly type="checkbox" className="ecl-checkbox__input" checked={this.props.checked}/>
+            <label className="ecl-checkbox__label">
+            <span className={`ecl-checkbox__box`}>
+            <svg className="ecl-icon ecl-icon--s ecl-checkbox__icon" focusable="false" aria-hidden="true"/>
+            </span>
+              <span className={`facet-item__value`}><b>{this.props.label}</b></span>
+            </label>
+          </div>
+        </fieldset>
+      </div>
+    );
+  }
+}
+
+export default CheckboxSpecialField;

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/Sidebar.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/Sidebar.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import SearchField from "./Field/SearchField";
 import CheckboxField from "./Field/CheckboxField";
+import CheckboxSpecialField from "./Field/CheckboxSpecialField";
 
 class Sidebar extends React.Component {
   constructor(props) {
@@ -8,6 +9,8 @@ class Sidebar extends React.Component {
   }
 
   render() {
+    const interestsValue = this.props.facetsValue['interests'];
+
     return (
       <div className="ecl-base-layout__aside">
         <div className="ecl-filter-sidebar ecl-filter-sidebar--is-ready">
@@ -16,6 +19,9 @@ class Sidebar extends React.Component {
               {this.props.translations.filter}
             </h2>
             <div className="ecl-filter-sidebar__items">
+              <CheckboxSpecialField label={'My interests only'} checked={interestsValue && interestsValue.my_interests} key={'my_interests'} facet={'interests'} updateFacet={this.props.updateFacet} value={'my_interests'}/>
+              <CheckboxSpecialField label={'My groups & content only'} checked={interestsValue && interestsValue.my_groups} key={'my_groups'} facet={'interests'} updateFacet={this.props.updateFacet} value={'my_groups'}/>
+
               {this.props.enableSearch &&
               <SearchField searchString={this.props.searchString} translations={this.props.translations} searchSolr={this.props.searchSolr}/>
               }

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/TopOptions/ActiveFacet.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/TopOptions/ActiveFacet.js
@@ -14,7 +14,7 @@ class SortOption extends React.Component {
 
   render() {
     return <div className="ecl-teaser-overview__active-filters-item">
-              <span className="ecl-tag ecl-tag--removable ecl-teaser-overview__active-filters-tag">{this.props.value}
+              <span className="ecl-tag ecl-tag--removable ecl-teaser-overview__active-filters-tag">{this.props.value[0].toUpperCase() + this.props.value.slice(1).replace(/_/g, " ")}
                 <button onClick={this.onClick} type="button" data-value="content-type=news" className="ecl-tag__icon" dangerouslySetInnerHTML={{__html: svg('close')}} />
               </span>
     </div>

--- a/lib/themes/eic_community/react/components/Block/Overview/entrypoint.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/entrypoint.js
@@ -19,6 +19,8 @@ ReactDOM.render(
     layout={element.dataset.sourceLayout}
     searchString={element.dataset.searchString}
     currentGroup={element.dataset.currentGroup}
+    enableFacetMyGroups={element.dataset.enableFacetMyGroups}
+    enableFacetInterests={element.dataset.enableFacetInterests}
   />,
   element
 );

--- a/lib/themes/eic_community/react/components/Block/Overview/index.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/index.js
@@ -54,6 +54,7 @@ class Overview extends React.Component {
     }
 
     this.state.facetsValue[facet][name] = value;
+
     this.searchSolr(this.state.searchText, this.state.page);
   }
 
@@ -158,6 +159,8 @@ class Overview extends React.Component {
               searchSolr={this.searchSolr}
               facetsValue={this.state.facetsValue}
               searchString={this.props.searchString}
+              enableFacetMyGroups={this.props.enableFacetMyGroups}
+              enableFacetInterests={this.props.enableFacetInterests}
             />
           </div>
         </div>


### PR DESCRIPTION
New fields in block configuration to be able to filter on SOLR via search API + integrate it into react

how to test it:

- [x] Go to your eic theme and npm install && npm run react-watch
- [x] Go to block layout, add EIC Search Overview to content region
- [x] Configuration : you need to enable "Add filter for my groups/contents" and "Add filter for my topics of interests"
- [x] Clear your cache and go to the homepage
- [x] You can now use your contents and should filter your content that your are the author + your groups. Or for interests, topics that match with yours