### PR TITLE
EICNET-1165: Group statistics doesn't update for logged in users

### DIFF
--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
@@ -253,8 +253,8 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
     // Get all group flags the user has access to.
     $membership_links = $this->getGroupFlagLinks($group);
 
-    // Load group statistics from SOLR.
-    $group_statistics = $this->groupStatisticsHelper->loadGroupStatisticsFromSearchIndex($group);
+    // Load group statistics from Database.
+    $group_statistics = $this->groupStatisticsHelper->loadGroupStatistics($group);
 
     $build['content'] = [
       '#theme' => 'eic_group_header_block',


### PR DESCRIPTION
### Fixes

- Group header - load group statistics from Database instead of SOLR (SOLR updates index asynchronously and this causes group header to show old values).

### Tests

- [ ] As a GO, create new documents + comments and see if the group header statistics get updated right after.