### PR TITLE
EICNET-975: Fix Story document title

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/content/node--news--story.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--news--story.inc
@@ -5,7 +5,9 @@
  * Prepares variables for node News and Story templates.
  */
 
+use Drupal\Component\Utility\Xss;
 use Drupal\Core\Block\BlockPluginInterface;
+use Drupal\Core\Render\Markup;
 use Drupal\eic_community\ValueObject\ImageValueObject;
 use Drupal\file\Entity\File;
 
@@ -107,7 +109,7 @@ function _eic_community_story_document_field(&$variables) {
   if (isset($variables['content']['field_document_media'][0])) {
     $media = $variables['content']['field_document_media'][0]['#media'];
     $file = File::load($media->field_media_file->target_id);
-    $file_description = isset($media->field_body) ? $media->field_body->value : $media->getName();
+    $file_description = isset($media->field_body) ? Markup::create(Xss::filter($media->get('field_body')->value)) : $media->getName();
 
     $variables['download'] = [
       'title' => $file_description,


### PR DESCRIPTION
### Improvements

- Strip html tags from document title in CType Story.

### Tests

- [ ] Create a new story and reference a document
- [ ] Go to the story page and check if the html have been removed from the document title