### PR TITLE
EICNET-1192: Group in Draft state can not be saved as Draft state

### DIFF
--- a/config/sync/user.role.content_administrator.yml
+++ b/config/sync/user.role.content_administrator.yml
@@ -26,6 +26,7 @@ permissions:
   - 'publish archived content'
   - 'unflag recommend_group'
   - 'use groups transition archive'
+  - 'use groups transition keep_in_draft'
   - 'use groups transition publish'
   - 'use groups transition upgrade_to_draft'
   - 'use text format basic_text'

--- a/config/sync/user.role.site_admin.yml
+++ b/config/sync/user.role.site_admin.yml
@@ -28,6 +28,7 @@ permissions:
   - 'use admin toolbar search'
   - 'use groups transition archive'
   - 'use groups transition create_new_group'
+  - 'use groups transition keep_in_draft'
   - 'use groups transition publish'
   - 'use groups transition unpublish'
   - 'use groups transition upgrade_to_draft'

--- a/config/sync/user.role.trusted_user.yml
+++ b/config/sync/user.role.trusted_user.yml
@@ -29,6 +29,7 @@ permissions:
   - 'unflag recommend_group'
   - 'use groups transition create_new_draft'
   - 'use groups transition create_new_group'
+  - 'use groups transition keep_in_draft'
   - 'use groups transition publish'
   - 'use text format basic_text'
   - 'use text format filtered_html'

--- a/config/sync/workflows.workflow.groups.yml
+++ b/config/sync/workflows.workflow.groups.yml
@@ -44,6 +44,12 @@ type_settings:
         - pending
       to: pending
       weight: -2
+    keep_in_draft:
+      label: 'Keep in draft'
+      from:
+        - draft
+      to: draft
+      weight: 3
     publish:
       label: Publish
       to: published


### PR DESCRIPTION
### Improvements

- Created new workflow transition to allow GO/SA/SCM users to be able to keep the group in draft state.

### Tests

- [ ] As a TU, create a new group;
- [ ] As SA, change the group state to Draft;
- [ ] As a TU, go to the group edit form and check if you have the options to keep the group in Draft or Publish.