### PR TITLE
EICNET-1187: CT Video back-end (rework)

### DIFF
--- a/config/sync/core.entity_form_display.node.video.default.yml
+++ b/config/sync/core.entity_form_display.node.video.default.yml
@@ -30,12 +30,12 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 9
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
   field_body:
-    weight: 20
+    weight: 1
     settings:
       rows: 5
       placeholder: ''
@@ -43,20 +43,16 @@ content:
     type: text_textarea
     region: content
   field_comments:
-    weight: 23
+    weight: 20
     settings: {  }
     third_party_settings: {  }
     type: comment_default
     region: content
   field_document_type:
     weight: 5
-    settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
+    settings: {  }
     third_party_settings: {  }
-    type: entity_reference_autocomplete
+    type: options_select
     region: content
   field_language:
     weight: 4
@@ -65,12 +61,12 @@ content:
     type: options_select
     region: content
   field_post_activity:
-    weight: 1
+    weight: 21
     region: content
     settings: {  }
     third_party_settings: {  }
   field_related_contributors:
-    weight: 22
+    weight: 19
     settings:
       title: Paragraph
       title_plural: Paragraphs
@@ -83,7 +79,7 @@ content:
     region: content
   field_video_media:
     type: media_library_widget
-    weight: 7
+    weight: 3
     settings:
       media_types: {  }
     third_party_settings: {  }
@@ -99,7 +95,7 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_vocab_topics:
-    weight: 21
+    weight: 2
     settings:
       match_top_level_limit: '0'
       disable_top_choices: '1'
@@ -111,52 +107,45 @@ content:
     region: content
   langcode:
     type: language_select
-    weight: 3
+    weight: 23
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 18
+    weight: 17
     settings: {  }
     region: content
     third_party_settings: {  }
   path:
     type: path
-    weight: 16
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
-  private:
-    weight: 2
-    region: content
-    settings:
-      display_label: true
-    third_party_settings: {  }
-    type: boolean_checkbox
   promote:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 11
+    weight: 10
     region: content
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 17
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }
   publish_state:
     type: scheduler_moderation
-    weight: 14
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }
   published_at:
     type: publication_date_timestamp
-    weight: 10
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -164,14 +153,14 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 19
+    weight: 18
     region: content
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 12
+    weight: 11
     region: content
     third_party_settings: {  }
   title:
@@ -184,7 +173,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 8
+    weight: 7
     settings:
       match_operator: CONTAINS
       size: 60
@@ -194,15 +183,21 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 15
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
   unpublish_state:
     type: scheduler_moderation
-    weight: 13
+    weight: 12
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  url_redirects:
+    weight: 22
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
   member_content_edit_access: true
+  private: true

--- a/config/sync/field.field.node.video.field_document_type.yml
+++ b/config/sync/field.field.node.video.field_document_type.yml
@@ -12,7 +12,7 @@ entity_type: node
 bundle: video
 label: 'Document type'
 description: ''
-required: false
+required: true
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/config/sync/field.field.node.video.field_video_media.yml
+++ b/config/sync/field.field.node.video.field_video_media.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - field.storage.node.field_video_media
     - media.type.remote_video
-    - media.type.video
     - node.type.video
 id: node.video.field_video_media
 field_name: field_video_media
@@ -22,7 +21,6 @@ settings:
   handler_settings:
     target_bundles:
       remote_video: remote_video
-      video: video
     sort:
       field: _none
       direction: ASC

--- a/config/sync/pathauto.pattern.library.yml
+++ b/config/sync/pathauto.pattern.library.yml
@@ -9,15 +9,16 @@ label: Library
 type: 'canonical_entities:node'
 pattern: '[node:node_group_url]/library/[node:title]'
 selection_criteria:
-  51ec4726-84c3-4bdc-bab0-0d69ff230f1b:
+  a9ca8400-c6bc-40de-b50d-141e57b05890:
     id: node_type
     bundles:
       document: document
       gallery: gallery
+      video: video
     negate: false
     context_mapping:
       node: node
-    uuid: 51ec4726-84c3-4bdc-bab0-0d69ff230f1b
+    uuid: a9ca8400-c6bc-40de-b50d-141e57b05890
 selection_logic: and
 weight: -8
 relationships: {  }

--- a/lib/themes/eic_community/includes/preprocess/content/node--video.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--video.inc
@@ -13,7 +13,7 @@ function eic_community_preprocess_node__video(array &$variables) {
     case 'full':
       _eic_community_display_flags($variables);
       _eic_community_display_topics($variables);
-      _eic_community_display_video_contributors($variables);
+      _eic_community_preprocess_video_contributors($variables);
 
       // Provide the Social Share block.
       if ($share_block = _eic_community_get_social_share_block()) {


### PR DESCRIPTION
### Changes CT Video

- Update form display;
- Make field_document_type;
- Allow only remote videos;
- Enable CT Video in pathauto pattern "Library";

### Tests

When creating a new Video in a group, make sure the back-end form is shown correctly:

- [ ] fields are shown in the right order
- [ ] field_document_type are required
- [ ] After saving the Video make sure the URL alias is `/groups/<group-name>/library/<video-name>`

See requirements -> https://citnet.tech.ec.europa.eu/CITnet/jira/browse/EICNET-1187.