### PR TITLE
EICNET-1332: Define weight of every menu item in the group menu

### DIFF
--- a/lib/modules/eic_groups/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_groups/src/Hooks/EntityOperations.php
@@ -331,7 +331,7 @@ class EntityOperations implements ContainerInjectionInterface {
             'uri' => 'internal:/group/' . $group->id() . '/about',
           ],
           'menu_name' => $menu_name,
-          'weight' => 1,
+          'weight' => 7,
         ]);
 
         try {

--- a/lib/modules/eic_groups/src/Plugin/GroupFeature/GroupFiles.php
+++ b/lib/modules/eic_groups/src/Plugin/GroupFeature/GroupFiles.php
@@ -28,7 +28,7 @@ class GroupFiles extends EicGroupsGroupFeaturePluginBase {
   protected function getMenuItem(Url $url, string $menu_name) {
     $menu_item = parent::getMenuItem($url, $menu_name);
     // Set a specific weight for the menu item.
-    $menu_item->set('weight', 7);
+    $menu_item->set('weight', 3);
     return $menu_item;
   }
 

--- a/lib/modules/eic_groups/src/Plugin/GroupFeature/GroupLatestActivityStream.php
+++ b/lib/modules/eic_groups/src/Plugin/GroupFeature/GroupLatestActivityStream.php
@@ -30,7 +30,7 @@ class GroupLatestActivityStream extends EicGroupsGroupFeaturePluginBase {
   protected function getMenuItem(Url $url, string $menu_name) {
     $menu_item = parent::getMenuItem($url, $menu_name);
     // Set a specific weight for the menu item.
-    $menu_item->set('weight', 7);
+    $menu_item->set('weight', 1);
     return $menu_item;
   }
 

--- a/lib/modules/eic_groups/src/Plugin/GroupFeature/GroupMembers.php
+++ b/lib/modules/eic_groups/src/Plugin/GroupFeature/GroupMembers.php
@@ -28,7 +28,7 @@ class GroupMembers extends EicGroupsGroupFeaturePluginBase {
   protected function getMenuItem(Url $url, string $menu_name) {
     $menu_item = parent::getMenuItem($url, $menu_name);
     // Set a specific weight for the menu item.
-    $menu_item->set('weight', 5);
+    $menu_item->set('weight', 6);
     return $menu_item;
   }
 

--- a/lib/modules/eic_groups/src/Plugin/GroupFeature/GroupWiki.php
+++ b/lib/modules/eic_groups/src/Plugin/GroupFeature/GroupWiki.php
@@ -29,7 +29,7 @@ class GroupWiki extends EicGroupsGroupFeaturePluginBase {
   protected function getMenuItem(Url $url, string $menu_name) {
     $menu_item = parent::getMenuItem($url, $menu_name);
     // Set a specific weight for the menu item.
-    $menu_item->set('weight', 2);
+    $menu_item->set('weight', 5);
     return $menu_item;
   }
 


### PR DESCRIPTION
### Improvements

- Update weights of group menu links.

### Tests

- [ ] Create a new group
- [ ] Edit the group and enable all group features
- [ ] Check if the gorup menu link weights follow the right order