### PR TITLE
EICNET-1079: Create a group feature for "Latest activity"

### DIFF
--- a/config/sync/eic_groups.group_features.eic_groups_latest_activity_stream.yml
+++ b/config/sync/eic_groups.group_features.eic_groups_latest_activity_stream.yml
@@ -1,0 +1,8 @@
+permissions:
+  - 'access latest activity stream'
+public_permissions:
+  - 'access latest activity stream'
+roles:
+  - group-member
+  - group-admin
+  - group-owner

--- a/config/sync/group.role.group-a416e6833.yml
+++ b/config/sync/group.role.group-a416e6833.yml
@@ -19,6 +19,7 @@ permissions:
   - 'access files overview'
   - 'access group content menu overview'
   - 'access group search'
+  - 'access latest activity stream'
   - 'access members overview'
   - 'access wiki overview'
   - 'delete any invitation'

--- a/config/sync/group.role.group-bf4b46c3a.yml
+++ b/config/sync/group.role.group-bf4b46c3a.yml
@@ -19,6 +19,7 @@ permissions:
   - 'access files overview'
   - 'access group content menu overview'
   - 'access group search'
+  - 'access latest activity stream'
   - 'access members overview'
   - 'access wiki overview'
   - 'delete any invitation'

--- a/config/sync/group.role.group-eca6128ca.yml
+++ b/config/sync/group.role.group-eca6128ca.yml
@@ -19,6 +19,7 @@ permissions:
   - 'access files overview'
   - 'access group content menu overview'
   - 'access group search'
+  - 'access latest activity stream'
   - 'access members overview'
   - 'access wiki overview'
   - 'delete any invitation'

--- a/lib/modules/eic_groups/config/install/eic_groups.group_features.eic_groups_latest_activity_stream.yml
+++ b/lib/modules/eic_groups/config/install/eic_groups.group_features.eic_groups_latest_activity_stream.yml
@@ -1,0 +1,8 @@
+permissions:
+  - 'access latest activity stream'
+public_permissions:
+  - 'access latest activity stream'
+roles:
+  - 'group-member'
+  - 'group-admin'
+  - 'group-owner'

--- a/lib/modules/eic_groups/eic_groups.group.permissions.yml
+++ b/lib/modules/eic_groups/eic_groups.group.permissions.yml
@@ -17,6 +17,10 @@ access files overview:
   title: 'Access Files overview'
   description: 'Gives access to the Files overview.'
   restrict access: FALSE
+access latest activity stream:
+  title: 'Access Latest Activity Stream'
+  description: 'Gives access to the Latest Activity Stream.'
+  restrict access: FALSE
 highlight group content:
   title: 'Highlight group content'
   description: 'Allow the user to highlight a group content (e.g: file/document)'

--- a/lib/modules/eic_groups/eic_groups.routing.yml
+++ b/lib/modules/eic_groups/eic_groups.routing.yml
@@ -49,10 +49,10 @@ eic_overviews.groups.overview_page.files:
     _group_permission: 'access files overview'
 
 eic_overviews.groups.overview_page.latest_activity_stream:
-  path: '/group/{group}/activity-stream'
+  path: '/group/{group}/latest-activity'
   defaults:
     # @todo: update controller namespace once we have the class.
     _controller: '\Drupal\eic_groups\Controller\AboutPageController::build'
-    _title: 'Latest activity stream'
+    _title: 'Latest activity'
   requirements:
     _group_permission: 'access latest activity stream'

--- a/lib/modules/eic_groups/eic_groups.routing.yml
+++ b/lib/modules/eic_groups/eic_groups.routing.yml
@@ -47,3 +47,12 @@ eic_overviews.groups.overview_page.files:
     _title: 'Files'
   requirements:
     _group_permission: 'access files overview'
+
+eic_overviews.groups.overview_page.latest_activity_stream:
+  path: '/group/{group}/activity-stream'
+  defaults:
+    # @todo: update controller namespace once we have the class.
+    _controller: '\Drupal\eic_groups\Controller\AboutPageController::build'
+    _title: 'Latest activity stream'
+  requirements:
+    _group_permission: 'access latest activity stream'

--- a/lib/modules/eic_groups/src/Plugin/GroupFeature/GroupLatestActivityStream.php
+++ b/lib/modules/eic_groups/src/Plugin/GroupFeature/GroupLatestActivityStream.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\eic_groups\Plugin\GroupFeature;
+
+use Drupal\Core\Url;
+
+/**
+ * Group feature plugin implementation for Latest activity stream.
+ *
+ * @GroupFeature(
+ *   id = "eic_groups_latest_activity_stream",
+ *   label = @Translation("Latest activity stream"),
+ *   description = @Translation("Group latest activity stream feature.")
+ * )
+ */
+class GroupLatestActivityStream extends EicGroupsGroupFeaturePluginBase {
+
+  /**
+   * Route of the latest activity stream overview.
+   *
+   * @todo Change the route name once we have the final overview page.
+   *
+   * @var string
+   */
+  const PRIMARY_OVERVIEW_ROUTE = 'eic_overviews.groups.overview_page.latest_activity_stream';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getMenuItem(Url $url, string $menu_name) {
+    $menu_item = parent::getMenuItem($url, $menu_name);
+    // Set a specific weight for the menu item.
+    $menu_item->set('weight', 7);
+    return $menu_item;
+  }
+
+}

--- a/lib/modules/eic_groups/src/Plugin/GroupFeature/GroupLatestActivityStream.php
+++ b/lib/modules/eic_groups/src/Plugin/GroupFeature/GroupLatestActivityStream.php
@@ -9,7 +9,7 @@ use Drupal\Core\Url;
  *
  * @GroupFeature(
  *   id = "eic_groups_latest_activity_stream",
- *   label = @Translation("Latest activity stream"),
+ *   label = @Translation("Latest activity"),
  *   description = @Translation("Group latest activity stream feature.")
  * )
  */


### PR DESCRIPTION
### Improvements

- Create group permissions: "access latest activity stream";
- Create group feature plugin to show/hide group menu link for the latest activity stream page (this should take into account permission "access latest activity stream");

### Tests

- [x] Create a new group and publish it
- [x] When viewing the group page, the group menu link "Latest activity" should be **disabled** by default
- [x] As anonymous user or logged in user I **can't** see the group menu link "Latest activity"
- [x] As GO enable the group feature "Latest activity"
- [x] As anonymous or logged in user, make sure you **can** see the group menu link "Latest activity" anymore