### PR TITLE
EICNET-1211/EICNET-1212: Make topic field required for CT Document and CT Gallery

### DIFF
--- a/config/sync/core.entity_form_display.node.document.default.yml
+++ b/config/sync/core.entity_form_display.node.document.default.yml
@@ -58,9 +58,13 @@ content:
     third_party_settings: {  }
   field_vocab_topics:
     weight: 4
-    settings: {  }
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
-    type: options_select
+    type: entity_reference_autocomplete
     region: content
   langcode:
     type: language_select

--- a/config/sync/core.entity_form_display.node.document.default.yml
+++ b/config/sync/core.entity_form_display.node.document.default.yml
@@ -11,6 +11,7 @@ dependencies:
   module:
     - comment
     - content_moderation
+    - eic_content
     - path
     - publication_date
     - scheduler
@@ -59,12 +60,12 @@ content:
   field_vocab_topics:
     weight: 4
     settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
+      match_top_level_limit: '0'
+      items_to_load: '25'
+      auto_select_parents: '1'
+      load_all: 0
     third_party_settings: {  }
-    type: entity_reference_autocomplete
+    type: entity_tree
     region: content
   langcode:
     type: language_select

--- a/config/sync/core.entity_form_display.node.gallery.default.yml
+++ b/config/sync/core.entity_form_display.node.gallery.default.yml
@@ -12,6 +12,7 @@ dependencies:
   module:
     - comment
     - content_moderation
+    - eic_content
     - media_library
     - path
     - publication_date
@@ -68,12 +69,12 @@ content:
   field_vocab_topics:
     weight: 3
     settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
+      match_top_level_limit: '0'
+      items_to_load: '25'
+      auto_select_parents: '1'
+      load_all: 0
     third_party_settings: {  }
-    type: entity_reference_autocomplete
+    type: entity_tree
     region: content
   langcode:
     type: language_select

--- a/config/sync/field.field.node.document.field_vocab_topics.yml
+++ b/config/sync/field.field.node.document.field_vocab_topics.yml
@@ -12,7 +12,7 @@ entity_type: node
 bundle: document
 label: Topics
 description: ''
-required: false
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/config/sync/field.field.node.gallery.field_vocab_topics.yml
+++ b/config/sync/field.field.node.gallery.field_vocab_topics.yml
@@ -12,7 +12,7 @@ entity_type: node
 bundle: gallery
 label: Topics
 description: ''
-required: false
+required: true
 translatable: true
 default_value: {  }
 default_value_callback: ''


### PR DESCRIPTION
### Improvements

- EICNET-1211: Make topics field required for CTypes Document and Gallery;
- EICNET-1212: Replace select list with autocomplete widget for Topics field in CType Document.

### Tests

- [x] Create a new group and publish it;
- [x] Try to create a Document and make sure the Topics field is required and the widget is an autocomplete;
- [x] Try to create a Gallery and make sure the Topics field is required;