### PR TITLE
[EICNET-1251]fix: Get correct user id from group content membership

### DIFF
--- a/lib/modules/eic_groups/src/Plugin/Block/LastGroupActivitiesBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/LastGroupActivitiesBlock.php
@@ -122,7 +122,7 @@ class LastGroupActivitiesBlock extends BlockBase implements ContainerFactoryPlug
 
     $members_data = array_map(function(GroupContent $groupContent) {
       $profiles = $this->entityTypeManager->getStorage('profile')->loadByProperties([
-        'uid' => $groupContent->get('uid')->getString(),
+        'uid' => $groupContent->getEntity()->id(),
         'type' => 'member',
       ]);
 
@@ -153,7 +153,8 @@ class LastGroupActivitiesBlock extends BlockBase implements ContainerFactoryPlug
       ];
     }, $members);
 
-    $current_group_route = $this->groupsHelper->getGroupFromRoute();    $user_group_roles = [];
+    $current_group_route = $this->groupsHelper->getGroupFromRoute();
+    $user_group_roles = [];
 
     if ($current_group_route) {
       $account = \Drupal::currentUser();

--- a/lib/modules/eic_search/src/Controller/SolrSearchController.php
+++ b/lib/modules/eic_search/src/Controller/SolrSearchController.php
@@ -326,6 +326,7 @@ class SolrSearchController extends ControllerBase {
 
     //If no pagination, it's a load more so we start at 1
     $solariumQuery->setStart(0);
+    $solariumQuery->setRows($offset * $page);
   }
 
 }


### PR DESCRIPTION
How to test:

- [ ] Go to group detail and click Latest activity
- [ ] Verify that users on the right column doesnt have weird data