### PR TITLE
[EICNET-798]fix: site_admin should also see content with community restriction

### DIFF
--- a/lib/modules/eic_search/src/Plugin/search_api/processor/GroupAccessContent.php
+++ b/lib/modules/eic_search/src/Plugin/search_api/processor/GroupAccessContent.php
@@ -142,7 +142,7 @@ class GroupAccessContent extends ProcessorPluginBase {
     ';
 
     // Restricted community group, only trusted_user role can view.
-    if (!$user->isAnonymous() && ($user->hasRole('trusted_user') || $user->hasRole('site_admin'))) {
+    if (!$user->isAnonymous() && ($user->hasRole(UserHelper::ROLE_TRUSTED_USER) || $user->hasRole(UserHelper::ROLE_SITE_ADMINISTRATOR) || UserHelper::isPowerUser($this->getCurrentUser()))) {
       $query .= ' OR (ss_group_visibility:' . GroupVisibilityType::GROUP_VISIBILITY_COMMUNITY . ')';
     }
 

--- a/lib/modules/eic_search/src/Plugin/search_api/processor/GroupAccessContent.php
+++ b/lib/modules/eic_search/src/Plugin/search_api/processor/GroupAccessContent.php
@@ -142,7 +142,7 @@ class GroupAccessContent extends ProcessorPluginBase {
     ';
 
     // Restricted community group, only trusted_user role can view.
-    if (!$user->isAnonymous() && $user->hasRole('trusted_user')) {
+    if (!$user->isAnonymous() && ($user->hasRole('trusted_user') || $user->hasRole('site_admin'))) {
       $query .= ' OR (ss_group_visibility:' . GroupVisibilityType::GROUP_VISIBILITY_COMMUNITY . ')';
     }
 

--- a/lib/modules/eic_search/src/Plugin/search_api/processor/GroupAccessContent.php
+++ b/lib/modules/eic_search/src/Plugin/search_api/processor/GroupAccessContent.php
@@ -142,7 +142,7 @@ class GroupAccessContent extends ProcessorPluginBase {
     ';
 
     // Restricted community group, only trusted_user role can view.
-    if (!$user->isAnonymous() && ($user->hasRole(UserHelper::ROLE_TRUSTED_USER) || $user->hasRole(UserHelper::ROLE_SITE_ADMINISTRATOR) || UserHelper::isPowerUser($this->getCurrentUser()))) {
+    if (!$user->isAnonymous() && ($user->hasRole(UserHelper::ROLE_TRUSTED_USER) || UserHelper::isPowerUser($this->getCurrentUser()))) {
       $query .= ' OR (ss_group_visibility:' . GroupVisibilityType::GROUP_VISIBILITY_COMMUNITY . ')';
     }
 


### PR DESCRIPTION
How to test:

- [ ] Check if you are site_admin role (not trusted user just)
- [ ] In search for content locked for community, a site_admin should be able to see it