### PR TITLE
EICNET-1172: A group can only have one GO

### DIFF
--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -427,3 +427,16 @@ function eic_groups_entity_base_field_info(EntityTypeInterface $entity_type) {
 
   return $fields;
 }
+
+/**
+ * Implements hook_entity_type_alter().
+ */
+function eic_groups_entity_type_alter(array &$entity_types) {
+  if (!isset($entity_types['group']) && !isset($entity_types['group_content'])) {
+    return;
+  }
+
+  // Add custom group membership validation constraint to the group_content
+  // entity.
+  $entity_types['group_content']->addConstraint('EICGroupMembership');
+}

--- a/lib/modules/eic_groups/src/Plugin/Validation/Constraint/GroupMembershipConstraint.php
+++ b/lib/modules/eic_groups/src/Plugin/Validation/Constraint/GroupMembershipConstraint.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\eic_groups\Plugin\Validation\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Provides a Group membership constraint.
+ *
+ * @Constraint(
+ *   id = "EICGroupMembership",
+ *   label = @Translation("Group membership", context = "Validation"),
+ * )
+ */
+class GroupMembershipConstraint extends Constraint {
+
+  /**
+   * The message that will be shown if group already has a owner.
+   *
+   * @var string
+   */
+  public $multipleOwners = 'A group cannot have multiple owners.';
+
+}

--- a/lib/modules/eic_groups/src/Plugin/Validation/Constraint/GroupMembershipConstraintValidator.php
+++ b/lib/modules/eic_groups/src/Plugin/Validation/Constraint/GroupMembershipConstraintValidator.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Drupal\eic_groups\Plugin\Validation\Constraint;
+
+use Drupal\eic_groups\EICGroupsHelper;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Validates the Group membership constraint.
+ */
+class GroupMembershipConstraintValidator extends ConstraintValidator {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validate($entity, Constraint $constraint) {
+    // We only validate group_content entities.
+    if ($entity->getEntityTypeId() !== 'group_content') {
+      return;
+    }
+
+    // We skip group_content entities that are not group_membership.
+    if ($entity->getGroupContentType()->getContentPluginId() !== 'group_membership') {
+      return;
+    }
+
+    $membership_roles = array_column($entity->group_roles->getValue(), 'target_id');
+
+    if (!in_array(EICGroupsHelper::GROUP_OWNER_ROLE, $membership_roles)) {
+      return;
+    }
+
+    /** @var \Drupal\group\Entity\GroupInterface $group */
+    $group = $entity->getGroup();
+
+    $group_owners = $group->getMembers([EICGroupsHelper::GROUP_OWNER_ROLE]);
+
+    // The group doesn't have any owner and therefore this group membership is
+    // valid.
+    if (empty($group_owners)) {
+      return;
+    }
+
+    foreach ($group_owners as $group_owner) {
+      // It's the same owner so we can exit.
+      if ($group_owner->getGroupContent()->id() === $entity->id()) {
+        break;
+      }
+
+      // Group cannot have multiple owners an so we add a violation.
+      $this->context->buildViolation($constraint->multipleOwners)
+        ->atPath('group_roles')
+        ->addViolation();
+      return;
+    }
+  }
+
+}


### PR DESCRIPTION
### Improvements

- Create entity constraint to validate if a group already has a owner before saving a membership.

### Tests

- [x] Create a new public group and publish it
- [x] As a TU, join the group
- [x] As SA/SCM, go to the group members list and edit the membership of the TU
- [x] Try to add the owner role and make sure you get an error message "**A group cannot have multiple owners.**"