### PR TITLE
[EICNET-1084] feat: Send activity messages in solr for comments

### DIFF
--- a/config/sync/core.entity_form_display.message.stream_comment_insert_update.default.yml
+++ b/config/sync/core.entity_form_display.message.stream_comment_insert_update.default.yml
@@ -1,16 +1,17 @@
-uuid: ad2084f6-820d-445d-b562-c03693222aa0
+uuid: 3c07aed1-bbb6-4f73-b015-fbbf0720f041
 langcode: en
 status: true
 dependencies:
   config:
-    - field.field.message.stream_wiki_page_insert_update.field_entity_type
-    - field.field.message.stream_wiki_page_insert_update.field_group_ref
-    - field.field.message.stream_wiki_page_insert_update.field_operation_type
-    - field.field.message.stream_wiki_page_insert_update.field_referenced_node
-    - message.template.stream_wiki_page_insert_update
-id: message.stream_wiki_page_insert_update.default
+    - field.field.message.stream_comment_insert_update.field_entity_type
+    - field.field.message.stream_comment_insert_update.field_group_ref
+    - field.field.message.stream_comment_insert_update.field_operation_type
+    - field.field.message.stream_comment_insert_update.field_referenced_comment
+    - field.field.message.stream_comment_insert_update.field_referenced_node
+    - message.template.stream_comment_insert_update
+id: message.stream_comment_insert_update.default
 targetEntityType: message
-bundle: stream_wiki_page_insert_update
+bundle: stream_comment_insert_update
 mode: default
 content:
   field_entity_type:
@@ -22,7 +23,7 @@ content:
     type: string_textfield
     region: content
   field_group_ref:
-    weight: 0
+    weight: 2
     settings:
       match_operator: CONTAINS
       match_limit: 10
@@ -32,15 +33,25 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_operation_type:
-    weight: 2
+    weight: 0
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
     type: string_textfield
     region: content
-  field_referenced_node:
+  field_referenced_comment:
     weight: 1
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+  field_referenced_node:
+    weight: 4
     settings:
       match_operator: CONTAINS
       match_limit: 10

--- a/config/sync/core.entity_form_display.message.stream_discussion_insert_update.default.yml
+++ b/config/sync/core.entity_form_display.message.stream_discussion_insert_update.default.yml
@@ -3,6 +3,8 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.message.stream_discussion_insert_update.field_entity_type
+    - field.field.message.stream_discussion_insert_update.field_group_ref
     - field.field.message.stream_discussion_insert_update.field_operation_type
     - field.field.message.stream_discussion_insert_update.field_referenced_node
     - message.template.stream_discussion_insert_update
@@ -11,6 +13,14 @@ targetEntityType: message
 bundle: stream_discussion_insert_update
 mode: default
 content:
+  field_entity_type:
+    weight: 2
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
   field_operation_type:
     weight: 1
     settings:
@@ -29,4 +39,5 @@ content:
     third_party_settings: {  }
     type: entity_reference_autocomplete
     region: content
-hidden: {  }
+hidden:
+  field_group_ref: true

--- a/config/sync/core.entity_form_display.message.stream_document_insert_update.default.yml
+++ b/config/sync/core.entity_form_display.message.stream_document_insert_update.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.message.stream_document_insert_update.field_entity_type
     - field.field.message.stream_document_insert_update.field_group_ref
     - field.field.message.stream_document_insert_update.field_operation_type
     - field.field.message.stream_document_insert_update.field_referenced_node
@@ -12,6 +13,14 @@ targetEntityType: message
 bundle: stream_document_insert_update
 mode: default
 content:
+  field_entity_type:
+    weight: 3
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
   field_group_ref:
     weight: 0
     settings:

--- a/config/sync/core.entity_view_display.message.stream_comment_insert_update.default.yml
+++ b/config/sync/core.entity_view_display.message.stream_comment_insert_update.default.yml
@@ -3,12 +3,57 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.message.stream_comment_insert_update.field_entity_type
+    - field.field.message.stream_comment_insert_update.field_group_ref
+    - field.field.message.stream_comment_insert_update.field_operation_type
+    - field.field.message.stream_comment_insert_update.field_referenced_comment
+    - field.field.message.stream_comment_insert_update.field_referenced_node
     - message.template.stream_comment_insert_update
 id: message.stream_comment_insert_update.default
 targetEntityType: message
 bundle: stream_comment_insert_update
 mode: default
 content:
+  field_entity_type:
+    weight: 4
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_group_ref:
+    weight: 3
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_operation_type:
+    weight: 1
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_referenced_comment:
+    weight: 2
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_referenced_node:
+    weight: 5
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
   partial_0:
     weight: 0
     region: content

--- a/config/sync/core.entity_view_display.message.stream_discussion_insert_update.default.yml
+++ b/config/sync/core.entity_view_display.message.stream_discussion_insert_update.default.yml
@@ -3,6 +3,8 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.message.stream_discussion_insert_update.field_entity_type
+    - field.field.message.stream_discussion_insert_update.field_group_ref
     - field.field.message.stream_discussion_insert_update.field_operation_type
     - field.field.message.stream_discussion_insert_update.field_referenced_node
     - message.template.stream_discussion_insert_update
@@ -11,6 +13,14 @@ targetEntityType: message
 bundle: stream_discussion_insert_update
 mode: default
 content:
+  field_entity_type:
+    weight: 3
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
   field_operation_type:
     weight: 2
     label: above

--- a/config/sync/core.entity_view_display.message.stream_document_insert_update.default.yml
+++ b/config/sync/core.entity_view_display.message.stream_document_insert_update.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.message.stream_document_insert_update.field_entity_type
     - field.field.message.stream_document_insert_update.field_group_ref
     - field.field.message.stream_document_insert_update.field_operation_type
     - field.field.message.stream_document_insert_update.field_referenced_node
@@ -12,6 +13,14 @@ targetEntityType: message
 bundle: stream_document_insert_update
 mode: default
 content:
+  field_entity_type:
+    weight: 4
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
   field_group_ref:
     weight: 1
     label: above

--- a/config/sync/core.entity_view_display.message.stream_wiki_page_insert_update.default.yml
+++ b/config/sync/core.entity_view_display.message.stream_wiki_page_insert_update.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.message.stream_wiki_page_insert_update.field_entity_type
     - field.field.message.stream_wiki_page_insert_update.field_group_ref
     - field.field.message.stream_wiki_page_insert_update.field_operation_type
     - field.field.message.stream_wiki_page_insert_update.field_referenced_node
@@ -12,6 +13,14 @@ targetEntityType: message
 bundle: stream_wiki_page_insert_update
 mode: default
 content:
+  field_entity_type:
+    weight: 4
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
   field_group_ref:
     weight: 1
     label: above

--- a/config/sync/field.field.message.stream_comment_insert_update.field_entity_type.yml
+++ b/config/sync/field.field.message.stream_comment_insert_update.field_entity_type.yml
@@ -1,0 +1,19 @@
+uuid: 2992a1c4-b969-40c6-bc7f-d43e4ade878e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_entity_type
+    - message.template.stream_comment_insert_update
+id: message.stream_comment_insert_update.field_entity_type
+field_name: field_entity_type
+entity_type: message
+bundle: stream_comment_insert_update
+label: 'Entity type'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.message.stream_comment_insert_update.field_group_ref.yml
+++ b/config/sync/field.field.message.stream_comment_insert_update.field_group_ref.yml
@@ -1,0 +1,29 @@
+uuid: ac251e06-cc71-414d-b1b4-02312b588edb
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_group_ref
+    - group.type.group
+    - message.template.stream_comment_insert_update
+id: message.stream_comment_insert_update.field_group_ref
+field_name: field_group_ref
+entity_type: message
+bundle: stream_comment_insert_update
+label: Group
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:group'
+  handler_settings:
+    target_bundles:
+      group: group
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.message.stream_comment_insert_update.field_operation_type.yml
+++ b/config/sync/field.field.message.stream_comment_insert_update.field_operation_type.yml
@@ -1,0 +1,19 @@
+uuid: 1f4365ae-0188-4346-b69c-e0aa4102a4a4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_operation_type
+    - message.template.stream_comment_insert_update
+id: message.stream_comment_insert_update.field_operation_type
+field_name: field_operation_type
+entity_type: message
+bundle: stream_comment_insert_update
+label: 'Operation type'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.message.stream_comment_insert_update.field_referenced_comment.yml
+++ b/config/sync/field.field.message.stream_comment_insert_update.field_referenced_comment.yml
@@ -1,0 +1,29 @@
+uuid: 4239c09e-7734-47d3-b847-d225bdde1143
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.node_comment
+    - field.storage.message.field_referenced_comment
+    - message.template.stream_comment_insert_update
+id: message.stream_comment_insert_update.field_referenced_comment
+field_name: field_referenced_comment
+entity_type: message
+bundle: stream_comment_insert_update
+label: 'Referenced comment'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:comment'
+  handler_settings:
+    target_bundles:
+      node_comment: node_comment
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.message.stream_comment_insert_update.field_referenced_node.yml
+++ b/config/sync/field.field.message.stream_comment_insert_update.field_referenced_node.yml
@@ -1,0 +1,45 @@
+uuid: f2651893-5080-44c6-aaae-9bc2299afb20
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_referenced_node
+    - message.template.stream_comment_insert_update
+    - node.type.book
+    - node.type.discussion
+    - node.type.document
+    - node.type.gallery
+    - node.type.news
+    - node.type.page
+    - node.type.story
+    - node.type.video
+    - node.type.wiki_page
+id: message.stream_comment_insert_update.field_referenced_node
+field_name: field_referenced_node
+entity_type: message
+bundle: stream_comment_insert_update
+label: 'Referenced node'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      book: book
+      discussion: discussion
+      document: document
+      gallery: gallery
+      news: news
+      page: page
+      story: story
+      video: video
+      wiki_page: wiki_page
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: book
+field_type: entity_reference

--- a/config/sync/field.field.message.stream_discussion_insert_update.field_entity_type.yml
+++ b/config/sync/field.field.message.stream_discussion_insert_update.field_entity_type.yml
@@ -1,0 +1,19 @@
+uuid: bda0b611-bd17-4210-8bce-dfb7d50124ec
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_entity_type
+    - message.template.stream_discussion_insert_update
+id: message.stream_discussion_insert_update.field_entity_type
+field_name: field_entity_type
+entity_type: message
+bundle: stream_discussion_insert_update
+label: 'Entity type'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.message.stream_document_insert_update.field_entity_type.yml
+++ b/config/sync/field.field.message.stream_document_insert_update.field_entity_type.yml
@@ -1,0 +1,19 @@
+uuid: 883b90d3-47b6-4a67-93e7-3c8442812ace
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_entity_type
+    - message.template.stream_document_insert_update
+id: message.stream_document_insert_update.field_entity_type
+field_name: field_entity_type
+entity_type: message
+bundle: stream_document_insert_update
+label: 'Entity type'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.message.stream_wiki_page_insert_update.field_entity_type.yml
+++ b/config/sync/field.field.message.stream_wiki_page_insert_update.field_entity_type.yml
@@ -1,0 +1,19 @@
+uuid: 14aa0123-db31-4f1c-a416-e7e51c95501f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_entity_type
+    - message.template.stream_wiki_page_insert_update
+id: message.stream_wiki_page_insert_update.field_entity_type
+field_name: field_entity_type
+entity_type: message
+bundle: stream_wiki_page_insert_update
+label: 'Entity type'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.message.field_entity_type.yml
+++ b/config/sync/field.storage.message.field_entity_type.yml
@@ -1,0 +1,21 @@
+uuid: 56d506cb-45e1-4563-b348-798073648f2c
+langcode: en
+status: true
+dependencies:
+  module:
+    - message
+id: message.field_entity_type
+field_name: field_entity_type
+entity_type: message
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.message.field_referenced_comment.yml
+++ b/config/sync/field.storage.message.field_referenced_comment.yml
@@ -1,0 +1,20 @@
+uuid: ca63a172-bd2d-464c-bd90-4b807864c8f9
+langcode: en
+status: true
+dependencies:
+  module:
+    - comment
+    - message
+id: message.field_referenced_comment
+field_name: field_referenced_comment
+entity_type: message
+type: entity_reference
+settings:
+  target_type: comment
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/search_api.index.global.yml
+++ b/config/sync/search_api.index.global.yml
@@ -631,6 +631,14 @@ field_settings:
       module:
         - group
         - user
+  message_id:
+    label: 'Message ID'
+    datasource_id: 'entity:message'
+    property_path: mid
+    type: integer
+    dependencies:
+      module:
+        - message
   operation_type:
     label: 'Operation type'
     datasource_id: 'entity:message'

--- a/config/sync/search_api.index.global.yml
+++ b/config/sync/search_api.index.global.yml
@@ -4,14 +4,12 @@ status: true
 dependencies:
   module:
     - search_api_solr
-    - node
+    - group
+    - user
+    - file
     - media
     - taxonomy
     - message
-    - user
-    - file
-    - paragraphs
-    - group
     - node
     - path
     - eic_private_content
@@ -26,11 +24,6 @@ dependencies:
     - flag
     - group_permissions
   config:
-    - field.storage.node.field_document_media
-    - field.storage.node.field_body
-    - field.storage.node.field_discussion_type
-    - field.storage.node.field_subtitle
-    - field.storage.node.field_language
     - field.storage.user.field_first_name
     - field.storage.user.field_last_name
     - field.storage.media.oe_media_image
@@ -39,27 +32,30 @@ dependencies:
     - field.storage.group.field_thumbnail
     - field.storage.group.field_vocab_topics
     - field.storage.group.field_body
+    - field.storage.message.field_entity_type
     - field.storage.message.field_group_ref
     - field.storage.message.field_operation_type
     - field.storage.message.field_referenced_node
     - field.storage.media.field_media_file
-    - field.storage.message.field_operation_type
-    - field.storage.message.field_referenced_node
+    - field.storage.node.field_document_media
+    - field.storage.node.field_language
     - field.storage.node.field_vocab_geo
-    - field.storage.node.field_vocab_topics
-    - field.storage.user.field_first_name
-    - field.storage.media.oe_media_file
     - field.storage.node.field_gallery_slides
-    - field.storage.paragraph.field_gallery_slide_media
     - field.storage.paragraph.field_gallery_slide_legend
-    - field.storage.profile.field_location_address
+    - field.storage.media.oe_media_file
+    - field.storage.paragraph.field_gallery_slide_media
+    - field.storage.node.field_vocab_topics
+    - field.storage.node.field_body
+    - field.storage.node.field_subtitle
+    - field.storage.node.field_discussion_type
     - field.storage.profile.field_body
+    - field.storage.profile.field_location_address
+    - field.storage.profile.field_vocab_job_title
     - field.storage.profile.field_vocab_language
+    - field.storage.profile.field_social_links
+    - field.storage.profile.field_vocab_geo
     - field.storage.profile.field_vocab_topic_expertise
     - field.storage.profile.field_vocab_topic_interest
-    - field.storage.profile.field_vocab_geo
-    - field.storage.profile.field_vocab_job_title
-    - field.storage.profile.field_social_links
     - search_api.server.global
     - core.entity_view_mode.group.no_html
     - core.entity_view_mode.node.no_html
@@ -725,15 +721,13 @@ field_settings:
       module:
         - node
   type:
-    label: 'Referenced node » Content » Content type'
+    label: 'Entity type'
     datasource_id: 'entity:message'
-    property_path: 'field_referenced_node:entity:type'
+    property_path: field_entity_type
     type: string
     dependencies:
       config:
-        - field.storage.message.field_referenced_node
-      module:
-        - node
+        - field.storage.message.field_entity_type
   url:
     label: URI
     property_path: search_api_url

--- a/lib/modules/eic_messages/eic_messages.module
+++ b/lib/modules/eic_messages/eic_messages.module
@@ -9,13 +9,11 @@ use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\BubbleableMetadata;
+use Drupal\eic_messages\ActivityStreamOperationTypes;
 use Drupal\eic_messages\Hooks\EntityOperations;
 use Drupal\eic_messages\Hooks\FormOperations;
-use Drupal\eic_messages\Hooks\GroupContentMessageCreator;
-use Drupal\eic_messages\Hooks\GroupMessageCreator;
 use Drupal\eic_messages\Hooks\LogMessageRenderer;
 use Drupal\eic_messages\Hooks\MessageTokens;
-use Drupal\eic_messages\Hooks\RequestMessageCreator;
 use Drupal\flag\FlaggingInterface;
 use Drupal\node\Entity\NodeType;
 
@@ -35,6 +33,24 @@ function eic_messages_group_update(EntityInterface $entity) {
   /** @var Drupal\eic_messages\Service\GroupMessageCreator $class */
   $class = \Drupal::service('eic_messages.message_creator.group');
   $class->groupUpdate($entity);
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_update().
+ */
+function eic_messages_comment_insert(EntityInterface $entity) {
+  /** @var \Drupal\eic_messages\Service\CommentMessageCreator $group_message_create */
+  $group_message_create = \Drupal::service('eic_messages.message_creator.comment');
+  $group_message_create->createCommentActivity($entity, ActivityStreamOperationTypes::NEW_ENTITY);
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_update().
+ */
+function eic_messages_comment_update(EntityInterface $entity) {
+  /** @var \Drupal\eic_messages\Service\CommentMessageCreator $group_message_create */
+  $group_message_create = \Drupal::service('eic_messages.message_creator.comment');
+  $group_message_create->createCommentActivity($entity, ActivityStreamOperationTypes::UPDATED_ENTITY);
 }
 
 /**

--- a/lib/modules/eic_messages/eic_messages.services.yml
+++ b/lib/modules/eic_messages/eic_messages.services.yml
@@ -13,3 +13,6 @@ services:
   eic_messages.message_creator.request:
     class: Drupal\eic_messages\Service\RequestMessageCreator
     arguments: ['@entity_type.manager', '@eic_messages.helper', '@eic_user.helper', '@eic_flags.handler_collector', '@renderer']
+  eic_messages.message_creator.comment:
+    class: Drupal\eic_messages\Service\CommentMessageCreator
+    arguments: ['@entity_type.manager', '@eic_messages.helper', '@eic_user.helper', '@eic_content.helper']

--- a/lib/modules/eic_messages/src/Service/CommentMessageCreator.php
+++ b/lib/modules/eic_messages/src/Service/CommentMessageCreator.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Drupal\eic_messages\Service;
+
+use Drupal\comment\CommentInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\eic_content\EICContentHelperInterface;
+use Drupal\eic_messages\MessageHelper;
+use Drupal\eic_user\UserHelper;
+
+/**
+ * Class CommentMessageCreator.
+ */
+class CommentMessageCreator extends MessageCreatorBase {
+
+  /**
+   * @var \Drupal\eic_content\EICContentHelperInterface
+   */
+  private $contentHelper;
+
+  /**
+   * CommentMessageCreator constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   * @param \Drupal\eic_messages\MessageHelper $eic_messages_helper
+   * @param \Drupal\eic_user\UserHelper $eic_user_helper
+   * @param \Drupal\eic_content\EICContentHelperInterface $content_helper
+   */
+  public function __construct(
+    EntityTypeManagerInterface $entity_type_manager,
+    MessageHelper $eic_messages_helper,
+    UserHelper $eic_user_helper,
+    EICContentHelperInterface $content_helper
+  ) {
+    parent::__construct($entity_type_manager, $eic_messages_helper, $eic_user_helper);
+
+    $this->contentHelper = $content_helper;
+  }
+
+  /**
+   * Creates an activity stream message for a comment on a content inside a group.
+   *
+   * @param CommentInterface $entity
+   *   The group having this content.
+   * @param string $operation
+   *   The type of the operation. See ActivityStreamOperationTypes
+   */
+  public function createCommentActivity(
+    CommentInterface $entity,
+    string $operation
+  ) {
+    $route_match = \Drupal::routeMatch();
+    if (!in_array($route_match->getRouteName(), ['comment.reply', 'entity.comment.edit_form'])) {
+      return;
+    }
+
+    $commented_entity = $entity->getCommentedEntity();
+    $group_content = $this->contentHelper->getGroupContentByEntity($commented_entity);
+    if (empty($group_content)) {
+      return;
+    }
+
+    $group_content = reset($group_content);
+    $group = $group_content->getGroup();
+    $message = \Drupal::entityTypeManager()->getStorage('message')->create([
+      'template' => 'stream_comment_insert_update',
+      'field_referenced_comment' => $entity,
+      'field_referenced_node' => $commented_entity,
+      'field_entity_type' => $entity->getEntityTypeId(),
+      'field_operation_type' => $operation,
+      'field_group_ref' => $group,
+    ]);
+
+    try {
+      $message->save();
+    } catch (\Exception $e) {
+      $logger = $this->getLogger('eic_messages');
+      $logger->error($e->getMessage());
+    }
+  }
+
+}

--- a/lib/modules/eic_messages/src/Service/GroupContentMessageCreator.php
+++ b/lib/modules/eic_messages/src/Service/GroupContentMessageCreator.php
@@ -78,6 +78,7 @@ class GroupContentMessageCreator extends MessageCreatorBase {
           'template' => $this->getActivityItemTemplate($entity),
           'field_referenced_node' => $entity,
           'field_operation_type' => $operation,
+          'field_entity_type' => $entity->getEntityTypeId(),
           'field_group_ref' => $group,
         ]);
         break;


### PR DESCRIPTION
### To Test

- [ ] Add a comment on any node
- [ ] In Solr you should get a message with 'ss_operation_type' = 'created' and 'ss_type' = 'comment' for it
- [ ] Update it, should should get a new one with 'ss_operation_type' = 'updated'