### PR TITLE
[EICNET-1276]fix: Do not multiply rows by current page

### DIFF
--- a/lib/modules/eic_search/src/Controller/SolrSearchController.php
+++ b/lib/modules/eic_search/src/Controller/SolrSearchController.php
@@ -316,7 +316,7 @@ class SolrSearchController extends ControllerBase {
    * @param \Drupal\eic_search\Search\Sources\SourceTypeInterface|null $source
    */
   private function generateQueryPager(Query &$solariumQuery, int $page, int $offset, ?SourceTypeInterface $source) {
-    $solariumQuery->setRows($page * $offset);
+    $solariumQuery->setRows($offset);
 
     //Default value will be to work like pagination
     if ($source instanceof SourceTypeInterface && $source->allowPagination()) {


### PR DESCRIPTION
How to test:

- [x] Go into /search
- [x] Be sure you have more than 20 contents for global
- [x] Go on second page and count that you have 10 results