### PR TITLE
EICNET-1395: Add local tasks on all contents

### DIFF
--- a/config/sync/context.context.local_tasks.yml
+++ b/config/sync/context.context.local_tasks.yml
@@ -1,0 +1,44 @@
+uuid: 1ebe70be-4c4b-42e3-af97-baff75b86eca
+langcode: en
+status: true
+dependencies:
+  module:
+    - route_condition
+name: local_tasks
+label: 'Local tasks'
+group: Global
+description: ''
+requireAllConditions: false
+disabled: false
+conditions:
+  route:
+    id: route
+    routes: entity.node.canonical
+    negate: false
+    uuid: 617b7388-6f0c-4dc1-abc0-5e9751ff626c
+    context_mapping: {  }
+reactions:
+  blocks:
+    blocks:
+      cbef2209-7805-487f-aea1-d2980b6a253d:
+        id: local_tasks_block
+        label: Tabs
+        provider: core
+        label_display: '0'
+        primary: 1
+        secondary: 1
+        region: content_before
+        weight: '0'
+        context_mapping: {  }
+        custom_id: local_tasks_block
+        theme: eic_community
+        css_class: ''
+        unique: 0
+        context_id: local_tasks
+        third_party_settings: {  }
+        uuid: cbef2209-7805-487f-aea1-d2980b6a253d
+    id: blocks
+    saved: false
+    uuid: 62e8b73b-088c-4bde-b719-f0f34bb7c10a
+    include_default_blocks: 0
+weight: 0


### PR DESCRIPTION
### Improvements

- Create new global context to display local tasks when viewing node pages.

### Tests

- [x] Go to a node detail page and check if the local tasks are shown in the region "Before content"