### PR TITLE
EICNET-1237: Wiki - Link Add wiki page is shown on moderated group

### DIFF
--- a/lib/modules/eic_groups/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_groups/src/Hooks/EntityOperations.php
@@ -197,8 +197,10 @@ class EntityOperations implements ContainerInjectionInterface {
             ];
             // Add wiki page create form url to the build array.
             if ($add_wiki_page_urls = $this->getWikiPageAddFormUrls($entity, $group)) {
-              $build['link_add_child_wiki_page'] = $add_wiki_page_urls['add_child_wiki_page']->toString();
-              $build['link_add_child_wiki_page_renderable'] = Link::fromTextAndUrl($this->t('Add a new wiki page'), $add_wiki_page_urls['add_child_wiki_page'])->toRenderable();
+              if ($add_wiki_page_urls['add_child_wiki_page']->access()) {
+                $build['link_add_child_wiki_page'] = $add_wiki_page_urls['add_child_wiki_page']->toString();
+                $build['link_add_child_wiki_page_renderable'] = Link::fromTextAndUrl($this->t('Add a new wiki page'), $add_wiki_page_urls['add_child_wiki_page'])->toRenderable();
+              }
             }
             // Unsets book navigation since we already have that show in the
             // eic_groups_wiki_book_navigation block plugin.
@@ -208,15 +210,19 @@ class EntityOperations implements ContainerInjectionInterface {
         elseif ($entity->bundle() === 'wiki_page') {
           // Add wiki page create form url to the build array.
           if ($add_wiki_page_urls = $this->getWikiPageAddFormUrls($entity)) {
-            $build['link_add_current_level_wiki_page'] = $add_wiki_page_urls['add_current_level_wiki_page']->toString();
-            $build['link_add_current_level_wiki_page_renderable'] = Link::fromTextAndUrl($this->t('Add a new page on the current level'), $add_wiki_page_urls['add_current_level_wiki_page'])->toRenderable();
-            $build['link_add_current_level_wiki_page_renderable']['#suffix'] = '<br>';
+            if ($add_wiki_page_urls['add_current_level_wiki_page']->access()) {
+              $build['link_add_current_level_wiki_page'] = $add_wiki_page_urls['add_current_level_wiki_page']->toString();
+              $build['link_add_current_level_wiki_page_renderable'] = Link::fromTextAndUrl($this->t('Add a new page on the current level'), $add_wiki_page_urls['add_current_level_wiki_page'])->toRenderable();
+              $build['link_add_current_level_wiki_page_renderable']['#suffix'] = '<br>';
+            }
 
-            // If the wiki page depth doesn't reach the maximum limit, then we
-            // can show the button to add a new child wiki page.
-            if (!$entity->book['p' . (WikiPageBookManager::BOOK_MAX_DEPTH + 1)]) {
-              $build['link_add_child_wiki_page'] = $add_wiki_page_urls['add_child_wiki_page']->toString();
-              $build['link_add_child_wiki_page_renderable'] = Link::fromTextAndUrl($this->t('Add a new wiki page below this page'), $add_wiki_page_urls['add_child_wiki_page'])->toRenderable();
+            if ($add_wiki_page_urls['add_child_wiki_page']->access()) {
+              // If the wiki page depth doesn't reach the maximum limit, then we
+              // can show the button to add a new child wiki page.
+              if (!$entity->book['p' . (WikiPageBookManager::BOOK_MAX_DEPTH + 1)]) {
+                $build['link_add_child_wiki_page'] = $add_wiki_page_urls['add_child_wiki_page']->toString();
+                $build['link_add_child_wiki_page_renderable'] = Link::fromTextAndUrl($this->t('Add a new wiki page below this page'), $add_wiki_page_urls['add_child_wiki_page'])->toRenderable();
+              }
             }
           }
         }

--- a/lib/themes/eic_community/templates/content/node--book--full.html.twig
+++ b/lib/themes/eic_community/templates/content/node--book--full.html.twig
@@ -22,16 +22,17 @@
 
             <h2>{{ elements.wiki_section_message['#markup'] }}</h2>
 
-
-            {% include "@ecl-twig/ec-component-link/ecl-link.html.twig" with {
-              link: no_items.link|default({})|merge({
-                icon_position: 'after',
-                type: 'standalone',
-                path: elements.link_add_child_wiki_page_renderable['#url'],
-                label: elements.link_add_child_wiki_page_renderable['#title']
-              }),
-              extra_classes: 'ecl-link--button ecl-link--button-primary',
-            } only %}
+            {% if elements.link_add_child_wiki_page_renderable is not empty %}
+              {% include "@ecl-twig/ec-component-link/ecl-link.html.twig" with {
+                link: no_items.link|default({})|merge({
+                  icon_position: 'after',
+                  type: 'standalone',
+                  path: elements.link_add_child_wiki_page_renderable['#url'],
+                  label: elements.link_add_child_wiki_page_renderable['#title']
+                }),
+                extra_classes: 'ecl-link--button ecl-link--button-primary',
+              } only %}
+            {% endif %}
 
           {% endblock %}
         {% endembed %}


### PR DESCRIPTION
### Fixes

- Show link to add new wiki pages only if the user has access to create a wiki page in the group.

### Tests

- [x] Create a new public group, enable Wiki in the group features and publish it
- [x] As anonymous try to access the group wiki section
- [x] You should **NOT** be able to see a link to create a new wiki page
- [x] As a GA, create a new wiki page
- [ ] As anonymous try to access the wiki page created by GA and make sure you can't sse the links to create new wiki pages