### PR TITLE
Fix node document preprocess

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/content/node--document.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--document.inc
@@ -5,6 +5,8 @@
  * Prepares variables for node document templates.
  */
 
+use Drupal\file\Entity\File;
+
 /**
  * Implements hook_preprocess_node() for document node.
  */


### PR DESCRIPTION
### Fixes

- Fix error Class 'File' not found in eic_community_preprocess_node__document().

### Tests

- [ ] Create a group
- [ ] Create a document in the group
- [ ] Go to the document detail page and check if there is no error