### PR TITLE
Bugfix: Load group statistics from SOLR

### DIFF
--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsHelper.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsHelper.php
@@ -54,7 +54,7 @@ class GroupStatisticsHelper implements GroupStatisticsHelperInterface {
     // Create the query.
     $query = $search_api_index->query();
     // Filter by group ID.
-    $query->addCondition('group_id', $group->id());
+    $query->addCondition('group_id_integer', $group->id());
     // Limit query to 1 result.
     $query->range(0, 1);
 


### PR DESCRIPTION
### Fixes

- Group statistics: adapt field condition "group_id" in method loadGroupStatisticsFromSearchIndex according to the new machine name of the indexed field ("group_id_integer").

### Tests

- [ ] Create a new group and publish it
- [ ] You should not have a PHP error when accessing the group homepage: `Drupal\search_api\SearchApiException: Filter term on unknown or unindexed field group_id. in Drupal\search_api_solr\Plugin\search_api\backend\SearchApiSolrBackend->createFilterQueries() (line 3002 of /var/www/html/web/modules/contrib/search_api_solr/src/Plugin/search_api/backend/SearchApiSolrBackend.php).`