### PR TITLE
EICNET-1369: Adapt comment section on video detail page (group library)

### DIFF
--- a/config/sync/core.entity_form_display.node.video.default.yml
+++ b/config/sync/core.entity_form_display.node.video.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.video.field_comments
     - field.field.node.video.field_document_type
     - field.field.node.video.field_language
+    - field.field.node.video.field_related_contributors
     - field.field.node.video.field_video_media
     - field.field.node.video.field_vocab_geo
     - field.field.node.video.field_vocab_topics
@@ -16,6 +17,7 @@ dependencies:
     - content_moderation
     - eic_content
     - media_library
+    - paragraphs
     - path
     - publication_date
     - scheduler
@@ -41,7 +43,7 @@ content:
     type: text_textarea
     region: content
   field_comments:
-    weight: 22
+    weight: 23
     settings: {  }
     third_party_settings: {  }
     type: comment_default
@@ -67,6 +69,18 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_related_contributors:
+    weight: 22
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: ''
+    third_party_settings: {  }
+    type: entity_reference_paragraphs
+    region: content
   field_video_media:
     type: media_library_widget
     weight: 7

--- a/config/sync/core.entity_view_display.node.video.default.yml
+++ b/config/sync/core.entity_view_display.node.video.default.yml
@@ -8,11 +8,13 @@ dependencies:
     - field.field.node.video.field_comments
     - field.field.node.video.field_document_type
     - field.field.node.video.field_language
+    - field.field.node.video.field_related_contributors
     - field.field.node.video.field_video_media
     - field.field.node.video.field_vocab_geo
     - field.field.node.video.field_vocab_topics
     - node.type.video
   module:
+    - entity_reference_revisions
     - oec_group_comments
     - text
     - user
@@ -44,6 +46,15 @@ content:
       link: true
     third_party_settings: {  }
     type: entity_reference_label
+    region: content
+  field_related_contributors:
+    weight: 7
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_entity_view
     region: content
   field_video_media:
     type: entity_reference_entity_view

--- a/config/sync/field.field.node.video.field_comments.yml
+++ b/config/sync/field.field.node.video.field_comments.yml
@@ -11,7 +11,7 @@ id: node.video.field_comments
 field_name: field_comments
 entity_type: node
 bundle: video
-label: Comments
+label: Replies
 description: ''
 required: true
 translatable: true

--- a/config/sync/field.field.node.video.field_related_contributors.yml
+++ b/config/sync/field.field.node.video.field_related_contributors.yml
@@ -1,0 +1,55 @@
+uuid: 1238e63a-3cd5-46ee-8112-9a0340bbe58e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_related_contributors
+    - node.type.video
+    - paragraphs.paragraphs_type.contributor
+  module:
+    - entity_reference_revisions
+id: node.video.field_related_contributors
+field_name: field_related_contributors
+entity_type: node
+bundle: video
+label: 'Related Contributors'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      contributor: contributor
+    target_bundles_drag_drop:
+      banner:
+        weight: 10
+        enabled: false
+      contributor:
+        enabled: true
+        weight: 11
+      cta_tile:
+        weight: 12
+        enabled: false
+      full_media_content:
+        weight: 13
+        enabled: false
+      full_text_content:
+        weight: 14
+        enabled: false
+      gallery_slide:
+        weight: 15
+        enabled: false
+      quote:
+        weight: 16
+        enabled: false
+      text_and_media_content:
+        weight: 17
+        enabled: false
+      tiles_content:
+        weight: 18
+        enabled: false
+field_type: entity_reference_revisions

--- a/lib/modules/eic_content/eic_content.module
+++ b/lib/modules/eic_content/eic_content.module
@@ -12,6 +12,8 @@
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\eic_content\Hooks\EntityOperations;
+use Drupal\eic_content\Hooks\EntityOperationsContributor;
+use Drupal\node\NodeInterface;
 
 /**
  * Implements hook_theme().
@@ -32,4 +34,33 @@ function eic_content_theme() {
 function eic_content_node_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
   \Drupal::classResolver(EntityOperations::class)
     ->nodeView($build, $entity, $display, $view_mode);
+
+  switch ($entity->bundle()) {
+    case 'discussion':
+    case 'video':
+      \Drupal::classResolver(EntityOperationsContributor::class)
+        ->nodeView($build, $entity, $display, $view_mode);
+      break;
+
+  }
+
+}
+
+/**
+ * Implements hook_entity_presave().
+ */
+function eic_content_entity_presave(EntityInterface $entity) {
+  if (FALSE === $entity instanceof NodeInterface) {
+    return;
+  }
+
+  switch ($entity->bundle()) {
+    case 'discussion':
+    case 'video':
+      \Drupal::classResolver(EntityOperationsContributor::class)
+        ->nodePreSave($entity);
+      break;
+
+  }
+
 }

--- a/lib/modules/eic_content/modules/eic_content_discussion/eic_content_discussion.module
+++ b/lib/modules/eic_content/modules/eic_content_discussion/eic_content_discussion.module
@@ -8,34 +8,3 @@
  * This file is no longer required in Drupal 8.
  * @see https://www.drupal.org/node/2217931
  */
-
-use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
-use Drupal\Core\Entity\EntityInterface;
-use Drupal\eic_content_discussion\Hooks\EntityOperations;
-use Drupal\node\NodeInterface;
-
-/**
- * Implements hook_entity_presave().
- */
-function eic_content_discussion_entity_presave(EntityInterface $entity) {
-  if (FALSE === $entity instanceof NodeInterface) {
-    return;
-  }
-
-  if ($entity->bundle() !== 'discussion') {
-    return;
-  }
-
-  \Drupal::classResolver(EntityOperations::class)
-    ->discussionPreSave($entity);
-}
-
-/**
- * Implements hook_ENTITY_TYPE_view().
- */
-function eic_content_discussion_node_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
-  if ('discussion' === $entity->bundle()) {
-    \Drupal::classResolver(EntityOperations::class)
-      ->nodeView($build, $entity, $display, $view_mode);
-  }
-}


### PR DESCRIPTION
### Changes

- Create contributors field in CType Video and apply contributors logic from discussions;
- Move logic from eic_content_discussion to eic_content.

### Tests

- [ ] Create a new group and publish it
- [ ] Create a new video
- [ ] Go to the video detail page and check if the title of the comments section is "Replies"
- [ ] Go to the video edit form and check if the owner is already set as contributor
- [ ] As a TU, join the group and leave a comment in the video
- [ ] As GO, go to the video edit form and check if the TU has been added to the list of contributors