### PR TITLE
EICNET-1371: Fix group file statistics for group content Gallery

### DIFF
--- a/lib/modules/eic_statistics/modules/eic_group_statistics/drush.services.yml
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/drush.services.yml
@@ -1,0 +1,6 @@
+services:
+  eic_group_statistics.commands:
+    class: \Drupal\eic_group_statistics\Commands\GroupStatisticsCommands
+    arguments: ['@eic_group_statistics.helper']
+    tags:
+      - { name: drush.command }

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.install
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.install
@@ -34,7 +34,7 @@ function eic_group_statistics_schema() {
       'members' => [
         'description' => 'Number of group members.',
         'type' => 'int',
-        'unsigned' => TRUE,
+        'unsigned' => FALSE,
         'not null' => TRUE,
         'default' => 0,
         'size' => 'medium',
@@ -42,7 +42,7 @@ function eic_group_statistics_schema() {
       'comments' => [
         'description' => 'Number of comments in the group',
         'type' => 'int',
-        'unsigned' => TRUE,
+        'unsigned' => FALSE,
         'not null' => TRUE,
         'default' => 0,
         'size' => 'medium',
@@ -50,7 +50,7 @@ function eic_group_statistics_schema() {
       'files' => [
         'description' => 'Number of files added to the group.',
         'type' => 'int',
-        'unsigned' => TRUE,
+        'unsigned' => FALSE,
         'not null' => TRUE,
         'default' => 0,
         'size' => 'medium',
@@ -58,7 +58,7 @@ function eic_group_statistics_schema() {
       'events' => [
         'description' => 'Number of events.',
         'type' => 'int',
-        'unsigned' => TRUE,
+        'unsigned' => FALSE,
         'not null' => TRUE,
         'default' => 0,
         'size' => 'medium',

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.services.yml
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.services.yml
@@ -1,7 +1,7 @@
 services:
   eic_group_statistics.storage:
     class: Drupal\eic_group_statistics\GroupStatisticsStorage
-    arguments: ['@database']
+    arguments: ['@database', '@entity_field.manager']
   eic_group_statistics.search_api.reindex:
     class: Drupal\eic_group_statistics\GroupStatisticsSearchApiReindex
     arguments: ['@eic_group_statistics.storage']

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/Commands/GroupStatisticsCommands.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/Commands/GroupStatisticsCommands.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Drupal\eic_group_statistics\Commands;
+
+use Drupal\eic_group_statistics\GroupStatisticsHelperInterface;
+use Drush\Commands\DrushCommands;
+
+/**
+ * A Drush commandfile.
+ *
+ * In addition to this file, you need a drush.services.yml
+ * in root of your module, and a composer.json file that provides the name
+ * of the services file to use.
+ *
+ * See these files for an example of injecting Drupal services:
+ *   - http://cgit.drupalcode.org/devel/tree/src/Commands/DevelCommands.php
+ *   - http://cgit.drupalcode.org/devel/tree/drush.services.yml
+ */
+class GroupStatisticsCommands extends DrushCommands {
+
+  /**
+   * The EIC group statistics helper service.
+   *
+   * @var \Drupal\eic_group_statistics\GroupStatisticsHelperInterface
+   */
+  protected $groupStatisticsHelper;
+
+  /**
+   * Constructs a new GroupStatisticsStorage object.
+   *
+   * @param \Drupal\eic_group_statistics\GroupStatisticsHelperInterface $group_statistics_helper
+   *   The EIC group statistics helper service.
+   */
+  public function __construct(GroupStatisticsHelperInterface $group_statistics_helper) {
+    $this->groupStatisticsHelper = $group_statistics_helper;
+  }
+
+  /**
+   * Command description here.
+   *
+   * @usage eic_group_statistics:updateGroupStatistics
+   *   Usage description
+   *
+   * @command eic_group_statistics:updateGroupStatistics
+   * @aliases update-group-statistics
+   */
+  public function updateGroupStatistics() {
+    $this->groupStatisticsHelper->updateAllGroupsStatistics();
+    $this->output()->writeln('All group statistics have been updated successfully.');
+    $this->logger()->info('All group statistics have been updated successfully.');
+  }
+
+}

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/Commands/GroupStatisticsCommands.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/Commands/GroupStatisticsCommands.php
@@ -30,8 +30,8 @@ class GroupStatisticsCommands extends DrushCommands {
   /**
    * Command to update all group statistics.
    *
-   * @usage eic_group_statistics:updateGroupStatistics
-   * @command eic_group_statistics:updateGroupStatistics
+   * @usage eic:updateGroupStatistics
+   * @command eic:updateGroupStatistics
    * @aliases update-group-statistics
    */
   public function updateGroupStatistics() {

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/Commands/GroupStatisticsCommands.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/Commands/GroupStatisticsCommands.php
@@ -6,15 +6,7 @@ use Drupal\eic_group_statistics\GroupStatisticsHelperInterface;
 use Drush\Commands\DrushCommands;
 
 /**
- * A Drush commandfile.
- *
- * In addition to this file, you need a drush.services.yml
- * in root of your module, and a composer.json file that provides the name
- * of the services file to use.
- *
- * See these files for an example of injecting Drupal services:
- *   - http://cgit.drupalcode.org/devel/tree/src/Commands/DevelCommands.php
- *   - http://cgit.drupalcode.org/devel/tree/drush.services.yml
+ * A Drush commandfile for updating group statistics.
  */
 class GroupStatisticsCommands extends DrushCommands {
 
@@ -36,11 +28,9 @@ class GroupStatisticsCommands extends DrushCommands {
   }
 
   /**
-   * Command description here.
+   * Command to update all group statistics.
    *
    * @usage eic_group_statistics:updateGroupStatistics
-   *   Usage description
-   *
    * @command eic_group_statistics:updateGroupStatistics
    * @aliases update-group-statistics
    */

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsHelper.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsHelper.php
@@ -104,4 +104,21 @@ class GroupStatisticsHelper implements GroupStatisticsHelperInterface {
     $this->groupStatisticsStorage->setMultipleGroupStatistics($groups_statistics);
   }
 
+  /**
+   * Gets the list of fields used to calculate group file statistics.
+   *
+   * @return array
+   *   Array of media and entity reference fields.
+   */
+  public static function getGroupFileStatisticFields() {
+    return [
+      'field_document_media' => 'field_document_media',
+      'field_related_downloads' => 'field_related_downloads',
+      'field_related_documents' => 'field_related_documents',
+      'field_gallery_slides' => [
+        'field_gallery_slide_media',
+      ],
+    ];
+  }
+
 }

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsHelper.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsHelper.php
@@ -104,21 +104,4 @@ class GroupStatisticsHelper implements GroupStatisticsHelperInterface {
     $this->groupStatisticsStorage->setMultipleGroupStatistics($groups_statistics);
   }
 
-  /**
-   * Gets the list of fields used to calculate group file statistics.
-   *
-   * @return array
-   *   Array of media and entity reference fields.
-   */
-  public static function getGroupFileStatisticFields() {
-    return [
-      'field_document_media' => 'field_document_media',
-      'field_related_downloads' => 'field_related_downloads',
-      'field_related_documents' => 'field_related_documents',
-      'field_gallery_slides' => [
-        'field_gallery_slide_media',
-      ],
-    ];
-  }
-
 }

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorage.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorage.php
@@ -239,30 +239,31 @@ class GroupStatisticsStorage implements GroupStatisticsStorageInterface {
     // Initialize array of media target ids that will be used to count the
     // number of files in group.
     $media_target_ids = [];
-    // Array of media fields per group content where we want to count file
-    // statistics. Keyed by group content bundle.
+    // Array of group content to count file statistics.
     $files_group_content_types = [
-      "discussion" => [
-        'field_related_documents',
-      ],
-      "document" => [
-        'field_document_media',
-      ],
-      "gallery" => [
-        'field_gallery_slides' => [
-          'field_gallery_slide_media',
-        ],
-      ],
-      "wiki_page" => [
-        'field_related_downloads',
-      ],
+      'discussion',
+      'document',
+      'gallery',
+      'wiki_page',
     ];
+    // Get array of fields that will be used to count the group file
+    // statistics.
+    $file_statistic_fields = self::getGroupFileStatisticFields();
 
     // We want to count the number of files for each group content that
     // contains media files. Note that we take into account multiple media
     // reference fields and also paragraph fields that contain media.
-    foreach ($files_group_content_types as $node_type => $fields) {
-      foreach ($fields as $field_name_key => $field_name) {
+    foreach ($files_group_content_types as $node_type) {
+      // Get all field definitions of the node type.
+      $field_definitions = $this->entityFieldManager->getFieldDefinitions('node', $node_type);
+
+      foreach ($file_statistic_fields as $field_name_key => $field_name) {
+
+        // Field doesn't exist in this node type, so we can skip it.
+        if (!isset($field_definitions[$field_name_key])) {
+          continue;
+        }
+
         // If the current value of $field_name is an array of media fields, we
         // assume this field as an entity reference field and so we count the
         // file statistics on the entity reference level. Currently it works
@@ -412,6 +413,26 @@ class GroupStatisticsStorage implements GroupStatisticsStorageInterface {
   private function calculateGroupEventsStatistics(GroupInterface $group) {
     // @todo Implement logic once we have the group type Event available.
     return 0;
+  }
+
+  /**
+   * Gets the list of fields used to calculate group file statistics.
+   *
+   * @return array
+   *   Array of media and entity reference fields.
+   *   - key: field machine name
+   *   - value: field machine name or array of field machine names in case of
+   *   entity reference fields.
+   */
+  public static function getGroupFileStatisticFields() {
+    return [
+      'field_document_media' => 'field_document_media',
+      'field_related_downloads' => 'field_related_downloads',
+      'field_related_documents' => 'field_related_documents',
+      'field_gallery_slides' => [
+        'field_gallery_slide_media',
+      ],
+    ];
   }
 
 }

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorage.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorage.php
@@ -347,7 +347,7 @@ class GroupStatisticsStorage implements GroupStatisticsStorageInterface {
   private function calculateEntityReferenceFieldFileStatistics(GroupInterface $group, $node_type, $reference_field_name, array $fields, array $media_target_ids) {
     $group_content_type = "{$group->bundle()}-group_node-{$node_type}";
 
-    $field_definitions = $this->entityTypeFieldManager->getFieldDefinitions('node', $node_type);
+    $field_definitions = $this->entityFieldManager->getFieldDefinitions('node', $node_type);
 
     if (!isset($field_definitions[$reference_field_name])) {
       return $media_target_ids;

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorage.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorage.php
@@ -353,9 +353,10 @@ class GroupStatisticsStorage implements GroupStatisticsStorageInterface {
       return $media_target_ids;
     }
 
+    // @todo We currently support only paragraph entities. We need to improve
+    // it in order to support all entity types.
     if (
-      $field_definitions[$reference_field_name]->getType() === 'entity_reference_revisions' &&
-      $field_definitions[$reference_field_name]->getTargetEntityTypeId() === 'paragraph'
+      $field_definitions[$reference_field_name]->getType() !== 'entity_reference_revisions'
     ) {
       return $media_target_ids;
     }

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorage.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsStorage.php
@@ -4,6 +4,7 @@ namespace Drupal\eic_group_statistics;
 
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Database\Connection;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\group\Entity\GroupInterface;
 
 /**
@@ -19,13 +20,26 @@ class GroupStatisticsStorage implements GroupStatisticsStorageInterface {
   protected $connection;
 
   /**
+   * The entity field manager.
+   *
+   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
+   */
+  protected $entityFieldManager;
+
+  /**
    * Constructs a new GroupStatisticsStorage object.
    *
-   * @return \Drupal\Core\Database\Connection
+   * @param \Drupal\Core\Database\Connection $connection
    *   The current active database's master connection.
+   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager
+   *   The entity field manager.
    */
-  public function __construct(Connection $connection) {
+  public function __construct(
+    Connection $connection,
+    EntityFieldManagerInterface $entity_field_manager
+  ) {
     $this->connection = $connection;
+    $this->entityFieldManager = $entity_field_manager;
   }
 
   /**
@@ -228,53 +242,161 @@ class GroupStatisticsStorage implements GroupStatisticsStorageInterface {
     // Array of media fields per group content where we want to count file
     // statistics. Keyed by group content bundle.
     $files_group_content_types = [
-      "{$group->bundle()}-group_node-discussion" => [
+      "discussion" => [
         'field_related_documents',
       ],
-      "{$group->bundle()}-group_node-document" => [
+      "document" => [
         'field_document_media',
       ],
-      "{$group->bundle()}-group_node-gallery" => [
-        'field_photos',
+      "gallery" => [
+        'field_gallery_slides' => [
+          'field_gallery_slide_media',
+        ],
       ],
-      "{$group->bundle()}-group_node-wiki_page" => [
+      "wiki_page" => [
         'field_related_downloads',
       ],
     ];
+
     // We want to count the number of files for each group content that
     // contains media files. Note that we take into account multiple media
-    // reference fields.
-    foreach ($files_group_content_types as $ctype => $fields) {
-      foreach ($fields as $field_name) {
-        // Query to count number of files per group content + media fields.
-        $query_files = $this->connection->select('group_content_field_data', 'gc_fd')
-          ->fields('n_field', ["{$field_name}_target_id"])
-          ->condition('gc_fd.gid', $group->id())
-          ->condition('gc_fd.type', $ctype, 'IN');
-
-        // We discard medias that already been counted.
-        if (!empty($media_target_ids)) {
-          $query_files->condition("n_field.{$field_name}_target_id", $media_target_ids, 'NOT IN');
+    // reference fields and also paragraph fields that contain media.
+    foreach ($files_group_content_types as $node_type => $fields) {
+      foreach ($fields as $field_name_key => $field_name) {
+        // If the current value of $field_name is an array of media fields, we
+        // assume this field as an entity reference field and so we count the
+        // file statistics on the entity reference level. Currently it works
+        // only with paragraph fields.
+        if (is_array($field_name)) {
+          $media_target_ids = $this->calculateEntityReferenceFieldFileStatistics($group, $node_type, $field_name_key, $field_name, $media_target_ids);
+          continue;
         }
 
-        $query_files->join("node__{$field_name}", 'n_field', 'gc_fd.entity_id = n_field.entity_id');
-        $query_files->join("node_field_data", 'n_fd', 'gc_fd.entity_id = n_fd.nid');
-        // We calculate statistics only for published nodes.
-        $query_files->condition('n_fd.status', TRUE);
-        $query_files->groupBy("n_field.{$field_name}_target_id");
-        $target_ids = $query_files->execute()->fetchAll();
-
-        // We save the media target ids returned by the query so we skip those
-        // in the next queries.
-        if (!empty($target_ids)) {
-          foreach ($target_ids as $target_id) {
-            $field_name_target_id = "{$field_name}_target_id";
-            $media_target_ids[] = $target_id->$field_name_target_id;
-          }
-        }
+        // The field is a media reference field so we count the file statistics
+        // for the media.
+        $media_target_ids = $this->calculateMediaReferenceFieldFileStatistics($group, $node_type, $field_name, $media_target_ids);
       }
     }
     return count($media_target_ids);
+  }
+
+  /**
+   * Calculates files statistics for a given media reference field.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The Group entity.
+   * @param string $node_type
+   *   The node bundle name.
+   * @param string $field_name
+   *   The media reference field name.
+   * @param array $media_target_ids
+   *   The array of media entity IDs that was already calculated.
+   *
+   * @return array
+   *   The updated array of media entity IDs.
+   */
+  private function calculateMediaReferenceFieldFileStatistics(GroupInterface $group, $node_type, $field_name, array $media_target_ids) {
+    $group_content_type = "{$group->bundle()}-group_node-{$node_type}";
+
+    // Query to count number of files per group content + media fields.
+    $query_files = $this->connection->select('group_content_field_data', 'gc_fd')
+      ->fields('n_field', ["{$field_name}_target_id"])
+      ->condition('gc_fd.gid', $group->id())
+      ->condition('gc_fd.type', $group_content_type, 'IN');
+
+    // We discard medias that already been counted.
+    if (!empty($media_target_ids)) {
+      $query_files->condition("n_field.{$field_name}_target_id", $media_target_ids, 'NOT IN');
+    }
+
+    $query_files->join("node__{$field_name}", 'n_field', 'gc_fd.entity_id = n_field.entity_id');
+    $query_files->join("node_field_data", 'n_fd', 'gc_fd.entity_id = n_fd.nid');
+    // We calculate statistics only for published nodes.
+    $query_files->condition('n_fd.status', TRUE);
+    $query_files->groupBy("n_field.{$field_name}_target_id");
+    $target_ids = $query_files->execute()->fetchAll();
+
+    // We update the array of media target IDs with IDs by the query so that
+    // we can skip those in future queries.
+    if (!empty($target_ids)) {
+      foreach ($target_ids as $target_id) {
+        $field_name_target_id = "{$field_name}_target_id";
+        $media_target_ids[] = $target_id->$field_name_target_id;
+      }
+    }
+    return $media_target_ids;
+  }
+
+  /**
+   * Calculates files statistics for a given entity reference field.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The Group entity.
+   * @param string $node_type
+   *   The node bundle name.
+   * @param string $reference_field_name
+   *   The entity reference field name.
+   * @param array $fields
+   *   The entity reference fields containing the media field names.
+   * @param array $media_target_ids
+   *   The array of media entity IDs that was already calculated.
+   *
+   * @return array
+   *   The updated array of media entity IDs.
+   */
+  private function calculateEntityReferenceFieldFileStatistics(GroupInterface $group, $node_type, $reference_field_name, array $fields, array $media_target_ids) {
+    $group_content_type = "{$group->bundle()}-group_node-{$node_type}";
+
+    $field_definitions = $this->entityTypeFieldManager->getFieldDefinitions('node', $node_type);
+
+    if (!isset($field_definitions[$reference_field_name])) {
+      return $media_target_ids;
+    }
+
+    if (
+      $field_definitions[$reference_field_name]->getType() === 'entity_reference_revisions' &&
+      $field_definitions[$reference_field_name]->getTargetEntityTypeId() === 'paragraph'
+    ) {
+      return $media_target_ids;
+    }
+
+    foreach ($fields as $field_name) {
+      // Query to count number of files per group content + media fields.
+      $query_files = $this->connection->select('group_content_field_data', 'gc_fd')
+        ->fields('p_field', ["{$field_name}_target_id"])
+        ->condition('gc_fd.gid', $group->id())
+        ->condition('gc_fd.type', $group_content_type, 'IN');
+
+      // Joins reference field table of the group content node.
+      $query_files->join("node__{$reference_field_name}", 'n_field', 'gc_fd.entity_id = n_field.entity_id');
+      $query_files->join("node_field_data", 'n_fd', 'gc_fd.entity_id = n_fd.nid');
+
+      // Joins the paragraph field table.
+      $query_files->join("paragraphs_item_field_data", 'p_fd', 'p_fd.parent_id = n_fd.nid');
+      $query_files->join("paragraph__{$field_name}", 'p_field', 'p_field.entity_id = p_fd.id');
+
+      // We discard medias that already been counted.
+      if (!empty($media_target_ids)) {
+        $query_files->condition("p_field.{$field_name}_target_id", $media_target_ids, 'NOT IN');
+      }
+
+      // We calculate statistics only for published nodes.
+      $query_files->condition('n_fd.status', TRUE);
+      // We group results by media target ID.
+      $query_files->groupBy("p_field.{$field_name}_target_id");
+      $target_ids = $query_files->execute()->fetchAll();
+
+      // We update the array of media target IDs with IDs by the query so that
+      // we can skip those in future queries.
+      if (!empty($target_ids)) {
+        foreach ($target_ids as $target_id) {
+          $field_name_target_id = "{$field_name}_target_id";
+          $media_target_ids[] = $target_id->$field_name_target_id;
+        }
+      }
+    }
+
+    return $media_target_ids;
   }
 
   /**

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/Hooks/EntityOperations.php
@@ -6,6 +6,7 @@ use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\eic_comments\CommentsHelper;
+use Drupal\eic_group_statistics\GroupStatisticsHelper;
 use Drupal\eic_group_statistics\GroupStatisticsSearchApiReindex;
 use Drupal\eic_group_statistics\GroupStatisticsStorageInterface;
 use Drupal\eic_group_statistics\GroupStatisticTypes;
@@ -307,16 +308,10 @@ class EntityOperations implements ContainerInjectionInterface {
     $medias = [];
     $unpublished_node_medias = [];
 
-    // @todo In the future we should consider configuring which fields to
-    // use via config entity and using an administration form.
-    $media_fields = [
-      'field_document_media' => 'field_document_media',
-      'field_related_downloads' => 'field_related_downloads',
-      'field_related_documents' => 'field_related_documents',
-      'field_gallery_slides' => [
-        'field_gallery_slide_media',
-      ],
-    ];
+    // Gets the array of field names that will be used to count group file
+    // statistics.
+    $media_fields = GroupStatisticsHelper::getGroupFileStatisticFields();
+
     foreach ($media_fields as $key => $field_name) {
       // If $field_name is an array we assume we are dealing with an entity
       // reference field.

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/Hooks/EntityOperations.php
@@ -431,6 +431,8 @@ class EntityOperations implements ContainerInjectionInterface {
       }
     }
 
+    // Updates group file statistics depending on the node operation: "create",
+    // "update" or "delete".
     switch ($operation) {
       case self::GROUP_FILE_STATISTICS_CREATE_OPERATION:
         // This is a new node so we count the new medias.

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/Hooks/EntityOperations.php
@@ -23,6 +23,21 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class EntityOperations implements ContainerInjectionInterface {
 
   /**
+   * Identifies the file statistics update operation when updating a node.
+   */
+  const GROUP_FILE_STATISTICS_CREATE_OPERATION = 'create';
+
+  /**
+   * Identifies the file statistics update operation when updating a node.
+   */
+  const GROUP_FILE_STATISTICS_UPDATE_OPERATION = 'update';
+
+  /**
+   * Identifies the file statistics update operation when deleting a node.
+   */
+  const GROUP_FILE_STATISTICS_DELETE_OPERATION = 'delete';
+
+  /**
    * The Group statistics storage.
    *
    * @var \Drupal\Core\Entity\EntityTypeManagerInterface
@@ -119,51 +134,7 @@ class EntityOperations implements ContainerInjectionInterface {
       case 'group-group_node-document':
       case 'group-group_node-wiki_page':
       case 'group-group_node-gallery':
-        /** @var \Drupal\node\NodeInterface $node */
-        $node = $entity->getEntity();
-
-        // If node is not published, we don't need to update group statistics.
-        if (!$node->isPublished()) {
-          $re_index = FALSE;
-          break;
-        }
-
-        $medias = [];
-
-        // @todo In the future we should consider configuring which fields to
-        // use via config entity and using an administration form.
-        $media_fields = [
-          'field_document_media',
-          'field_photos',
-          'field_related_downloads',
-          'field_related_documents',
-        ];
-        foreach ($media_fields as $field_name) {
-          if ($node->hasField($field_name)) {
-            foreach ($node->get($field_name)->referencedEntities() as $media) {
-              /** @var \Drupal\media\MediaInterface $media */
-              $medias[] = $media;
-            }
-          }
-        }
-
-        // If node has no media entities, we don't need to update group file
-        // statistics.
-        if (empty($medias)) {
-          $re_index = FALSE;
-          break;
-        }
-
-        // Counts the number of times we need to increment the file statistic.
-        $count = $this->countGroupFileStatistics($group, $node, $medias);
-
-        if (!$count) {
-          $re_index = FALSE;
-          break;
-        }
-
-        // Update group file statistics.
-        $this->groupStatisticsStorage->increment($group, GroupStatisticTypes::STAT_TYPE_FILES, $count);
+        $re_index = $this->updateGroupFileStatistics($entity->getEntity(), $entity);
         break;
 
       default:
@@ -234,42 +205,7 @@ class EntityOperations implements ContainerInjectionInterface {
       case 'document':
       case 'wiki_page':
       case 'gallery':
-        $medias = [];
-
-        // @todo In the future we should consider configuring which fields to
-        // use via config entity and using an administration form.
-        $media_fields = [
-          'field_document_media',
-          'field_photos',
-          'field_related_downloads',
-          'field_related_documents',
-        ];
-        foreach ($media_fields as $field_name) {
-          if ($entity->hasField($field_name)) {
-            foreach ($entity->get($field_name)->referencedEntities() as $media) {
-              /** @var \Drupal\media\MediaInterface $media */
-              $medias[] = $media;
-            }
-          }
-        }
-
-        // If node has no media entities, we don't need to update group file
-        // statistics.
-        if (empty($medias)) {
-          $re_index = FALSE;
-          break;
-        }
-
-        // Counts the number of times we need to decrement the file statistic.
-        $count = $this->countGroupFileStatistics($group, $entity, $medias);
-
-        if (!$count) {
-          $re_index = FALSE;
-          break;
-        }
-
-        // Update group file statistics.
-        $this->groupStatisticsStorage->decrement($group, GroupStatisticTypes::STAT_TYPE_FILES, $count);
+        $re_index = $this->updateGroupFileStatistics($entity, $group_content, self::GROUP_FILE_STATISTICS_DELETE_OPERATION);
         break;
 
       default:
@@ -304,150 +240,7 @@ class EntityOperations implements ContainerInjectionInterface {
       case 'document':
       case 'wiki_page':
       case 'gallery':
-        $old_medias = [];
-        $medias = [];
-        $unpublished_node_medias = [];
-
-        // @todo In the future we should consider configuring which fields to
-        // use via config entity and using an administration form.
-        $media_fields = [
-          'field_document_media',
-          'field_related_downloads',
-          'field_related_documents',
-        ];
-        $media_fields['field_gallery_slides'] = [
-          'field_gallery_slide_media',
-        ];
-        foreach ($media_fields as $key => $field_name) {
-          if (is_array($field_name)) {
-            if ($entity->hasField($key)) {
-
-              /** @var \Drupal\Core\Field\FieldDefinitionInterface $field_definition */
-              $field_definition = $entity->get($key)->getFieldDefinition();
-
-              if (
-                $field_definition->getType() === 'entity_reference_revisions'
-              ) {
-
-                foreach ($entity->original->get($key)->referencedEntities() as $paragraph) {
-                  foreach ($field_name as $paragraph_field) {
-                    // Sets array of old medias to decrement from group file
-                    // statistics.
-                    foreach ($paragraph->get($paragraph_field)->referencedEntities() as $media) {
-                      $old_medias[$media->id()] = $media;
-                    }
-                  }
-                }
-
-                foreach ($entity->get($key)->referencedEntities() as $paragraph) {
-                  foreach ($field_name as $paragraph_field) {
-                    // Sets array of new medias to increment to the group file
-                    // statistics.
-                    foreach ($paragraph->get($paragraph_field)->referencedEntities() as $media) {
-                      if (!isset($old_medias[$media->id()])) {
-                        $medias[$media->id()] = $media;
-                      }
-                      else {
-                        unset($old_medias[$media->id()]);
-
-                        // If the node has been unpublished, we add the node
-                        // medias to an array so that they get decremented from
-                        // file statistics.
-                        if ($entity->original->isPublished() && !$entity->isPublished()) {
-                          $unpublished_node_medias[$media->id()] = $media;
-                        }
-                        elseif (!$entity->original->isPublished() && $entity->isPublished()) {
-                          // If the node has been published, we add the node
-                          // medias to the medias array so that they get
-                          // incremented in file statistics.
-                          $medias[$media->id()] = $media;
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-            continue;
-          }
-
-          if ($entity->hasField($field_name)) {
-
-            // Sets array of old medias to decrement from group file
-            // statistics.
-            foreach ($entity->original->get($field_name)->referencedEntities() as $media) {
-              $old_medias[$media->id()] = $media;
-            }
-
-            // Sets array of new medias to increment to the group file
-            // statistics.
-            foreach ($entity->get($field_name)->referencedEntities() as $media) {
-              if (!isset($old_medias[$media->id()])) {
-                $medias[$media->id()] = $media;
-              }
-              else {
-                unset($old_medias[$media->id()]);
-
-                // If the node has been unpublished, we add the node medias to
-                // an array so that they get decremented from file statistics.
-                if ($entity->original->isPublished() && !$entity->isPublished()) {
-                  $unpublished_node_medias[$media->id()] = $media;
-                }
-                elseif (!$entity->original->isPublished() && $entity->isPublished()) {
-                  // If the node has been published, we add the node medias to
-                  // the medias array so that they get incremented in file
-                  // statistics.
-                  $medias[$media->id()] = $media;
-                }
-              }
-            }
-          }
-        }
-
-        // If there are no media entities to increment or decrement, then we
-        // don't need to update group file statistics.
-        if (empty($medias) && empty($old_medias) && empty($unpublished_node_medias)) {
-          $re_index = FALSE;
-          break;
-        }
-
-        $increment_count = 0;
-        if (!empty($medias) && $entity->isPublished()) {
-          // Counts the number of times we need to increment to the file
-          // statistics.
-          $increment_count = $this->countGroupFileStatistics($group, $entity, $medias);
-        }
-
-        $decrement_count = 0;
-        if (!empty($old_medias) && $entity->original->isPublished()) {
-          // Counts the number of times we need to decrement in the file
-          // statistics. Note that we decrement only if the previous status
-          // was published.
-          $decrement_count = $this->countGroupFileStatistics($group, $entity, $old_medias);
-        }
-
-        if (!empty($unpublished_node_medias)) {
-          // Counts the number of times we need to decrement in the file
-          // statistics when the node is unpublished.
-          $decrement_count += $this->countGroupFileStatistics($group, $entity, $unpublished_node_medias);
-        }
-
-        // If counters are empty, we don't need to update group file
-        // statistics.
-        if (!$increment_count && !$decrement_count) {
-          $re_index = FALSE;
-          break;
-        }
-
-        // Increments group file statistics.
-        if ($increment_count) {
-          $this->groupStatisticsStorage->increment($group, GroupStatisticTypes::STAT_TYPE_FILES, $increment_count);
-        }
-
-        // Decrements group file statistics.
-        if ($decrement_count) {
-          $this->groupStatisticsStorage->decrement($group, GroupStatisticTypes::STAT_TYPE_FILES, $decrement_count);
-        }
+        $re_index = $this->updateGroupFileStatistics($entity, $group_content, self::GROUP_FILE_STATISTICS_UPDATE_OPERATION);
         break;
 
       default:
@@ -488,6 +281,241 @@ class EntityOperations implements ContainerInjectionInterface {
   }
 
   /**
+   * Updates group file statistics when a node is created/updated/deleted.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The node entity object.
+   * @param \Drupal\group\Entity\GroupContentInterface $group_content
+   *   The group content entity object that relates to the node.
+   * @param string $operation
+   *   The operation type: "create", "update" or "delete".
+   *
+   * @return bool
+   *   TRUE if the group file statistics have been updated.
+   */
+  private function updateGroupFileStatistics(
+    EntityInterface $entity,
+    GroupContentInterface $group_content,
+    $operation = self::GROUP_FILE_STATISTICS_CREATE_OPERATION
+  ) {
+    $group = $group_content->getGroup();
+
+    // If operation is "create" we assume this group content node is new.
+    $group_content_is_new = $operation === self::GROUP_FILE_STATISTICS_CREATE_OPERATION ? TRUE : FALSE;
+
+    $old_medias = [];
+    $medias = [];
+    $unpublished_node_medias = [];
+
+    // @todo In the future we should consider configuring which fields to
+    // use via config entity and using an administration form.
+    $media_fields = [
+      'field_document_media' => 'field_document_media',
+      'field_related_downloads' => 'field_related_downloads',
+      'field_related_documents' => 'field_related_documents',
+      'field_gallery_slides' => [
+        'field_gallery_slide_media',
+      ],
+    ];
+    foreach ($media_fields as $key => $field_name) {
+      if (is_array($field_name)) {
+        if ($entity->hasField($key)) {
+
+          /** @var \Drupal\Core\Field\FieldDefinitionInterface $field_definition */
+          $field_definition = $entity->get($key)->getFieldDefinition();
+
+          if (
+            $field_definition->getType() === 'entity_reference_revisions'
+          ) {
+
+            // Node is not new, so we need grab the old medias to decrement
+            // later.
+            if (!$group_content_is_new && $operation === self::GROUP_FILE_STATISTICS_UPDATE_OPERATION) {
+              foreach ($entity->original->get($key)->referencedEntities() as $paragraph) {
+                foreach ($field_name as $paragraph_field) {
+                  // Sets array of old medias to decrement from group file
+                  // statistics.
+                  foreach ($paragraph->get($paragraph_field)->referencedEntities() as $media) {
+                    $old_medias[$media->id()] = $media;
+                  }
+                }
+              }
+            }
+
+            foreach ($entity->get($key)->referencedEntities() as $paragraph) {
+              foreach ($field_name as $paragraph_field) {
+                // Sets array of new medias to increment to the group file
+                // statistics.
+                foreach ($paragraph->get($paragraph_field)->referencedEntities() as $media) {
+
+                  // Node is new, so we just need to add the new medias to
+                  // increment.
+                  if ($group_content_is_new || $operation === 'delete') {
+                    $medias[] = $media;
+                    continue;
+                  }
+
+                  // At this point it means the node alrady exists.
+                  if (!isset($old_medias[$media->id()])) {
+                    $medias[$media->id()] = $media;
+                  }
+                  else {
+                    unset($old_medias[$media->id()]);
+
+                    // If the node has been unpublished, we add the node
+                    // medias to an array so that they get decremented from
+                    // file statistics.
+                    if ($entity->original->isPublished() && !$entity->isPublished()) {
+                      $unpublished_node_medias[$media->id()] = $media;
+                    }
+                    elseif (!$entity->original->isPublished() && $entity->isPublished()) {
+                      // If the node has been published, we add the node
+                      // medias to the medias array so that they get
+                      // incremented in file statistics.
+                      $medias[$media->id()] = $media;
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        continue;
+      }
+
+      if ($entity->hasField($field_name)) {
+
+        // Node is not new, so we need grab the old medias to decrement later.
+        if (!$group_content_is_new && $operation === self::GROUP_FILE_STATISTICS_UPDATE_OPERATION) {
+          // Sets array of old medias to decrement from group file
+          // statistics.
+          foreach ($entity->original->get($field_name)->referencedEntities() as $media) {
+            $old_medias[$media->id()] = $media;
+          }
+        }
+
+        // Sets array of new medias to increment to the group file
+        // statistics.
+        foreach ($entity->get($field_name)->referencedEntities() as $media) {
+
+          if ($group_content_is_new || $operation === self::GROUP_FILE_STATISTICS_DELETE_OPERATION) {
+            $medias[] = $media;
+            continue;
+          }
+
+          if (!isset($old_medias[$media->id()])) {
+            $medias[$media->id()] = $media;
+          }
+          else {
+            unset($old_medias[$media->id()]);
+
+            // If the node has been unpublished, we add the node medias to
+            // an array so that they get decremented from file statistics.
+            if ($entity->original->isPublished() && !$entity->isPublished()) {
+              $unpublished_node_medias[$media->id()] = $media;
+            }
+            elseif (!$entity->original->isPublished() && $entity->isPublished()) {
+              // If the node has been published, we add the node medias to
+              // the medias array so that they get incremented in file
+              // statistics.
+              $medias[$media->id()] = $media;
+            }
+          }
+        }
+      }
+    }
+
+    switch ($operation) {
+      case self::GROUP_FILE_STATISTICS_CREATE_OPERATION:
+        // This is a new node so we count the new medias.
+        // If node has no media entities, we don't need to update group file
+        // statistics.
+        if (empty($medias)) {
+          return FALSE;
+        }
+
+        // Counts the number of times we need to decrement the file statistic.
+        $count = $this->countGroupFileStatistics($group, $entity, $medias);
+
+        if (!$count) {
+          return FALSE;
+        }
+
+        // Update group file statistics.
+        $this->groupStatisticsStorage->increment($group, GroupStatisticTypes::STAT_TYPE_FILES, $count);
+
+        return TRUE;
+
+      case self::GROUP_FILE_STATISTICS_DELETE_OPERATION:
+        // If node has no media entities, we don't need to update group file
+        // statistics.
+        if (empty($medias)) {
+          return FALSE;
+        }
+
+        // Counts the number of times we need to decrement the file statistic.
+        $count = $this->countGroupFileStatistics($group, $entity, $medias);
+
+        if (!$count) {
+          return FALSE;
+        }
+
+        // Update group file statistics.
+        $this->groupStatisticsStorage->decrement($group, GroupStatisticTypes::STAT_TYPE_FILES, $count);
+
+        return TRUE;
+
+      case self::GROUP_FILE_STATISTICS_UPDATE_OPERATION:
+        // At this point, it means that the node already exists and we need to
+        // count the file statistics taking into consideration new and old
+        // medias. If there are no media entities to increment or decrement,
+        // then we don't need to update group file statistics.
+        if (empty($medias) && empty($old_medias) && empty($unpublished_node_medias)) {
+          return FALSE;
+        }
+
+        $increment_count = 0;
+        if (!empty($medias) && $entity->isPublished()) {
+          // Counts the number of times we need to increment to the file
+          // statistics.
+          $increment_count = $this->countGroupFileStatistics($group, $entity, $medias);
+        }
+
+        $decrement_count = 0;
+        if (!empty($old_medias) && $entity->original->isPublished()) {
+          // Counts the number of times we need to decrement in the file
+          // statistics. Note that we decrement only if the previous status
+          // was published.
+          $decrement_count = $this->countGroupFileStatistics($group, $entity, $old_medias);
+        }
+
+        if (!empty($unpublished_node_medias)) {
+          // Counts the number of times we need to decrement in the file
+          // statistics when the node is unpublished.
+          $decrement_count += $this->countGroupFileStatistics($group, $entity, $unpublished_node_medias);
+        }
+
+        // If counters are empty, we don't need to update group file
+        // statistics.
+        if (!$increment_count && !$decrement_count) {
+          return FALSE;
+        }
+
+        // Increments group file statistics.
+        if ($increment_count) {
+          $this->groupStatisticsStorage->increment($group, GroupStatisticTypes::STAT_TYPE_FILES, $increment_count);
+        }
+
+        // Decrements group file statistics.
+        if ($decrement_count) {
+          $this->groupStatisticsStorage->decrement($group, GroupStatisticTypes::STAT_TYPE_FILES, $decrement_count);
+        }
+        return TRUE;
+
+    }
+  }
+
+  /**
    * Counts group file statistics for a given node with medias.
    *
    * @param \Drupal\group\Entity\GroupInterface $group
@@ -504,6 +532,11 @@ class EntityOperations implements ContainerInjectionInterface {
   private function countGroupFileStatistics(GroupInterface $group, NodeInterface $node, array $medias = []) {
     $count_updates = 0;
 
+    $source_entity_types = [
+      'node',
+      'paragraph',
+    ];
+
     if (!$medias) {
       return $count_updates;
     }
@@ -514,7 +547,7 @@ class EntityOperations implements ContainerInjectionInterface {
       $media_usage = $this->entityUsage->listSources($media);
 
       // If there is no media usage, we increment the counter.
-      if (!isset($media_usage['node']) && isset($media_usage['paragraph'])) {
+      if (!isset($media_usage['node']) && !isset($media_usage['paragraph'])) {
         $count_updates++;
         continue;
       }
@@ -528,66 +561,63 @@ class EntityOperations implements ContainerInjectionInterface {
       // If media is being referenced elsewhere, then we need to make sure it
       // hasn't been referenced in this group before updating the file
       // statistics.
-      if (count($media_usage['node']) > 0 || count($media_usage['paragraph'])) {
+      if (count($media_usage['node']) > 0 || count($media_usage['paragraph']) > 0) {
         $source_nodes = [];
         $source_node_ids = [];
 
-        // Because the media usage is saved per node revision, we need to make
-        // sure the media is presented in the latest revision of every node.
-        // If the media is not presented in the latest revision of a node, that
-        // node will be discarded.
-        foreach ($media_usage['node'] as $nid => $media_usage_items) {
-          $latest_vid = $this->entityTypeManager->getStorage('node')->getLatestRevisionId($nid);
+        foreach ($source_entity_types as $entity_type) {
 
-          foreach ($media_usage_items as $media_usage_item) {
-            if ((int) $media_usage_item['source_vid'] === $latest_vid) {
-              $node_revision = $this->entityTypeManager->getStorage('node')->loadRevision($latest_vid);
+          // Because the media usage is saved per revision, we need to make
+          // sure the media is presented in the latest revision of every
+          // entity. If the media is not presented in the latest revision, that
+          // entity will be discarded.
+          foreach ($media_usage[$entity_type] as $entity_id => $media_usage_items) {
+            $latest_vid = $this->entityTypeManager->getStorage($entity_type)->getLatestRevisionId($entity_id);
 
-              // Make sure the revision is published, otherwise we skip this
-              // node.
-              if (!$node_revision->isPublished()) {
-                continue;
+            foreach ($media_usage_items as $media_usage_item) {
+              if ((int) $media_usage_item['source_vid'] === $latest_vid) {
+                $entity_revision = $this->entityTypeManager->getStorage($entity_type)->loadRevision($latest_vid);
+
+                // If the source entity is a paragraph.
+                if ($entity_type === 'paragraph') {
+                  $paragraph_node = $entity_revision->getParentEntity();
+
+                  // If for some reason the paragraph points to a deleted
+                  // parent entity, we skip this one.
+                  if (!$paragraph_node) {
+                    continue;
+                  }
+
+                  // Make sure the paragraph node is published, otherwise we
+                  // skip this one.
+                  if (!$paragraph_node->isPublished()) {
+                    continue;
+                  }
+
+                  if ($node->id() === $paragraph_node->id()) {
+                    continue;
+                  }
+
+                  if (!in_array($paragraph_node->id(), $source_node_ids)) {
+                    $source_nodes[] = $paragraph_node;
+                    $source_node_ids[] = $paragraph_node->id();
+                  }
+                  break;
+                }
+
+                // Make sure the revision is published, otherwise we skip this
+                // node.
+                if (!$entity_revision->isPublished()) {
+                  continue;
+                }
+
+                $source_nodes[] = $entity_revision;
+                $source_node_ids[] = $entity_revision->id();
+
+                // Latest revision has been found in the usage. We don't need
+                // go through the remaining items.
+                break;
               }
-
-              $source_nodes[] = $node_revision;
-              $source_node_ids[] = $node_revision->id();
-              // Latest revision has been found in the usage. We don't need to
-              // go through the remaining items.
-              break;
-            }
-          }
-        }
-
-        // Because the media usage is saved per node revision, we need to make
-        // sure the media is presented in the latest revision of every node.
-        // If the media is not presented in the latest revision of a node, that
-        // node will be discarded.
-        foreach ($media_usage['paragraph'] as $paragraph_id => $media_usage_items) {
-          $latest_vid = $this->entityTypeManager->getStorage('paragraph')->getLatestRevisionId($paragraph_id);
-
-          foreach ($media_usage_items as $media_usage_item) {
-            if ((int) $media_usage_item['source_vid'] === $latest_vid) {
-              $paragraph_revision = $this->entityTypeManager->getStorage('paragraph')->loadRevision($latest_vid);
-
-              $paragraph_node = $paragraph_revision->getParentEntity();
-
-              // Make sure the revision is published, otherwise we skip this
-              // node.
-              if (!$paragraph_node->isPublished()) {
-                continue;
-              }
-
-              if ($node->id() === $paragraph_node->id()) {
-                continue;
-              }
-
-              if (!in_array($paragraph_node->id(), $source_node_ids)) {
-                $source_nodes[] = $paragraph_node;
-                $source_node_ids[] = $paragraph_node->id();
-              }
-              // Latest revision has been found in the usage. We don't need
-              // go through the remaining items.
-              break;
             }
           }
         }

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/Hooks/EntityOperations.php
@@ -23,7 +23,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class EntityOperations implements ContainerInjectionInterface {
 
   /**
-   * Identifies the file statistics update operation when updating a node.
+   * Identifies the file statistics create operation when creating a node.
    */
   const GROUP_FILE_STATISTICS_CREATE_OPERATION = 'create';
 
@@ -33,7 +33,7 @@ class EntityOperations implements ContainerInjectionInterface {
   const GROUP_FILE_STATISTICS_UPDATE_OPERATION = 'update';
 
   /**
-   * Identifies the file statistics update operation when deleting a node.
+   * Identifies the file statistics delete operation when deleting a node.
    */
   const GROUP_FILE_STATISTICS_DELETE_OPERATION = 'delete';
 

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/Hooks/EntityOperations.php
@@ -6,8 +6,8 @@ use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\eic_comments\CommentsHelper;
-use Drupal\eic_group_statistics\GroupStatisticsHelper;
 use Drupal\eic_group_statistics\GroupStatisticsSearchApiReindex;
+use Drupal\eic_group_statistics\GroupStatisticsStorage;
 use Drupal\eic_group_statistics\GroupStatisticsStorageInterface;
 use Drupal\eic_group_statistics\GroupStatisticTypes;
 use Drupal\entity_usage\EntityUsageInterface;
@@ -310,7 +310,7 @@ class EntityOperations implements ContainerInjectionInterface {
 
     // Gets the array of field names that will be used to count group file
     // statistics.
-    $media_fields = GroupStatisticsHelper::getGroupFileStatisticFields();
+    $media_fields = GroupStatisticsStorage::getGroupFileStatisticFields();
 
     foreach ($media_fields as $key => $field_name) {
       // If $field_name is an array we assume we are dealing with an entity

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/Hooks/EntityOperations.php
@@ -350,7 +350,7 @@ class EntityOperations implements ContainerInjectionInterface {
 
                   // Node is new, so we just need to add the new medias to
                   // increment.
-                  if ($group_content_is_new || $operation === 'delete') {
+                  if ($group_content_is_new || $operation === self::GROUP_FILE_STATISTICS_DELETE_OPERATION) {
                     $medias[] = $media;
                     continue;
                   }

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/Hooks/EntityOperations.php
@@ -318,6 +318,12 @@ class EntityOperations implements ContainerInjectionInterface {
       ],
     ];
     foreach ($media_fields as $key => $field_name) {
+      // If $field_name is an array we assume we are dealing with an entity
+      // reference field.
+      // @todo Currently it supports only paragraph entities. We should improve
+      // it in order to support all entity types. This is also not bullet proof
+      // since it does not support also more than 1 level of fields and
+      // therefore, we can't check for nested entity reference fields.
       if (is_array($field_name)) {
         if ($entity->hasField($key)) {
 


### PR DESCRIPTION
### Improvements

- Create drush command to update all group statistics;
- Updated eic_group_statistics schema so that it now supports negative values for each statistic;
- Re-factor logic to count files statistics for a given group;
- Improve logic to count group file statistics when user creates/updates/deletes a node and make the group statistics work with Content Type Gallery.

### Tests

- [x] Create a new group and publish it
- [x] Create new documents, discussions and gallerys and make sure you reference medias
- [x] Check if the group statistics are correct when viewing the group header
- [x] Try to update some of the content and check if the group statistics are updated accordingly
- [x] Try to remove some of the content and check if the group statistics are also updated

NOTES: don't remove nodes using bulk operations otherwise the group statistics will be wrong. For now we have to remove nodes 1 by 1.