### PR TITLE
EICNET-391: As a GO/GA, I can manage videos in the content of a Discussion detailed page (Rework)

### DIFF
--- a/config/sync/core.entity_form_display.node.discussion.default.yml
+++ b/config/sync/core.entity_form_display.node.discussion.default.yml
@@ -8,7 +8,7 @@ dependencies:
     - field.field.node.discussion.field_discussion_type
     - field.field.node.discussion.field_related_contributors
     - field.field.node.discussion.field_related_documents
-    - field.field.node.discussion.field_video
+    - field.field.node.discussion.field_related_downloads
     - field.field.node.discussion.field_vocab_geo
     - field.field.node.discussion.field_vocab_topics
     - node.type.discussion
@@ -61,7 +61,7 @@ content:
     third_party_settings: {  }
   field_related_contributors:
     type: entity_reference_paragraphs
-    weight: 22
+    weight: 21
     settings:
       title: Paragraph
       title_plural: Paragraphs
@@ -81,8 +81,8 @@ content:
     third_party_settings: {  }
     type: entity_reference_autocomplete
     region: content
-  field_video:
-    weight: 21
+  field_related_downloads:
+    weight: 22
     settings:
       media_types: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_view_display.node.discussion.default.yml
+++ b/config/sync/core.entity_view_display.node.discussion.default.yml
@@ -9,7 +9,7 @@ dependencies:
     - field.field.node.discussion.field_discussion_type
     - field.field.node.discussion.field_related_contributors
     - field.field.node.discussion.field_related_documents
-    - field.field.node.discussion.field_video
+    - field.field.node.discussion.field_related_downloads
     - field.field.node.discussion.field_vocab_geo
     - field.field.node.discussion.field_vocab_topics
     - node.type.discussion
@@ -64,9 +64,9 @@ content:
     third_party_settings: {  }
     type: entity_reference_label
     region: content
-  field_video:
-    weight: 108
-    label: hidden
+  field_related_downloads:
+    weight: 109
+    label: above
     settings:
       link: true
     third_party_settings: {  }

--- a/config/sync/core.entity_view_display.node.discussion.teaser.yml
+++ b/config/sync/core.entity_view_display.node.discussion.teaser.yml
@@ -9,7 +9,7 @@ dependencies:
     - field.field.node.discussion.field_discussion_type
     - field.field.node.discussion.field_related_contributors
     - field.field.node.discussion.field_related_documents
-    - field.field.node.discussion.field_video
+    - field.field.node.discussion.field_related_downloads
     - field.field.node.discussion.field_vocab_geo
     - field.field.node.discussion.field_vocab_topics
     - node.type.discussion
@@ -92,7 +92,7 @@ hidden:
   field_comments: true
   field_related_contributors: true
   field_related_documents: true
-  field_video: true
+  field_related_downloads: true
   field_vocab_geo: true
   field_vocab_topics: true
   langcode: true

--- a/config/sync/field.field.node.discussion.field_related_downloads.yml
+++ b/config/sync/field.field.node.discussion.field_related_downloads.yml
@@ -1,16 +1,16 @@
-uuid: ba1d70a5-550f-4b7a-9cae-05a49d4d94ef
+uuid: 5946d267-a169-4ad3-97a3-0669760db678
 langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.node.field_video
+    - field.storage.node.field_related_downloads
     - media.type.video
     - node.type.discussion
-id: node.discussion.field_video
-field_name: field_video
+id: node.discussion.field_related_downloads
+field_name: field_related_downloads
 entity_type: node
 bundle: discussion
-label: Video
+label: Downloads
 description: ''
 required: false
 translatable: true

--- a/lib/themes/eic_community/includes/preprocess/content/node--discussion.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--discussion.inc
@@ -9,7 +9,6 @@ use Drupal\taxonomy\Entity\Term;
 use Drupal\comment\Entity\Comment;
 use Drupal\Component\Utility\Xss;
 use Drupal\Core\Render\Markup;
-use Drupal\Core\Url;
 
 /**
  * Implements hook_preprocess_node() for discussion node.
@@ -73,35 +72,6 @@ function _preprocess_discussion_full(&$variables, $discussion_type, $node) {
       $value['#options']['attributes']['class'][] = 'ecl-tag';
       $value['#options']['attributes']['class'][] = 'ecl-featured-list__item-tag';
       $variables['elements']['field_vocab_topics'][$key] = $value;
-    }
-  }
-
-  // Add video download section.
-  $media_videos = $node->get('field_video')->referencedEntities();
-  foreach ($media_videos as $media) {
-    switch ($media->bundle()) {
-      case 'video':
-        $file = $media->field_media_video_file->entity;
-        $download_url = Url::fromRoute('media_entity_download.download',
-          [
-            'media' => $media->id(),
-          ]
-        );
-        $variables['video_download'] = [
-          'title' => $media->getName(),
-          'language' => $media->language()->getName(),
-          'timestamp' => eic_community_get_teaser_time_display($media->get('changed')->getString()),
-          'filesize' => format_size($file->get('filesize')->getString()),
-          'highlight' => FALSE,
-          'path' => $download_url->toString(),
-          'icon_file_path' => $variables['eic_icon_path'],
-          'icon' => [
-            'type' => 'general',
-            'name' => 'video',
-          ],
-        ];
-        break;
-
     }
   }
 }

--- a/lib/themes/eic_community/includes/preprocess/field/field--media--eic-document.inc
+++ b/lib/themes/eic_community/includes/preprocess/field/field--media--eic-document.inc
@@ -5,8 +5,7 @@
  * Contains implementation for docuemnt media preprocessor.
  */
 
-use Drupal\file\Entity\File;
-use Drupal\media\Entity\Media;
+use Drupal\Core\Url;
 
 /**
  * Implements hook_preprocess_HOOK().
@@ -15,8 +14,46 @@ function eic_community_preprocess_field__field_related_downloads(array &$variabl
   $documents = [];
 
   foreach ($variables['element']['#items'] as $item) {
-    $media = Media::load($item->target_id);
-    $file = File::load($media->field_media_file->target_id);
+    /** @var \Drupal\media\Entity\Media $media */
+    $media = $item->entity;
+    $file = FALSE;
+
+    // Load all fields definitions from the media and grab the file entity from
+    // the file reference field.
+    $entity_fields = \Drupal::service('entity_field.manager')->getFieldDefinitions('media', $media->bundle());
+    foreach ($entity_fields as $field) {
+      /** @var \Drupal\Core\Field\FieldDefinitionInterface $field */
+
+      // We already found the file, so we can break the loop.
+      if ($file) {
+        break;
+      }
+
+      switch ($field->getType()) {
+        case 'file':
+        case 'image':
+          // We skip thumbnail property of the media.
+          if ($field->getName() === 'thumbnail') {
+            break;
+          }
+
+          $file = $media->get($field->getName())->entity;
+          break;
+      }
+    }
+
+    // This media has no file, so we skip it.
+    if (!$file) {
+      break;
+    }
+
+    $file_type = strstr($file->get('filemime')->getString(), '/', TRUE);
+
+    $download_url = Url::fromRoute('media_entity_download.download',
+      [
+        'media' => $media->id(),
+      ]
+    );
 
     $document = [
       'title' => $media->getName(),
@@ -24,9 +61,11 @@ function eic_community_preprocess_field__field_related_downloads(array &$variabl
       'timestamp' => eic_community_get_teaser_time_display($media->get('changed')->getString()),
       'filesize' => format_size($file->get('filesize')->getString()),
       'highlight' => FALSE,
+      'path' => $download_url->toString(),
+      'icon_file_path' => $variables['eic_icon_path'],
       'icon' => [
-        'type' => 'custom',
-        'name' => substr(strrchr($file->get('filemime')->getString(), '/'), 1),
+        'type' => $file_type === 'video' ? 'general' : 'custom',
+        'name' => $file_type === 'video' ? $file_type : substr(strrchr($file->get('filemime')->getString(), '/'), 1),
       ],
     ];
 

--- a/lib/themes/eic_community/templates/content/node--discussion--full.html.twig
+++ b/lib/themes/eic_community/templates/content/node--discussion--full.html.twig
@@ -41,11 +41,11 @@
             {% endif %}
           </div>
         {% endif %}
-        {% if video_download %}
+        {# {% if video_download %}
           {% include "@theme/patterns/components/attachment.html.twig" with video_download only %}
-        {% else %}
-          {{ elements.field_video }}
-        {% endif %}
+        {% else %} #}
+        {{ content.field_related_downloads }}
+        {# {% endif %} #}
       {% endblock %}
       {% block sidebar %}
         {% if flags %}


### PR DESCRIPTION
### Improvements

- Remove field_video from CT Discussion, re-use field_related_downloads from wiki page in order to keep congruence.

### Tests

- [x] Create a group
- [x] Create a new discussion and upload a video
- [x] Go to the detail page of the discussion and make sure the link to download the video is shown