### PR TITLE
[EICNET-1172]fix: Remove the "group owner" option in the group invite form

### DIFF
--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -142,13 +142,15 @@ function eic_groups_form_alter(&$form, FormStateInterface $form_state, $form_id)
       \Drupal::classResolver(FormOperations::class)
         ->groupWikiPageFormAlter($form, $form_state, $form_id);
       break;
-
     case 'group_content_group-group_membership_group-join_form':
       // Do custom changes in group membership join form.
       \Drupal::classResolver(FormOperations::class)
         ->groupMembershipJoinFormAlter($form, $form_state, $form_id);
       break;
-
+    case 'group_content_group-group_invitation_add_form':
+      \Drupal::classResolver(FormOperations::class)
+        ->groupInvitationFormAlter($form, $form_state, $form_id);
+      break;
   }
 }
 

--- a/lib/modules/eic_groups/src/Hooks/FormOperations.php
+++ b/lib/modules/eic_groups/src/Hooks/FormOperations.php
@@ -9,6 +9,7 @@ use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Url;
 use Drupal\eic_content_wiki_page\WikiPageBookManager;
+use Drupal\eic_groups\EICGroupsHelper;
 use Drupal\eic_groups\EICGroupsHelperInterface;
 use Drupal\group\Entity\Group;
 use Drupal\node\Entity\Node;
@@ -185,6 +186,15 @@ class FormOperations implements ContainerInjectionInterface {
         'formRedirectToGroupHomepage',
       ];
     }
+  }
+
+  /**
+   * Implements hook_form_alter() for group invitation form
+   *
+   * Remove the group-owner option
+   */
+  public function groupInvitationFormAlter(&$form, FormStateInterface $form_state, $form_id) {
+    unset($form['group_roles']['widget']['#options'][EICGroupsHelper::GROUP_OWNER_ROLE]);
   }
 
   /**


### PR DESCRIPTION
How to test it:

- [ ] Go to a group where you can invite someone
- [ ] Click on the link, you should not see the "group owner" option anymore