### PR TITLE
[EICNET-1164] fix: Prevent error for optional contributor fields

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/paragraphs/paragraph--contributor.inc
+++ b/lib/themes/eic_community/includes/preprocess/paragraphs/paragraph--contributor.inc
@@ -7,6 +7,7 @@
 
 use Drupal\eic_community\ValueObject\ImageValueObject;
 use Drupal\user\Entity\User;
+use Drupal\user\UserInterface;
 
 /**
  * Implements hook_preprocess_paragraph().
@@ -59,7 +60,7 @@ function eic_community_preprocess_paragraph__contributor(array &$variables) {
   }
   else {
     $user = User::load($paragraph->field_user_ref->getString());
-    if ($user instanceof User) {
+    if ($user instanceof UserInterface) {
       $user_display = eic_community_get_teaser_user_display($user);
 
       if ($variables['logged_in'] === FALSE) {

--- a/lib/themes/eic_community/includes/preprocess/paragraphs/paragraph--contributor.inc
+++ b/lib/themes/eic_community/includes/preprocess/paragraphs/paragraph--contributor.inc
@@ -56,17 +56,18 @@ function eic_community_preprocess_paragraph__contributor(array &$variables) {
         ],
       ];
     }
-
   }
   else {
     $user = User::load($paragraph->field_user_ref->getString());
-    $user_display = eic_community_get_teaser_user_display($user);
+    if ($user instanceof User) {
+      $user_display = eic_community_get_teaser_user_display($user);
 
-    if ($variables['logged_in'] === FALSE) {
-      unset($user_display['path']);
+      if ($variables['logged_in'] === FALSE) {
+        unset($user_display['path']);
+      }
+
+      $contributor = array_merge($contributor, $user_display);
     }
-
-    $contributor = array_merge($contributor, $user_display);
   }
 
   $variables['author'] = $contributor;


### PR DESCRIPTION
Currently the contributor paragraphs is optional, if you don't add one everything is ok. But the user can add one whitout filling the fields. This PR prevents an error when this happens

## To Test

- [ ] Create an empty contributor paragraph field
- [ ] You shouldn't have an error but an empty contributor paragraph (since fields are not field)