### PR TITLE
EICNET-955: Truncate group description to 350 chars in group header.

### DIFF
--- a/config/sync/core.entity_view_display.group.group.default.yml
+++ b/config/sync/core.entity_view_display.group.group.default.yml
@@ -14,18 +14,39 @@ dependencies:
     - field.field.group.group.field_vocab_topics
     - field.field.group.group.field_welcome_message
     - group.type.group
+  module:
+    - smart_trim
 id: group.group.default
 targetEntityType: group
 bundle: group
 mode: default
 content:
   content_moderation_control:
-    weight: -20
+    weight: 0
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_body:
+    type: smart_trim
+    weight: 5
+    region: content
+    label: hidden
+    settings:
+      trim_length: 350
+      trim_type: chars
+      trim_suffix: ...
+      wrap_class: trimmed
+      more_text: More
+      more_class: more-link
+      wrap_output: false
+      more_link: false
+      trim_options:
+        text: false
+        trim_zero: false
+      summary_handler: full
+    third_party_settings: {  }
   field_group_invite_members:
-    weight: 11
+    weight: 4
     label: above
     settings:
       format: default
@@ -35,7 +56,7 @@ content:
     type: boolean
     region: content
   field_related_news_stories:
-    weight: 0
+    weight: 1
     label: above
     settings:
       link: true
@@ -48,19 +69,18 @@ content:
     third_party_settings: {  }
     region: content
   flag_follow_group:
-    weight: 10
+    weight: 2
     region: content
     settings: {  }
     third_party_settings: {  }
   flag_recommend_group:
-    weight: 10
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
   changed: true
   created: true
-  field_body: true
   field_hero: true
   field_message_to_site_admin: true
   field_related_groups: true

--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
@@ -6,7 +6,6 @@ use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\Core\Render\Markup;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Url;
@@ -271,7 +270,7 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
         'id' => $group->id(),
         'bundle' => $group->bundle(),
         'title' => $group->label(),
-        'description' => Markup::create($group->get('field_body')->value),
+        'description' => $group->field_body->view('full'),
         'operation_links' => array_merge($operation_links, $node_operation_links, $visible_group_operation_links),
         'membership_links' => array_merge($membership_links, $user_operation_links),
         'stats' => [
@@ -371,12 +370,17 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
   }
 
   /**
-   * If group does not allow to invite members, hide invite group link in header
+   * Removes the invite members link.
    *
-   * @param $group
-   * @param $user_operation_links
+   * If group does not allow to invite members, hide invite group link from the
+   * group header.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group entity.
+   * @param array $user_operation_links
+   *   Array of user operation links.
    */
-  private function processInviteUserPermission($group, &$user_operation_links) {
+  private function processInviteUserPermission(GroupInterface $group, array &$user_operation_links) {
     $key = 'invite-user';
 
     if (!array_key_exists($key, $user_operation_links)) {
@@ -393,12 +397,17 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
   }
 
   /**
-   * Remove the "leave group" link if group in draft/pending or if the user is the group owner
+   * Removes the "leave group" link from group.
    *
-   * @param $group
-   * @param $user_operation_links
+   * It only removes the link ff the group is in draft/pending or if the user
+   * is the group owner.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group entity.
+   * @param array $user_operation_links
+   *   Array of user operation links.
    */
-  private function processLeaveGroupPermission($group, &$user_operation_links) {
+  private function processLeaveGroupPermission(GroupInterface $group, array &$user_operation_links) {
     $key = 'group-leave';
 
     if (!array_key_exists($key, $user_operation_links)) {
@@ -423,4 +432,5 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
 
     unset($user_operation_links[$key]);
   }
+
 }


### PR DESCRIPTION
### Improvements

- Truncate group description to 350 chars in group header;
- Fix coding standards.

### Tests

- [ ] Create a new group with a very long description;
- [ ] Check if the group description is truncated to 350 chars in the group header.