### PR TITLE
EICNET-392: As a GO/GA, I can manage videos in the content of a Wiki detailed page

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/field/field--media--eic-document.inc
+++ b/lib/themes/eic_community/includes/preprocess/field/field--media--eic-document.inc
@@ -5,8 +5,7 @@
  * Contains implementation for docuemnt media preprocessor.
  */
 
-use Drupal\file\Entity\File;
-use Drupal\media\Entity\Media;
+use Drupal\Core\Url;
 
 /**
  * Implements hook_preprocess_HOOK().
@@ -15,8 +14,46 @@ function eic_community_preprocess_field__field_related_downloads(array &$variabl
   $documents = [];
 
   foreach ($variables['element']['#items'] as $item) {
-    $media = Media::load($item->target_id);
-    $file = File::load($media->field_media_file->target_id);
+    /** @var \Drupal\media\Entity\Media $media */
+    $media = $item->entity;
+    $file = FALSE;
+
+    // Load all fields definitions from the media and grab the file entity from
+    // the file reference field.
+    $entity_fields = \Drupal::service('entity_field.manager')->getFieldDefinitions('media', $media->bundle());
+    foreach ($entity_fields as $field) {
+      /** @var \Drupal\Core\Field\FieldDefinitionInterface $field */
+
+      // We already found the file, so we can break the loop.
+      if ($file) {
+        break;
+      }
+
+      switch ($field->getType()) {
+        case 'file':
+        case 'image':
+          // We skip thumbnail property of the media.
+          if ($field->getName() === 'thumbnail') {
+            break;
+          }
+
+          $file = $media->get($field->getName())->entity;
+          break;
+      }
+    }
+
+    // This media has no file, so we skip it.
+    if (!$file) {
+      break;
+    }
+
+    $file_type = strstr($file->get('filemime')->getString(), '/', TRUE);
+
+    $download_url = Url::fromRoute('media_entity_download.download',
+      [
+        'media' => $media->id(),
+      ]
+    );
 
     $document = [
       'title' => $media->getName(),
@@ -24,9 +61,11 @@ function eic_community_preprocess_field__field_related_downloads(array &$variabl
       'timestamp' => eic_community_get_teaser_time_display($media->get('changed')->getString()),
       'filesize' => format_size($file->get('filesize')->getString()),
       'highlight' => FALSE,
+      'path' => $download_url->toString(),
+      'icon_file_path' => $variables['eic_icon_path'],
       'icon' => [
-        'type' => 'custom',
-        'name' => substr(strrchr($file->get('filemime')->getString(), '/'), 1),
+        'type' => $file_type === 'video' ? 'general' : 'custom',
+        'name' => $file_type === 'video' ? $file_type : substr(strrchr($file->get('filemime')->getString(), '/'), 1),
       ],
     ];
 


### PR DESCRIPTION
### Improvements

- Improvements in hook eic_community_preprocess_field__field_related_downloads() so that it includes video files in the list of related downloads.

### Tests

- [x] Create a group
- [x] Create a new wiki page in the group and upload a video in the Related downloads field
- [x] Go to the wiki page detail and check if the download link is shown 