### PR TITLE
EICNET-1345: SA/SCM should be able to edit all group content of any group (Part 2)

### DIFF
--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -298,6 +298,9 @@ function eic_groups_group_content_info_alter(array &$definitions) {
       continue;
     }
 
+    // Overrides the standard group content node class in order to fix access
+    // to the operation links.
+    $definition['class'] = '\Drupal\eic_groups\Plugin\GroupContentEnabler\GroupNode';
     // Overrides the group content access controll handler class.
     $definition['handlers']['access'] = '\Drupal\eic_groups\Access\GroupContentNodeAccessControlHandler';
   }

--- a/lib/modules/eic_groups/src/Plugin/GroupContentEnabler/GroupNode.php
+++ b/lib/modules/eic_groups/src/Plugin/GroupContentEnabler/GroupNode.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Drupal\eic_groups\Plugin\GroupContentEnabler;
+
+use Drupal\group\Entity\GroupInterface;
+use Drupal\Core\Url;
+use Drupal\gnode\Plugin\GroupContentEnabler\GroupNode as GroupNodeBase;
+
+/**
+ * Extends content enabler class for group content nodes.
+ */
+class GroupNode extends GroupNodeBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getGroupOperations(GroupInterface $group) {
+    $account = \Drupal::currentUser();
+    $plugin_id = $this->getPluginId();
+    $type = $this->getEntityBundle();
+    $operations = [];
+
+    $route_params = ['group' => $group->id(), 'plugin_id' => $plugin_id];
+    $create_url = Url::fromRoute('entity.group_content.create_form', $route_params);
+
+    // If the user has access to the route, we add the operation.
+    if ($create_url->access($account)) {
+      $operations["gnode-create-$type"] = [
+        'title' => $this->t('Add @type', ['@type' => $this->getNodeType()->label()]),
+        'url' => new Url('entity.group_content.create_form', $route_params),
+        'weight' => 30,
+      ];
+    }
+
+    return $operations;
+  }
+
+}


### PR DESCRIPTION
### Fixes

- Override GroupNode class in order to fix issue where group operations were empty for SA/SCM users that were not members of the group;
- Allow SA/SCM to create group content (override permission system).

### Tests

- [x] As a TU, create a new group
- [x] Make sure you can't add new group content until the group status is set to draft
- [x] As SA/SCM, go to the group homepage and check if you have the **Post content** dropdown in the group header
- [x] Edit the group status to draft
- [x] As TU, go to the group homepage and check if you are able to create content