### PR TITLE
EICNET-1166: Fix ajax callback issues in forms

### DIFF
--- a/lib/modules/eic_messages/src/Hooks/FormOperations.php
+++ b/lib/modules/eic_messages/src/Hooks/FormOperations.php
@@ -3,6 +3,7 @@
 namespace Drupal\eic_messages\Hooks;
 
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\DependencyInjection\DependencySerializationTrait;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -17,6 +18,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class FormOperations implements ContainerInjectionInterface {
 
+  use DependencySerializationTrait;
   use StringTranslationTrait;
 
   /**


### PR DESCRIPTION
### Improvements

- Use `DependencySerializationTrait `in `Drupal\eic_messages\Hooks\FormOperation` class since we are adding a submit handler from a class using dependency injection.

### Tests

- [ ] Create a new public group and publish it;
- [ ] Try to create a new gallery in the group and try to select medias, add multiple Topics and Regions. Make sure there are no errors when ajax callback is triggered.