### PR TITLE
EICNET-1369: Adapt comment section on video detail page (group library) Part 2

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/content/node--news--story.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--news--story.inc
@@ -148,23 +148,36 @@ function _eic_community_display_flags(&$variables) {
  * Preproccess contributors.
  */
 function _eic_community_display_contributors(&$variables) {
-  if ($variables['node']->bundle() === 'story') {
-    $contributors = [];
+  /** @var \Drupal\node\NodeInterface $node */
+  $node = $variables['node'];
+  $contributors = [];
 
-    foreach ($variables['elements']['field_story_paragraphs'] as $key => $value) {
-      if (is_int($key)) {
-        $contributors[] = [
-          'content' => $value,
-        ];
+  $contributors_fields = [
+    'field_story_paragraphs',
+    'field_related_contributors',
+  ];
+
+  $field_title = FALSE;
+
+  foreach ($contributors_fields as $field_name) {
+    if ($node->hasField($field_name)) {
+      $field_title = $variables['elements'][$field_name]['#title'];
+
+      foreach ($variables['elements'][$field_name] as $key => $value) {
+        if (is_int($key)) {
+          $contributors[] = [
+            'content' => $value,
+          ];
+        }
       }
     }
+  }
 
-    if (count($contributors) > 0) {
-      $variables['contributors'] = [
-        'title' => $variables['elements']['field_story_paragraphs']['#title'],
-        'items' => $contributors,
-      ];
-    }
+  if (count($contributors) > 0) {
+    $variables['contributors'] = [
+      'title' => $field_title,
+      'items' => $contributors,
+    ];
   }
 }
 

--- a/lib/themes/eic_community/includes/preprocess/content/node--video.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--video.inc
@@ -13,12 +13,28 @@ function eic_community_preprocess_node__video(array &$variables) {
     case 'full':
       _eic_community_display_flags($variables);
       _eic_community_display_topics($variables);
-      _eic_community_display_contributors($variables);
+      _eic_community_display_video_contributors($variables);
 
       // Provide the Social Share block.
       if ($share_block = _eic_community_get_social_share_block()) {
         $variables['social_share'] = $share_block;
       }
       break;
+  }
+}
+
+/**
+ * Preprocess video contributors to show in the detail page.
+ */
+function _eic_community_preprocess_video_contributors(array &$variables) {
+  if (!empty($variables['elements']['contributor_ids'])) {
+    $users = \Drupal::entityTypeManager()->getStorage('user')->loadMultiple($variables['elements']['contributor_ids']);
+    $contributors = ['items' => []];
+
+    foreach ($users as $user) {
+      $contributors['items'][] = eic_community_get_teaser_user_display($user);
+    }
+
+    $variables['contributors'] = $contributors;
   }
 }


### PR DESCRIPTION
### Improvements

- Show contributors in CT Video.

### Tests

- [x] Create a new public group and publish it
- [x] Create a new video in the group and add some contributors
- [x] Go to the video detail page and check if the contributors list is shown next to the comments section

### Todo

- [x] Fix FE style issue when not a GM, the **Replies** title is shown too close to the actual first reply.

FE fixes will be done in a follow-up ticket -> https://citnet.tech.ec.europa.eu/CITnet/jira/browse/EICNET-1433