### PR TITLE
Bugfix: Fix Flags issue in Group header

### DIFF
--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
@@ -345,6 +345,11 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
     // access to.
     foreach (array_keys($group->flags) as $flag_name) {
       $flag = $this->flagService->getFlagById(str_replace('flag_', '', $flag_name));
+
+      if (!$flag) {
+        continue;
+      }
+
       $user_flag = $this->flagService->getFlagging($flag, $group);
 
       // We need to create a fake flag if the user never flagged the content,


### PR DESCRIPTION
### Fixes

- Add condition to check if a flag exists before loading the group flags in the group header.

### Tests

- [ ] Create a new group
- [ ] Go to the group homepage and check if don't have a php error like `TypeError: Argument 1 passed to Drupal\flag\FlagService::getFlagging() must implement interface Drupal\flag\FlagInterface, null given`