### PR TITLE
EICNET-1165: Fix Group statistics update on install

### DIFF
--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorage.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorage.php
@@ -141,35 +141,9 @@ class GroupStatisticsStorage implements GroupStatisticsStorageInterface {
    * {@inheritdoc}
    */
   public function setMultipleGroupStatistics(array $groups_statistics) {
-    $query = $this->connection->merge('eic_group_statistics')
-      ->key('gid');
-
-    $fields = [];
     foreach ($groups_statistics as $group_statistics) {
-      // We make sure the array item is an instance of GroupStatistics,
-      // otherwise we skip it.
-      if (!($group_statistics instanceof GroupStatistics)) {
-        continue;
-      }
-      $fields[] = [
-        'gid' => $group_statistics->getGroupId(),
-        'members' => $group_statistics->getMembersCount(),
-        'comments' => $group_statistics->getCommentsCount(),
-        'files' => $group_statistics->getFilesCount(),
-        'events' => $group_statistics->getEventsCount(),
-      ];
+      $this->setGroupStatistics($group_statistics);
     }
-
-    // Nothing to update. We can exit.
-    if (empty($fields)) {
-      return;
-    }
-
-    $query->fields($fields)
-      ->execute();
-
-    // Invalidate group cache tags.
-    Cache::invalidateTags(['group:' . $group_statistics->getGroupId()]);
   }
 
   /**


### PR DESCRIPTION
### Improvements

- GroupStatisticsStorage::setMultipleGroupStatistics() method was throwing an issue trying to merge multiple rows at once so we internally call the "setGroupStatistics" for each group (queries are executed per group).

### Tests

Before testing make sure you do the following:

- [ ] As a TU, create multiple groups
- [ ] As user 1 join those groups created by the TU
- [ ] Take a database dump in case we need to repeat the further tests
- [ ] Remove or comment dependency to eic_group_statistics in `eic_groups.info.yml`
- [ ] Uninstall eic_group_statistics module (`drush pmu eic_group_statistics`). This will automatically remove the eic_group_statistics table from DB.

Test phase:

- [ ] Install eic_group_statistics (`drush en eic_group_statistics`)
- [ ] Make sure the group statistics for all the groups created previously shows 2 members