### PR TITLE
EICNET-391: As a GO/GA, I can manage videos in the content of a Discussion detailed page

### DIFF
--- a/config/sync/core.entity_form_display.node.discussion.default.yml
+++ b/config/sync/core.entity_form_display.node.discussion.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.discussion.field_discussion_type
     - field.field.node.discussion.field_related_contributors
     - field.field.node.discussion.field_related_documents
+    - field.field.node.discussion.field_video
     - field.field.node.discussion.field_vocab_geo
     - field.field.node.discussion.field_vocab_topics
     - node.type.discussion
@@ -15,6 +16,7 @@ dependencies:
     - comment
     - content_moderation
     - eic_content
+    - media_library
     - paragraphs
     - path
     - publication_date
@@ -53,13 +55,13 @@ content:
     type: options_select
     region: content
   field_post_activity:
-    weight: 22
+    weight: 23
     region: content
     settings: {  }
     third_party_settings: {  }
   field_related_contributors:
     type: entity_reference_paragraphs
-    weight: 21
+    weight: 22
     settings:
       title: Paragraph
       title_plural: Paragraphs
@@ -78,6 +80,13 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: entity_reference_autocomplete
+    region: content
+  field_video:
+    weight: 21
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+    type: media_library_widget
     region: content
   field_vocab_geo:
     weight: 7
@@ -192,6 +201,11 @@ content:
   unpublish_state:
     type: scheduler_moderation
     weight: 16
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  url_redirects:
+    weight: 24
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_view_display.node.discussion.default.yml
+++ b/config/sync/core.entity_view_display.node.discussion.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.discussion.field_discussion_type
     - field.field.node.discussion.field_related_contributors
     - field.field.node.discussion.field_related_documents
+    - field.field.node.discussion.field_video
     - field.field.node.discussion.field_vocab_geo
     - field.field.node.discussion.field_vocab_topics
     - node.type.discussion
@@ -57,6 +58,14 @@ content:
     region: content
   field_related_documents:
     weight: 105
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_video:
+    weight: 108
     label: hidden
     settings:
       link: true

--- a/config/sync/core.entity_view_display.node.discussion.teaser.yml
+++ b/config/sync/core.entity_view_display.node.discussion.teaser.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.discussion.field_discussion_type
     - field.field.node.discussion.field_related_contributors
     - field.field.node.discussion.field_related_documents
+    - field.field.node.discussion.field_video
     - field.field.node.discussion.field_vocab_geo
     - field.field.node.discussion.field_vocab_topics
     - node.type.discussion
@@ -91,6 +92,7 @@ hidden:
   field_comments: true
   field_related_contributors: true
   field_related_documents: true
+  field_video: true
   field_vocab_geo: true
   field_vocab_topics: true
   langcode: true

--- a/config/sync/field.field.node.discussion.field_video.yml
+++ b/config/sync/field.field.node.discussion.field_video.yml
@@ -1,0 +1,29 @@
+uuid: ba1d70a5-550f-4b7a-9cae-05a49d4d94ef
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_video
+    - media.type.video
+    - node.type.discussion
+id: node.discussion.field_video
+field_name: field_video
+entity_type: node
+bundle: discussion
+label: Video
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      video: video
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/lib/themes/eic_community/includes/preprocess/content/node--discussion.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--discussion.inc
@@ -9,6 +9,7 @@ use Drupal\taxonomy\Entity\Term;
 use Drupal\comment\Entity\Comment;
 use Drupal\Component\Utility\Xss;
 use Drupal\Core\Render\Markup;
+use Drupal\Core\Url;
 
 /**
  * Implements hook_preprocess_node() for discussion node.
@@ -40,6 +41,8 @@ function eic_community_preprocess_node__discussion(array &$variables) {
  * Preprocesses full display.
  */
 function _preprocess_discussion_full(&$variables, $discussion_type, $node) {
+  /** @var \Drupal\node\NodeInterface $node */
+  $node = $variables['node'];
   $variables['type'] = $discussion_type;
   if (!empty($variables['elements']['contributor_ids'])) {
     $users = \Drupal::entityTypeManager()->getStorage('user')->loadMultiple($variables['elements']['contributor_ids']);
@@ -70,6 +73,35 @@ function _preprocess_discussion_full(&$variables, $discussion_type, $node) {
       $value['#options']['attributes']['class'][] = 'ecl-tag';
       $value['#options']['attributes']['class'][] = 'ecl-featured-list__item-tag';
       $variables['elements']['field_vocab_topics'][$key] = $value;
+    }
+  }
+
+  // Add video download section.
+  $media_videos = $node->get('field_video')->referencedEntities();
+  foreach ($media_videos as $media) {
+    switch ($media->bundle()) {
+      case 'video':
+        $file = $media->field_media_video_file->entity;
+        $download_url = Url::fromRoute('media_entity_download.download',
+          [
+            'media' => $media->id(),
+          ]
+        );
+        $variables['video_download'] = [
+          'title' => $media->getName(),
+          'language' => $media->language()->getName(),
+          'timestamp' => eic_community_get_teaser_time_display($media->get('changed')->getString()),
+          'filesize' => format_size($file->get('filesize')->getString()),
+          'highlight' => FALSE,
+          'path' => $download_url->toString(),
+          'icon_file_path' => $variables['eic_icon_path'],
+          'icon' => [
+            'type' => 'general',
+            'name' => 'video',
+          ],
+        ];
+        break;
+
     }
   }
 }

--- a/lib/themes/eic_community/templates/content/node--discussion--full.html.twig
+++ b/lib/themes/eic_community/templates/content/node--discussion--full.html.twig
@@ -41,6 +41,11 @@
             {% endif %}
           </div>
         {% endif %}
+        {% if video_download %}
+          {% include "@theme/patterns/components/attachment.html.twig" with video_download only %}
+        {% else %}
+          {{ elements.field_video }}
+        {% endif %}
       {% endblock %}
       {% block sidebar %}
         {% if flags %}


### PR DESCRIPTION
### Features

- Create field_video in CT Discussion to allow users to upload videos;
- Show discussion video in the frontend (new theme variables and updated twig template).

### Tests

- [ ] Create a group
- [ ] Create a discussion and upload a video
- [ ] Go to the discussion detail page and check if there is a section to download the video

### Notes

- For now the frontend only serves as an example which means that it might suffer changes in the future.