### PR TITLE
EICNET-1156: Breadcrumb - Story should be Stories

### DIFF
--- a/lib/modules/eic_content/src/ContentBreadcrumbBuilder.php
+++ b/lib/modules/eic_content/src/ContentBreadcrumbBuilder.php
@@ -75,7 +75,7 @@ class ContentBreadcrumbBuilder implements BreadcrumbBuilderInterface {
 
         case 'story':
           // @todo Replace link route with overview page route when available.
-          $links[] = Link::createFromRoute($this->t('Story'), '<front>');
+          $links[] = Link::createFromRoute($this->t('Stories'), '<front>');
           break;
 
       }


### PR DESCRIPTION
### Improvements

- Replace breadcrumb link "Story" with "Stories".

### Tests

- [x] Create a new story and publish it 
- [x] Go to the story detail page and check if the breadcrumb looks like: `Home > Stories > Story name`