### PR TITLE
[EICNET-1253]fix: Set 5000 as length cause custom widget have labels in value

### DIFF
--- a/lib/modules/eic_content/src/Plugin/Field/FieldWidget/EntityTreeWidget.php
+++ b/lib/modules/eic_content/src/Plugin/Field/FieldWidget/EntityTreeWidget.php
@@ -96,6 +96,7 @@ class EntityTreeWidget extends WidgetBase {
         '#default_value' => $items->referencedEntities(),
         '#tags' => TRUE,
         '#target_type' => $this->getFieldSetting('target_type'),
+        '#maxlength' => 5000,
         '#element_validate' => [
           [static::class, 'validate'],
         ],


### PR DESCRIPTION
This PR impact the entity tree field widget

How to test:

- [ ] Go to story creation/edit
- [ ] Select a lot of topics (needs to have all labels concatenated >= 128 characters)
- [ ] see if it's saving