### PR TITLE
EICNET-1354: Generate the statistics for the stories / news in the backend

### DIFF
--- a/lib/modules/eic_block_types/eic_block_types.module
+++ b/lib/modules/eic_block_types/eic_block_types.module
@@ -8,3 +8,21 @@
  * This file is no longer required in Drupal 8.
  * @see https://www.drupal.org/node/2217931
  */
+
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\eic_block_types\Hooks\EntityOperations;
+
+/**
+ * Implements hook_ENTITY_TYPE_view().
+ */
+function eic_content_block_content_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
+  switch ($entity->bundle()) {
+    case 'latest_news_stories':
+      \Drupal::classResolver(EntityOperations::class)
+        ->blockContentView($build, $entity, $display, $view_mode);
+      break;
+
+  }
+
+}

--- a/lib/modules/eic_block_types/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_block_types/src/Hooks/EntityOperations.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Drupal\eic_block_types\Hooks;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\flag\FlagCountManagerInterface;
+use Drupal\node\NodeInterface;
+use Drupal\statistics\NodeStatisticsDatabaseStorage;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class EntityOperations.
+ *
+ * Implementations of entity hooks for block_content entities.
+ */
+class EntityOperations implements ContainerInjectionInterface {
+
+  /**
+   * The Entity file download count service.
+   *
+   * @var \Drupal\statistics\NodeStatisticsDatabaseStorage
+   */
+  protected $nodeStatisticsDatabaseStorage;
+
+  /**
+   * The entity field manager.
+   *
+   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
+   */
+  private $entityFieldManager;
+
+  /**
+   * The Flag count manager.
+   *
+   * @var \Drupal\flag\FlagCountManagerInterface
+   */
+  private $flagCountManager;
+
+  /**
+   * Constructs a EntityOperation object.
+   *
+   * @param \Drupal\statistics\NodeStatisticsDatabaseStorage $node_statistics_db_storage
+   *   The Entity file download count service.
+   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager
+   *   The entity field manager.
+   * @param \Drupal\flag\FlagCountManagerInterface $flag_count_manager
+   *   The Flag count manager.
+   */
+  public function __construct(NodeStatisticsDatabaseStorage $node_statistics_db_storage, EntityFieldManagerInterface $entity_field_manager, FlagCountManagerInterface $flag_count_manager) {
+    $this->nodeStatisticsDatabaseStorage = $node_statistics_db_storage;
+    $this->entityFieldManager = $entity_field_manager;
+    $this->flagCountManager = $flag_count_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('statistics.storage.node'),
+      $container->get('entity_field.manager'),
+      $container->get('flag.count')
+    );
+  }
+
+  /**
+   * Acts on hook_node_view() for node entities.
+   *
+   * @param array $build
+   *   The renderable array representing the entity content.
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The node entity object.
+   * @param \Drupal\Core\Entity\Display\EntityViewDisplayInterface $display
+   *   The entity view display holding the display options.
+   * @param string $view_mode
+   *   The view mode the entity is rendered in.
+   */
+  public function blockContentView(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
+    switch ($entity->bundle()) {
+      case 'latest_news_stories':
+        $this->viewLatestNewsStoriesStatistics($build, $entity, $display, $view_mode);
+        break;
+
+    }
+  }
+
+  /**
+   * Adds nodes statistics to the latest news and stories block.
+   *
+   * @param array $build
+   *   The renderable array representing the entity content.
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The node entity object.
+   * @param \Drupal\Core\Entity\Display\EntityViewDisplayInterface $display
+   *   The entity view display holding the display options.
+   * @param string $view_mode
+   *   The view mode the entity is rendered in.
+   */
+  private function viewLatestNewsStoriesStatistics(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
+    $nodes = [];
+
+    // Adds News/Stories to the array of nodes to process.
+    if (!$entity->get('field_articles')->isEmpty()) {
+      $nodes = $entity->get('field_articles')->referencedEntities();
+    }
+
+    // Adds featured News/Story to the beginning of array of nodes.
+    if (!$entity->get('field_featured_article')->isEmpty()) {
+      array_unshift($nodes, $entity->get('field_featured_article')->entity);
+    }
+
+    $build['node_stats'] = [];
+
+    // Process the array of nodes and add statistics to the renderable array.
+    foreach ($nodes as $node) {
+      if (!$node instanceof NodeInterface) {
+        continue;
+      }
+
+      // Page views statistic.
+      $page_views = 0;
+      if ($node_views = $this->nodeStatisticsDatabaseStorage->fetchView($node->id())) {
+        $page_views = $node_views->getTotalCount();
+      }
+      $build['node_stats'][$node->id()]['page_views'] = [
+        '#markup' => '',
+        '#value' => $page_views,
+      ];
+
+      // Comments count statistic.
+      $comment_count = 0;
+      $entity_fields = $this->entityFieldManager->getFieldDefinitions('node', $node->bundle());
+      foreach ($entity_fields as $field) {
+        switch ($field->getType()) {
+          case 'comment':
+            $comment_count += (int) $node->get($field->getName())->comment_count;
+            break;
+
+        }
+      }
+      $build['node_stats'][$node->id()]['comments_count'] = [
+        '#markup' => '',
+        '#items' => $comment_count,
+      ];
+
+      // Flags count statistic.
+      $build['node_stats'][$node->id()]['flag_counts'] = [
+        '#markup' => '',
+        '#items' => $this->flagCountManager->getEntityFlagCounts($node),
+      ];
+    }
+  }
+
+}

--- a/lib/modules/eic_block_types/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_block_types/src/Hooks/EntityOperations.php
@@ -143,7 +143,7 @@ class EntityOperations implements ContainerInjectionInterface {
       }
       $build['node_stats'][$node->id()]['comments_count'] = [
         '#markup' => '',
-        '#items' => $comment_count,
+        '#value' => $comment_count,
       ];
 
       // Flags count statistic.

--- a/lib/modules/eic_statistics/src/NodeStatisticsDatabaseStorage.php
+++ b/lib/modules/eic_statistics/src/NodeStatisticsDatabaseStorage.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\eic_statistics;
 
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\State\StateInterface;
 use Drupal\eic_statistics\Event\PageViewCountUpdate;
@@ -62,6 +63,8 @@ class NodeStatisticsDatabaseStorage extends CoreNodeStatisticsDatabaseStorage {
     // Dispatch an event.
     $event = new PageViewCountUpdate($id, $page_views);
     $this->eventDispatcher->dispatch($event, PageViewCountUpdate::EVENT_NAME);
+    // On each stat update we invalidate the stat cache for the given node and all nodes (this one isn't used for the moment)
+    Cache::invalidateTags(["eic_statistics:node:$id"]);
 
     return $page_views;
   }

--- a/lib/themes/eic_community/includes/preprocess/blocks/block--latest-news-stories.inc
+++ b/lib/themes/eic_community/includes/preprocess/blocks/block--latest-news-stories.inc
@@ -110,6 +110,10 @@ function eic_community_preprocess_block__latest_news_stories(&$variables, &$cach
     $variables['news_stories_items'][] = $item;
 
     // Add node cache tags.
-    $cache_tags = Cache::mergeTags($cache_tags, $node->getCacheTags());
+    $cache_tags = Cache::mergeTags(
+      $cache_tags,
+      $node->getCacheTags(),
+      ['eic_statistics:node:' . $node->id()]
+    );
   }
 }

--- a/lib/themes/eic_community/includes/preprocess/blocks/block--latest-news-stories.inc
+++ b/lib/themes/eic_community/includes/preprocess/blocks/block--latest-news-stories.inc
@@ -60,7 +60,7 @@ function eic_community_preprocess_block__latest_news_stories(&$variables, &$cach
           'name' => 'comment',
         ],
         'label' => t('Comments'),
-        'value' => isset($node_stats) ? $node_stats['comments_count']['#items'] : 0,
+        'value' => isset($node_stats) ? $node_stats['comments_count']['#value'] : 0,
       ],
       [
         'icon' => [

--- a/lib/themes/eic_community/includes/preprocess/blocks/block--latest-news-stories.inc
+++ b/lib/themes/eic_community/includes/preprocess/blocks/block--latest-news-stories.inc
@@ -47,7 +47,12 @@ function eic_community_preprocess_block__latest_news_stories(&$variables, &$cach
     if ($variables['logged_in'] === FALSE) {
       unset($node_author['path']);
     }
-    // @todo Add real statistics.
+
+    if (isset($variables['content']['node_stats'][$node->id()])) {
+      $node_stats = $variables['content']['node_stats'][$node->id()];
+    }
+
+    // Add node statistics.
     $stats = [
       [
         'icon' => [
@@ -55,7 +60,7 @@ function eic_community_preprocess_block__latest_news_stories(&$variables, &$cach
           'name' => 'comment',
         ],
         'label' => t('Comments'),
-        'value' => 0,
+        'value' => isset($node_stats) ? $node_stats['comments_count']['#items'] : 0,
       ],
       [
         'icon' => [
@@ -63,7 +68,7 @@ function eic_community_preprocess_block__latest_news_stories(&$variables, &$cach
           'name' => 'views',
         ],
         'label' => t('Views'),
-        'value' => 0,
+        'value' => isset($node_stats) ? $node_stats['page_views']['#value'] : 0,
       ],
       [
         'icon' => [
@@ -71,7 +76,7 @@ function eic_community_preprocess_block__latest_news_stories(&$variables, &$cach
           'name' => 'like',
         ],
         'label' => t('Likes'),
-        'value' => 0,
+        'value' => isset($node_stats['flag_counts']['#items']['like_content']) ? $node_stats['flag_counts']['#items']['like_content'] : 0,
       ],
     ];
 


### PR DESCRIPTION
### Improvements

- Add News and Story statistics to the latest news and stories block in the homepage.

### Tests

- [x] Add some news and stories to the Latest News and Stories block in the homepage
- [x] Check if the statistics are shown for the features News or Story
- [x] Go to the News or Story detail page and add some comments + like it
- [x] Go back to the homepage and check if the statistics have been updated 