### PR TITLE
EICNET-1352: Group overview - Admins don't see all groups

### DIFF
--- a/lib/modules/eic_search/src/Plugin/search_api/processor/GroupAccessContent.php
+++ b/lib/modules/eic_search/src/Plugin/search_api/processor/GroupAccessContent.php
@@ -4,8 +4,8 @@ namespace Drupal\eic_search\Plugin\search_api\processor;
 
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\eic_groups\Constants\GroupVisibilityType;
+use Drupal\eic_user\UserHelper;
 use Drupal\group\GroupMembership;
-use Drupal\search_api\Annotation\SearchApiProcessor;
 use Drupal\search_api\Datasource\DatasourceInterface;
 use Drupal\search_api\Processor\ProcessorPluginBase;
 use Drupal\search_api\Processor\ProcessorProperty;
@@ -106,14 +106,28 @@ class GroupAccessContent extends ProcessorPluginBase {
   }
 
   /**
-   * Create the query string for SOLR to match with group visibility
+   * Create the query string for SOLR to match with group visibility.
    *
    * @return string
+   *   The group visibility query string to send to SOLR.
    */
   private function buildGroupVisibilityQuery(): string {
     $user_id = $this->currentUser->id();
 
     $user = User::load($user_id);
+
+    // Power user can access all groups.
+    if (UserHelper::isPowerUser($user)) {
+      return '
+        (
+          ss_group_visibility:' . GroupVisibilityType::GROUP_VISIBILITY_PUBLIC . '
+          OR ss_group_visibility:' . GroupVisibilityType::GROUP_VISIBILITY_PRIVATE . '
+          OR ss_group_visibility:' . GroupVisibilityType::GROUP_VISIBILITY_COMMUNITY . '
+          OR ss_group_visibility:' . GroupVisibilityType::GROUP_VISIBILITY_CUSTOM_RESTRICTED . '
+        )
+      ';
+    }
+
     $email = explode('@', $user->getEmail());
     $domain = array_pop($email) ?: 0;
 
@@ -125,7 +139,7 @@ class GroupAccessContent extends ProcessorPluginBase {
       return $group_membership->getGroup()->id();
     }, $groups);
 
-    // If group is private, the user needs to be in group to view it
+    // If group is private, the user needs to be in group to view it.
     $group_ids_formatted = !empty($group_ids) ? implode(' OR ', $group_ids) : 0;
 
     $query = '
@@ -134,12 +148,12 @@ class GroupAccessContent extends ProcessorPluginBase {
     OR (ss_group_visibility:' . GroupVisibilityType::GROUP_VISIBILITY_OPTION_EMAIL_DOMAIN . ' AND ss_' . GroupVisibilityType::GROUP_VISIBILITY_OPTION_EMAIL_DOMAIN . ':*' . $domain . '*)
     ';
 
-    // Restricted community group, only trusted_user role can view
+    // Restricted community group, only trusted_user role can view.
     if (!$user->isAnonymous() && $user->hasRole('trusted_user')) {
       $query .= ' OR (ss_group_visibility:' . GroupVisibilityType::GROUP_VISIBILITY_COMMUNITY . ')';
     }
 
-    // Trusted users restriction
+    // Trusted users restriction.
     if (!$user->isAnonymous()) {
       $username = $user->getAccountName();
       $query .= ' OR (ss_group_visibility:' . GroupVisibilityType::GROUP_VISIBILITY_OPTION_TRUSTED_USERS . ' AND ss_' . GroupVisibilityType::GROUP_VISIBILITY_OPTION_TRUSTED_USERS . ':*' . "$user_id|$username" . '*)';


### PR DESCRIPTION
### Fixes

- Allow Administrators to see all groups in the overview page;
- Fix coding standards.

### Tests

- [ ] As a TU, create a new private group
- [ ] As SA/SCM, go to `/admin/group` and edit the group. Change the group state to draft and save it.
- [ ] As TU, publish the group.
- [ ] As SA/SCM, go to `/groups` and make sure you can view the group.
- [ ] As TU, try to change the group visibility to **Community members only** or **Custom restricted** and check if SA/SCM can still see the group in the overview page `/groups`