### PR TITLE
EICNET-1193: Discussions tab of public group not shown for anonymous user/TU

### DIFF
--- a/config/sync/eic_groups.group_features.eic_groups_discussions.yml
+++ b/config/sync/eic_groups.group_features.eic_groups_discussions.yml
@@ -1,6 +1,8 @@
 permissions:
   - 'access discussions overview'
   - 'create group_node:discussion entity'
+public_permissions:
+  - 'access discussions overview'
 roles:
   - group-member
   - group-admin

--- a/config/sync/eic_groups.group_features.eic_groups_members.yml
+++ b/config/sync/eic_groups.group_features.eic_groups_members.yml
@@ -1,5 +1,6 @@
 permissions:
   - 'access members overview'
+public_permissions: []
 roles:
   - group-member
   - group-admin

--- a/config/sync/eic_groups.group_features.eic_groups_wiki.yml
+++ b/config/sync/eic_groups.group_features.eic_groups_wiki.yml
@@ -1,5 +1,7 @@
 permissions:
+  - 'access wiki overview'
   - 'create group_node:wiki_page entity'
+public_permissions: []
 roles:
   - group-member
   - group-admin

--- a/lib/modules/eic_groups/config/install/eic_groups.group_features.eic_groups_discussions.yml
+++ b/lib/modules/eic_groups/config/install/eic_groups.group_features.eic_groups_discussions.yml
@@ -1,6 +1,8 @@
 permissions:
   - 'access discussions overview'
   - 'create group_node:discussion entity'
+public_permissions:
+  - 'access discussions overview'
 roles:
   - 'group-member'
   - 'group-admin'

--- a/lib/modules/eic_groups/config/install/eic_groups.group_features.eic_groups_members.yml
+++ b/lib/modules/eic_groups/config/install/eic_groups.group_features.eic_groups_members.yml
@@ -1,5 +1,6 @@
 permissions:
   - 'access members overview'
+public_permissions: []
 roles:
   - 'group-member'
   - 'group-admin'

--- a/lib/modules/eic_groups/config/install/eic_groups.group_features.eic_groups_wiki.yml
+++ b/lib/modules/eic_groups/config/install/eic_groups.group_features.eic_groups_wiki.yml
@@ -1,5 +1,7 @@
 permissions:
+  - 'access wiki overview'
   - 'create group_node:wiki_page entity'
+public_permissions: []
 roles:
   - 'group-member'
   - 'group-admin'

--- a/lib/modules/eic_groups/config/schema/eic_groups.group_features.schema.yml
+++ b/lib/modules/eic_groups/config/schema/eic_groups.group_features.schema.yml
@@ -6,6 +6,11 @@ eic_groups.group_features.*:
       label: 'Permissions'
       sequence:
         type: string
+    permissions:
+      type: sequence
+      label: 'Public Permissions'
+      sequence:
+        type: string
     roles:
       type: sequence
       label: 'Roles'


### PR DESCRIPTION
### Improvements

- Improve handlePermissions() method from EicGroupsGroupFeaturePluginBase class so that it also adds and removes group feature permissions for public roles (anonymous and outsiders);
- Update group features schema in order to be able to define the group feature permissions for the public roles.

### Tests

- [x] Create a public group and publish it
- [x] Enable group feature "Discussions"
- [x] As anonymous user go to the group homepage and check if you can see the menu link "Discussions"
- [x] Click on "Discussions" and make sure you are redirected to the list of group discussions. Make also sure you can see the page.