### PR TITLE
EICNET-1164: When contributor field is left empty, the story can't be saved

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/content/node--news--story.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--news--story.inc
@@ -164,7 +164,40 @@ function _eic_community_display_contributors(&$variables) {
       $field_title = $variables['elements'][$field_name]['#title'];
 
       foreach ($variables['elements'][$field_name] as $key => $value) {
+        $has_contributor = FALSE;
+
         if (is_int($key)) {
+          /** @var \Drupal\paragraphs\ParagraphInterface $contributor */
+          $contributor = $value['#paragraph'];
+          $variant = $contributor->get('paragraph_view_mode')->value;
+
+          switch ($variant) {
+            case 'external_person':
+              if (!$contributor->get('field_name')->isEmpty()) {
+                $has_contributor = TRUE;
+              }
+              break;
+
+            case 'platform_member':
+              if (!$contributor->get('field_user_ref')->isEmpty()) {
+                $user = $contributor->get('field_user_ref')->entity;
+
+                // User entity has probably been deleted but the reference
+                // still exists. In this case, we do nothing.
+                if (!$user) {
+                  break;
+                }
+
+                $has_contributor = TRUE;
+              }
+              break;
+
+          }
+
+          if (!$has_contributor) {
+            continue;
+          }
+
           $contributors[] = [
             'content' => $value,
           ];


### PR DESCRIPTION
### Improvements

- Hide Story contributors from detail page when paragraphs are empty.

### Tests

- [ ] Create a new story and add a contributor with variant set to External person and leave the fields empty.
- [ ] Go to the story detail page and check if the Contributors field is hidden.
- [ ] Edit the story and change the contributor variant to Platform member and save it. Leave the contributor fields empty.
- [ ] Go to the story detail page and check if the Contributors field is still hidden.
- [ ] Edit the story once again and this time try to add a Contributor name (for External person variant) or a User reference (for Platform member variant)
- [ ] Go to the story detail page and check if the Contributors field is now visible