### PR TITLE
EICNET-1185: Delete the recommend flag on stories

### DIFF
--- a/config/sync/flag.flag.recommend.yml
+++ b/config/sync/flag.flag.recommend.yml
@@ -10,8 +10,6 @@ label: 'Recommend (Content)'
 bundles:
   - discussion
   - document
-  - news
-  - story
 entity_type: node
 global: false
 weight: 0

--- a/lib/modules/eic_content/eic_content.services.yml
+++ b/lib/modules/eic_content/eic_content.services.yml
@@ -8,5 +8,6 @@ services:
 
   eic_content.breadcrumb:
     class: Drupal\eic_content\ContentBreadcrumbBuilder
+    arguments: ['@current_user']
     tags:
       - { name: breadcrumb_builder, priority: 999 }

--- a/lib/modules/eic_content/src/ContentBreadcrumbBuilder.php
+++ b/lib/modules/eic_content/src/ContentBreadcrumbBuilder.php
@@ -6,6 +6,7 @@ use Drupal\Core\Breadcrumb\Breadcrumb;
 use Drupal\Core\Breadcrumb\BreadcrumbBuilderInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\node\NodeInterface;
 
@@ -15,6 +16,23 @@ use Drupal\node\NodeInterface;
 class ContentBreadcrumbBuilder implements BreadcrumbBuilderInterface {
 
   use StringTranslationTrait;
+
+  /**
+   * The current user service.
+   *
+   * @var \Drupal\Core\Session\AccountProxyInterface
+   */
+  protected $currentUser;
+
+  /**
+   * Constructs a new ContentBreadcrumbBuilder object.
+   *
+   * @param \Drupal\Core\Session\AccountProxyInterface $current_user
+   *   The current user service.
+   */
+  public function __construct(AccountProxyInterface $current_user) {
+    $this->currentUser = $current_user;
+  }
 
   /**
    * {@inheritdoc}
@@ -45,7 +63,7 @@ class ContentBreadcrumbBuilder implements BreadcrumbBuilderInterface {
 
     if ($node instanceof NodeInterface) {
       // Adds the user access as cacheable dependency.
-      if ($access = $node->access('view', $this->account, TRUE)) {
+      if ($access = $node->access('view', $this->currentUser->getAccount(), TRUE)) {
         $breadcrumb->addCacheableDependency($access);
       }
 


### PR DESCRIPTION
### Improvements

- Remove recommend flag from CTypes News and Story;
- Fix Notice: Undefined property: Drupal\eic_content\ContentBreadcrumbBuilder::$account in Drupal\eic_content\ContentBreadcrumbBuilder when viewing a News or Story page.

### Tests

- [ ] Create a News and a Story and publish them.
- [ ] Check if the flag "Recommend" has been removed.
- [ ] Go to `/admin/reports/dblog` and make sure you have no notice: "**Notice: Undefined property: Drupal\eic_content\ContentBreadcrumbBuilder::$account in Drupal\eic_content\ContentBreadcrumbBuilder when viewing a News or Story page.**"