### PR TITLE
EICNET-1267-1268: As a AU/GM, I can download videos from the content of a News/Story detailed page

### DIFF
--- a/lib/modules/eic_media/eic_media.module
+++ b/lib/modules/eic_media/eic_media.module
@@ -8,3 +8,50 @@
  * This file is no longer required in Drupal 8.
  * @see https://www.drupal.org/node/2217931
  */
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\eic_user\UserHelper;
+
+/**
+ * Implements hook_ENTITY_TYPE_access().
+ */
+function eic_media_media_access(EntityInterface $entity, $operation, AccountInterface $account) {
+  $route_name = \Drupal::routeMatch()->getRouteName();
+
+  // If the route name is not the system files route, it means the user is not
+  // accessing the file download route, so we don't need extra conditions to
+  // check if the user has access to any entity that this media is attached to.
+  if ($route_name !== 'system.files') {
+    return AccessResult::neutral();
+  }
+
+  // Allow access to power users.
+  if (UserHelper::isPowerUser($account)) {
+    return AccessResult::allowed()
+      ->cachePerUser();
+  }
+
+  // Loads up the entity usage for the media.
+  $media_usage = \Drupal::service('entity_usage.usage')->listSources($entity);
+
+  // We loop through all source entities and we try to find one the user has
+  // access to.
+  foreach (array_keys($media_usage) as $entity_type) {
+    foreach (array_keys($media_usage[$entity_type]) as $entity_id) {
+      $entity = \Drupal::entityTypeManager()->getStorage($entity_type)->load($entity_id);
+      $access = $entity->access('view', $account, TRUE);
+
+      if ($access->isAllowed()) {
+        // We found an entity the user has access to. The user can download
+        // the media.
+        return $access;
+      }
+    }
+  }
+
+  // At this point, it means the user has no access to any entity this media is
+  // attached to and therefore, we deny access.
+  return AccessResult::forbidden();
+}

--- a/lib/themes/eic_community/includes/preprocess/content/node--news--story.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--news--story.inc
@@ -243,8 +243,8 @@ function _eic_community_story_video_field(&$variables) {
           'path' => $download_url->toString(),
           'icon_file_path' => $variables['eic_icon_path'],
           'icon' => [
-            'type' => 'custom',
-            'name' => substr(strrchr($file->get('filemime')->getString(), '/'), 1),
+            'type' => 'general',
+            'name' => 'video',
           ],
         ];
         break;

--- a/lib/themes/eic_community/includes/preprocess/content/node--news--story.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--news--story.inc
@@ -65,6 +65,7 @@ function _eic_community_preprocess_node_news_story(array &$variables) {
   if ($variables['view_mode'] === 'full') {
     // Main elements.
     _eic_community_story_image_field($variables);
+    _eic_community_story_video_field($variables);
     _eic_community_story_document_field($variables);
     // Sidebar elements.
     _eic_community_display_flags($variables);
@@ -214,5 +215,34 @@ function _eic_community_story_related_stories(&$variables) {
       'title' => $variables['elements']['field_related_stories']['#title'],
       'items' => $related_stories,
     ];
+  }
+}
+
+/**
+ * Preprocess video field full news/story.
+ */
+function _eic_community_story_video_field(&$variables) {
+  if (isset($variables['content']['field_video'][0])) {
+    $media = $variables['content']['field_video'][0]['#media'];
+
+    switch ($media->bundle()) {
+      case 'video':
+        $file = File::load($media->field_media_video_file->target_id);
+        $variables['video_download'] = [
+          'title' => $media->getName(),
+          'language' => $media->language()->getName(),
+          'timestamp' => eic_community_get_teaser_time_display($media->get('changed')->getString()),
+          'filesize' => format_size($file->get('filesize')->getString()),
+          'highlight' => FALSE,
+          'path' => file_create_url($file->getFileUri()),
+          'icon_file_path' => $variables['eic_icon_path'],
+          'icon' => [
+            'type' => 'custom',
+            'name' => substr(strrchr($file->get('filemime')->getString(), '/'), 1),
+          ],
+        ];
+        break;
+
+    }
   }
 }

--- a/lib/themes/eic_community/includes/preprocess/content/node--news--story.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--news--story.inc
@@ -7,6 +7,7 @@
 
 use Drupal\Component\Utility\Xss;
 use Drupal\Core\Render\Markup;
+use Drupal\Core\Url;
 use Drupal\eic_community\ValueObject\ImageValueObject;
 use Drupal\eic_private_content\PrivateContentConst;
 use Drupal\file\Entity\File;
@@ -228,13 +229,18 @@ function _eic_community_story_video_field(&$variables) {
     switch ($media->bundle()) {
       case 'video':
         $file = File::load($media->field_media_video_file->target_id);
+        $download_url = Url::fromRoute('media_entity_download.download',
+          [
+            'media' => $media->id(),
+          ]
+        );
         $variables['video_download'] = [
           'title' => $media->getName(),
           'language' => $media->language()->getName(),
           'timestamp' => eic_community_get_teaser_time_display($media->get('changed')->getString()),
           'filesize' => format_size($file->get('filesize')->getString()),
           'highlight' => FALSE,
-          'path' => file_create_url($file->getFileUri()),
+          'path' => $download_url->toString(),
           'icon_file_path' => $variables['eic_icon_path'],
           'icon' => [
             'type' => 'custom',

--- a/lib/themes/eic_community/templates/content/node--story--full.html.twig
+++ b/lib/themes/eic_community/templates/content/node--story--full.html.twig
@@ -6,7 +6,11 @@
         {% include "@theme/patterns/compositions/media-wrapper.html.twig" with image_wrapper only %}
       {% endif %}
       {{ elements.field_news_paragraphs }}
-      {{ elements.field_video }}
+      {% if video_download %}
+        {% include "@theme/patterns/components/attachment.html.twig" with video_download only %}
+      {% else %}
+        {{ elements.field_video }}
+      {% endif %}
       {% if download %}
         {% include "@theme/patterns/components/attachment.html.twig" with download only %}
       {% endif %}


### PR DESCRIPTION
### Improvements

- Show video download button when viewing detail page of a News/Story.
- Implement hook eic_media_media_access() in order to validate access to media files via "system.files" route. There was an issue where users could download a video file without having access to any node or group where the media is attached to.

### Tests

- [ ] Create a News or a Story and upload a video file
- [ ] Go to the detail page and check if you see a button to download the video
- [ ] As anonymous user, go to the News/Story detail page and make sure you can download the file
- [ ] As admin, update the content and check the option "Only visible to community members"
- [ ] As anonymous user, try to download the file as anonymous user via URL and make sure you get access denied

### Todo

- [ ] For now, the button to download a video is a copy of the download document. We are still waiting for an update on the design in order to update the theme accordingly.