### PR TITLE
EICNET-477: Add document language field to document media type

### DIFF
--- a/config/sync/core.entity_form_display.media.eic_document.default.yml
+++ b/config/sync/core.entity_form_display.media.eic_document.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.media.eic_document.field_body
+    - field.field.media.eic_document.field_language
     - field.field.media.eic_document.field_media_file
     - field.field.media.eic_document.field_vocab_topics
     - media.type.eic_document
@@ -18,7 +19,7 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 5
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -30,15 +31,21 @@ content:
     third_party_settings: {  }
     type: text_textarea
     region: content
+  field_language:
+    weight: 5
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
   field_media_file:
-    weight: 3
+    weight: 4
     settings:
       progress_indicator: throbber
     third_party_settings: {  }
     type: file_generic
     region: content
   field_vocab_topics:
-    weight: 2
+    weight: 3
     settings: {  }
     third_party_settings: {  }
     type: options_select
@@ -60,7 +67,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 6
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -68,12 +75,12 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 7
+    weight: 9
     region: content
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 4
+    weight: 6
     settings:
       match_operator: CONTAINS
       size: 60

--- a/config/sync/core.entity_view_display.media.eic_document.default.yml
+++ b/config/sync/core.entity_view_display.media.eic_document.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.media.eic_document.field_body
+    - field.field.media.eic_document.field_language
     - field.field.media.eic_document.field_media_file
     - field.field.media.eic_document.field_vocab_topics
     - media.type.eic_document
@@ -21,6 +22,14 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: text_default
+    region: content
+  field_language:
+    weight: 11
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
     region: content
   field_media_file:
     label: visually_hidden

--- a/config/sync/core.entity_view_display.media.eic_document.download.yml
+++ b/config/sync/core.entity_view_display.media.eic_document.download.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.media.download
     - field.field.media.eic_document.field_body
+    - field.field.media.eic_document.field_language
     - field.field.media.eic_document.field_media_file
     - field.field.media.eic_document.field_vocab_topics
     - media.type.eic_document
@@ -51,6 +52,7 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_language: true
   field_vocab_topics: true
   langcode: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.media.eic_document.media_library.yml
+++ b/config/sync/core.entity_view_display.media.eic_document.media_library.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.media.media_library
     - field.field.media.eic_document.field_body
+    - field.field.media.eic_document.field_language
     - field.field.media.eic_document.field_media_file
     - field.field.media.eic_document.field_vocab_topics
     - media.type.eic_document
@@ -44,6 +45,7 @@ content:
 hidden:
   created: true
   field_body: true
+  field_language: true
   field_vocab_topics: true
   langcode: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.media.eic_document.oe_theme_main_content.yml
+++ b/config/sync/core.entity_view_display.media.eic_document.oe_theme_main_content.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.media.oe_theme_main_content
     - field.field.media.eic_document.field_body
+    - field.field.media.eic_document.field_language
     - field.field.media.eic_document.field_media_file
     - field.field.media.eic_document.field_vocab_topics
     - media.type.eic_document
@@ -59,6 +60,7 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_language: true
   langcode: true
   search_api_excerpt: true
   thumbnail: true

--- a/config/sync/field.field.media.eic_document.field_language.yml
+++ b/config/sync/field.field.media.eic_document.field_language.yml
@@ -1,0 +1,29 @@
+uuid: c4153c91-d024-4e4b-afa6-7dc1cbd6c630
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_language
+    - media.type.eic_document
+    - taxonomy.vocabulary.languages
+id: media.eic_document.field_language
+field_name: field_language
+entity_type: media
+bundle: eic_document
+label: Language
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      languages: languages
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.storage.media.field_language.yml
+++ b/config/sync/field.storage.media.field_language.yml
@@ -1,0 +1,20 @@
+uuid: 75468ad5-695e-403a-af96-f46d6d096e8a
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - taxonomy
+id: media.field_language
+field_name: field_language
+entity_type: media
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/lib/themes/eic_community/includes/preprocess/content/node--document.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--document.inc
@@ -21,8 +21,25 @@ function eic_community_preprocess_node__document(array &$variables) {
       return;
     }
 
+    $document_media = $node->get('field_document_media')->entity;
+    $language = $node->language()->getName();
+
+    // Gets the document language based on the field_language of the Media
+    // type.
+    if (!$document_media->get('field_language')->isEmpty()) {
+      $lang_term = $document_media->get('field_language')->entity;
+
+      if ($lang_term->hasTranslation($node->language()->getId())) {
+        $translated_lang_term = \Drupal::service('entity.repository')->getTranslationFromContext($lang_term, $language);
+        $language = $translated_lang_term->getName();
+      }
+      else {
+        $language = $lang_term->getName();
+      }
+    }
+
     $document = [
-      'language' => $node->language()->getName(),
+      'language' => $language,
       'timestamp' => eic_community_get_teaser_time_display($node->get('changed')->getString()),
       'filesize' => format_size($file->get('filesize')->getString()),
       'highlight' => FALSE,

--- a/lib/themes/eic_community/includes/preprocess/content/node--document.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--document.inc
@@ -5,8 +5,6 @@
  * Prepares variables for node document templates.
  */
 
-use Drupal\file\Entity\File;
-
 /**
  * Implements hook_preprocess_node() for document node.
  */
@@ -15,7 +13,15 @@ function eic_community_preprocess_node__document(array &$variables) {
   $node = $variables['node'];
 
   if ($variables['teaser']) {
-    $file = File::load($node->get('field_document_media')->getString());
+
+    // If document has no medias, we do nothing.
+    if ($node->get('field_document_media')->isEmpty()) {
+      return;
+    }
+
+    $document_media = reset($node->get('field_document_media')->referencedEntities());
+
+    $file = $document_media->get('field_media_file')->entity;
 
     if (!$file) {
       return;
@@ -28,7 +34,14 @@ function eic_community_preprocess_node__document(array &$variables) {
     // type.
     if (!$document_media->get('field_language')->isEmpty()) {
       $lang_term = $document_media->get('field_language')->entity;
+    }
+    elseif (!$node->get('field_language')->isEmpty()) {
+      // If the media document doesn't have a language we use the one from the
+      // node.
+      $lang_term = $node->get('field_language')->entity;
+    }
 
+    if (isset($lang_term)) {
       if ($lang_term->hasTranslation($node->language()->getId())) {
         $translated_lang_term = \Drupal::service('entity.repository')->getTranslationFromContext($lang_term, $language);
         $language = $translated_lang_term->getName();


### PR DESCRIPTION
### Changes

- Add new taxonomy term field "Language" in Media Type "Document";
- Show the media document field language when viewing the teaser version.

### Tests

- [ ] Create a new group
- [ ] Create a new Document for the group and when creating the media, select a language for the media (create a taxonomy term with a name other than "English")
- [ ] Go to the group homepage and check if it's the right language that is shown in the document teaser