### PR TITLE
[EICNET-1163]feature: Add "disable top level selection" so moderator will not be able to select top options

### DIFF
--- a/config/sync/core.entity_form_display.node.discussion.default.yml
+++ b/config/sync/core.entity_form_display.node.discussion.default.yml
@@ -14,6 +14,7 @@ dependencies:
   module:
     - comment
     - content_moderation
+    - eic_content
     - paragraphs
     - path
     - publication_date
@@ -91,12 +92,13 @@ content:
   field_vocab_topics:
     weight: 6
     settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
+      match_top_level_limit: '1'
+      disable_top_choices: '1'
+      items_to_load: '25'
+      load_all: 0
+      auto_select_parents: 0
     third_party_settings: {  }
-    type: entity_reference_autocomplete
+    type: entity_tree
     region: content
   langcode:
     type: language_select

--- a/config/sync/core.entity_form_display.node.document.default.yml
+++ b/config/sync/core.entity_form_display.node.document.default.yml
@@ -59,9 +59,10 @@ content:
     weight: 4
     settings:
       match_top_level_limit: '0'
+      disable_top_choices: '1'
       items_to_load: '25'
-      auto_select_parents: '1'
       load_all: 0
+      auto_select_parents: 0
     third_party_settings: {  }
     type: entity_tree
     region: content

--- a/config/sync/core.entity_form_display.node.gallery.default.yml
+++ b/config/sync/core.entity_form_display.node.gallery.default.yml
@@ -70,9 +70,10 @@ content:
     weight: 3
     settings:
       match_top_level_limit: '0'
+      disable_top_choices: '1'
       items_to_load: '25'
-      auto_select_parents: '1'
       load_all: 0
+      auto_select_parents: 0
     third_party_settings: {  }
     type: entity_tree
     region: content

--- a/config/sync/core.entity_form_display.node.news.default.yml
+++ b/config/sync/core.entity_form_display.node.news.default.yml
@@ -22,6 +22,7 @@ dependencies:
   module:
     - comment
     - content_moderation
+    - eic_content
     - media_library
     - paragraphs
     - path
@@ -152,12 +153,13 @@ content:
   field_vocab_topics:
     weight: 1
     settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
+      match_top_level_limit: '0'
+      disable_top_choices: '1'
+      items_to_load: '25'
+      load_all: 0
+      auto_select_parents: 0
     third_party_settings: {  }
-    type: entity_reference_autocomplete
+    type: entity_tree
     region: content
   langcode:
     type: language_select

--- a/config/sync/core.entity_form_display.node.story.default.yml
+++ b/config/sync/core.entity_form_display.node.story.default.yml
@@ -21,6 +21,7 @@ dependencies:
   module:
     - comment
     - content_moderation
+    - eic_content
     - media_library
     - paragraphs
     - path
@@ -144,12 +145,13 @@ content:
   field_vocab_topics:
     weight: 11
     settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
+      match_top_level_limit: '0'
+      disable_top_choices: '1'
+      items_to_load: '25'
+      load_all: 0
+      auto_select_parents: 0
     third_party_settings: {  }
-    type: entity_reference_autocomplete
+    type: entity_tree
     region: content
   langcode:
     type: language_select

--- a/config/sync/core.entity_form_display.node.video.default.yml
+++ b/config/sync/core.entity_form_display.node.video.default.yml
@@ -11,6 +11,7 @@ dependencies:
   module:
     - comment
     - content_moderation
+    - eic_content
     - media_library
     - path
     - publication_date
@@ -44,9 +45,9 @@ content:
     region: content
   field_post_activity:
     weight: 0
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   field_video_media:
     type: media_library_widget
     weight: 124
@@ -57,12 +58,13 @@ content:
   field_vocab_topics:
     weight: 122
     settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
+      match_top_level_limit: '0'
+      disable_top_choices: '1'
+      items_to_load: '25'
+      load_all: 0
+      auto_select_parents: 0
     third_party_settings: {  }
-    type: entity_reference_autocomplete
+    type: entity_tree
     region: content
   langcode:
     type: language_select

--- a/lib/modules/eic_content/src/Plugin/Field/FieldWidget/EntityTreeWidget.php
+++ b/lib/modules/eic_content/src/Plugin/Field/FieldWidget/EntityTreeWidget.php
@@ -37,6 +37,12 @@ class EntityTreeWidget extends WidgetBase {
       '#description' => $this->t('The number of top-level choices to make. Use <em>0</em> to remove the limit.', [], ['context' => 'eic_content']),
     ];
 
+    $element['disable_top_choices'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Disable top choices selection', [], ['context' => 'eic_content']),
+      '#default_value' => $this->getSetting('disable_top_choices'),
+    ];
+
     $element['load_all'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Load all items by default', [], ['context' => 'eic_content']),
@@ -69,6 +75,7 @@ class EntityTreeWidget extends WidgetBase {
         'match_top_level_limit' => 0,
         'items_to_load' => 25,
         'auto_select_parents' => TRUE,
+        'disable_top_choices' => FALSE,
         'load_all' => FALSE,
       ] + parent::defaultSettings();
   }
@@ -121,6 +128,7 @@ class EntityTreeWidget extends WidgetBase {
             ->toString(),
           'data-match-limit' => $this->getSetting('match_top_level_limit'),
           'data-items-to-load' => $this->getSetting('items_to_load'),
+          'data-disable-top' => $this->getSetting('disable_top_choices'),
           'data-load-all' => $this->getSetting('load_all'),
           'data-target-bundle' => $target_bundle,
           'data-target-entity' => $target_entity,

--- a/lib/themes/eic_community/react/components/Field/EntityTree/entrypoint.js
+++ b/lib/themes/eic_community/react/components/Field/EntityTree/entrypoint.js
@@ -19,6 +19,7 @@ for (let element of elements) {
       targetBundle={element.dataset.targetBundle}
       matchLimit={element.dataset.matchLimit ? parseInt(element.dataset.matchLimit) : 0}
       length={element.dataset.itemsToLoad ? parseInt(element.dataset.itemsToLoad) : 25}
+      disableTop={parseInt(element.dataset.disableTop)}
       loadAll={parseInt(element.dataset.loadAll)}
       drupalInput={element}
       translations={JSON.parse(element.dataset.translations)}

--- a/lib/themes/eic_community/react/components/Field/EntityTree/index.js
+++ b/lib/themes/eic_community/react/components/Field/EntityTree/index.js
@@ -93,6 +93,11 @@ class EntityTree extends React.Component {
       return;
     }
 
+    // If the disable top select option is enable and parent was selected, do not check the option
+    if (this.props.disableTop === 1 && parseInt(value.parent) === 0) {
+      return;
+    }
+
     const topLevelLength = selectedTerms.filter(function(item){
       return parseInt(item.parent) === 0;
     }).length;


### PR DESCRIPTION
How to test : 

- [ ] Create/edit a gallery (or other content type that have Topics field)
- [ ] Check if you can select top level checkbox, you shouldn't be able to select them

PS: be sure that you organize correctly terms of topics taxonomy for eg : 

- Thematic
   - Thematic A
   - Thematic B
- Horizontal
   - Horizontal A
   
  
Horizontal and Thematic shouldn't be selectable