### PR TITLE
EICNET-1237: Wiki - Link Add wiki page is shown on moderated group (Part 2)

### DIFF
--- a/lib/modules/eic_groups/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_groups/src/Hooks/EntityOperations.php
@@ -209,6 +209,8 @@ class EntityOperations implements ContainerInjectionInterface {
             // Unsets book navigation since we already have that show in the
             // eic_groups_wiki_book_navigation block plugin.
             unset($build['book_navigation']);
+            // Adds user group permissions cache.
+            $build['#cache']['contexts'][] = 'user.group_permissions';
           }
         }
         elseif ($entity->bundle() === 'wiki_page') {
@@ -227,6 +229,8 @@ class EntityOperations implements ContainerInjectionInterface {
               }
             }
           }
+          // Adds user group permissions cache.
+          $build['#cache']['contexts'][] = 'user.group_permissions';
         }
         break;
 


### PR DESCRIPTION
### Fixes

- Fix cache issue when user is viewing a wiki page and then joins the group.

### Test

- [x] As SA/SCM create a new public group, enable wiki section in group features and publish it
- [x] As a TU, navigate to the group wiki section and make sure you can't view the button to add a new wiki page
- [x] Join the group and check if you now see the button to add a new wiki page
- [x]  Leave the group and make sure you don't see the button anymore
- [x] As SA/SCM, create a new wiki page in the group
- [x] As a TU, navigate to the wiki page detail and make sure you can't view the buttons to add a new wiki page (current level and level bellow)
- [x] Join the group and check if you now see the buttons