### PR TITLE
[EICNET-787]fix: Remove the word "page" after content type

### DIFF
--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/GlobalResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/GlobalResultItem.js
@@ -59,7 +59,7 @@ class GlobalResultItem extends React.Component {
                 <div className="ecl-teaser__detail">
                   <span dangerouslySetInnerHTML={{__html: svg(icon, 'ecl-icon ecl-icon--s ecl-teaser__detail-icon')}} />
                   <a href="?author=amFuZWRvZQ==" className="ecl-teaser__detail-contributor">{this.props.result.ss_global_fullname} </a>
-                  created a new <a href="#">{this.props.result.ss_global_content_type.replace(/_/g, " ")}</a> page
+                  created a new <a href={this.props.result.ss_url}>{this.props.result.ss_global_content_type.replace(/_/g, " ")}</a>
                   - <div className="ecl-timestamp ecl-timestamp--inherits-color ecl-teaser__timestamp">
                   <time className="ecl-timestamp__label">{`${date.getDate()} ${this.months[date.getMonth()]} ${date.getFullYear()}`}</time>
                 </div>


### PR DESCRIPTION
Test : 

- [ ] Go to "/search" and check under title of each result item if the word "page" is removed after the content type