### PR TITLE
EICNET-1402: Show correct breadcrumb when viewing CTypes Gallery and Document

### DIFF
--- a/lib/modules/eic_groups/eic_groups.routing.yml
+++ b/lib/modules/eic_groups/eic_groups.routing.yml
@@ -38,19 +38,3 @@ eic_groups.group.highlight_content:
     _highlight_group_content: 'TRUE'
     node: \d+
     group: \d+
-
-eic_overviews.groups.overview_page.files:
-  path: '/group/{group}/library'
-  defaults:
-    _controller: '\Drupal\eic_overviews\Controller\GroupOverviewsController::buildGenericPage'
-    _title: 'Files'
-  requirements:
-    _group_permission: 'access files overview'
-
-eic_overviews.groups.overview_page.latest_activity_stream:
-  path: '/group/{group}/latest-activity'
-  defaults:
-    _controller: '\Drupal\eic_overviews\Controller\GroupOverviewsController::buildGenericPage'
-    _title: 'Latest activity'
-  requirements:
-    _group_permission: 'access latest activity stream'

--- a/lib/modules/eic_groups/src/Breadcrumb/GroupBreadcrumbBuilder.php
+++ b/lib/modules/eic_groups/src/Breadcrumb/GroupBreadcrumbBuilder.php
@@ -127,8 +127,8 @@ class GroupBreadcrumbBuilder implements BreadcrumbBuilderInterface {
 
               case 'document':
               case 'gallery':
-                // @todo Replace link route with overview page route when available.
-                $links[] = Link::createFromRoute($this->t('Library'), '<none>');
+              case 'video':
+                $links[] = Link::fromTextAndUrl($this->t('Files'), GroupOverviewPages::getGroupOverviewPageUrl('files', $group));
                 break;
 
             }

--- a/lib/modules/eic_overviews/eic_overviews.routing.yml
+++ b/lib/modules/eic_overviews/eic_overviews.routing.yml
@@ -15,6 +15,13 @@ eic_overviews.groups.overview_page.discussions:
     _title: 'Discussions'
   requirements:
     _group_permission: 'access discussions overview'
+eic_overviews.groups.overview_page.files:
+  path: '/group/{group}/library'
+  defaults:
+    _controller: '\Drupal\eic_overviews\Controller\GroupOverviewsController::buildGenericPage'
+    _title: 'Files'
+  requirements:
+    _group_permission: 'access files overview'
 eic_overviews.groups.overview_page.members:
   path: '/group/{group}/people'
   defaults:
@@ -22,6 +29,13 @@ eic_overviews.groups.overview_page.members:
     _title: 'Members'
   requirements:
     _group_permission: 'access members overview'
+eic_overviews.groups.overview_page.latest_activity_stream:
+  path: '/group/{group}/latest-activity'
+  defaults:
+    _controller: '\Drupal\eic_overviews\Controller\GroupOverviewsController::buildGenericPage'
+    _title: 'Latest activity'
+  requirements:
+    _group_permission: 'access latest activity stream'
 eic_overviews.groups.overview_page.search:
   path: '/group/{group}/search'
   defaults:

--- a/lib/modules/eic_overviews/src/GroupOverviewPages.php
+++ b/lib/modules/eic_overviews/src/GroupOverviewPages.php
@@ -18,6 +18,11 @@ class GroupOverviewPages {
   const DISCUSSIONS = 'eic_overviews.groups.overview_page.discussions';
 
   /**
+   * Route to the group files overview.
+   */
+  const FILES = 'eic_overviews.groups.overview_page.files';
+
+  /**
    * Route to the group members overview.
    */
   const MEMBERS = 'eic_overviews.groups.overview_page.members';
@@ -43,6 +48,10 @@ class GroupOverviewPages {
     switch ($page) {
       case 'discussions':
         $page_id = self::DISCUSSIONS;
+        break;
+
+      case 'files':
+        $page_id = self::FILES;
         break;
 
       case 'members':


### PR DESCRIPTION
### Improvements

- Move group overview route definitions to eic_overviews module;
- Add group library overview constants;
- Fix group breadcrumb builder when viewing CTypes Document, Gallery and Video.

### Tests

- [ ] Create a group
- [ ] Create a new Document, a Gallery and a Video in the group
- [ ] Go to the detail page each content and check if the breadcrumb is `Home > Groups > Group name > Files > content name`  and each slug points to the right URL