### PR TITLE
EICNET-1355: Do not make avatar clickable for anonymous users

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/blocks/block--latest-news-stories.inc
+++ b/lib/themes/eic_community/includes/preprocess/blocks/block--latest-news-stories.inc
@@ -44,10 +44,6 @@ function eic_community_preprocess_block__latest_news_stories(&$variables, &$cach
     $node_author = eic_community_get_teaser_user_display($node_translation->getOwner());
     $time_ago = \Drupal::service('date.formatter')->formatTimeDiffSince($node_translation->get('published_at')->value, ['granularity' => 1]);
 
-    if ($variables['logged_in'] === FALSE) {
-      unset($node_author['path']);
-    }
-
     if (isset($variables['content']['node_stats'][$node->id()])) {
       $node_stats = $variables['content']['node_stats'][$node->id()];
     }

--- a/lib/themes/eic_community/includes/preprocess/paragraphs/paragraph--contributor.inc
+++ b/lib/themes/eic_community/includes/preprocess/paragraphs/paragraph--contributor.inc
@@ -63,10 +63,6 @@ function eic_community_preprocess_paragraph__contributor(array &$variables) {
     if ($user instanceof UserInterface) {
       $user_display = eic_community_get_teaser_user_display($user);
 
-      if ($variables['logged_in'] === FALSE) {
-        unset($user_display['path']);
-      }
-
       $contributor = array_merge($contributor, $user_display);
     }
   }

--- a/lib/themes/eic_community/includes/preprocess/users/user.inc
+++ b/lib/themes/eic_community/includes/preprocess/users/user.inc
@@ -42,8 +42,12 @@ function _get_profile_image_array(EntityInterface $user): ?array {
 function eic_community_get_teaser_user_display(User $user) {
   $author = [
     'name' => $user->getDisplayName(),
-    'path' => $user->toUrl()->toString(),
   ];
+
+  // We add the user profile page URL if the current user has access to it.
+  if ($user->toUrl()->access()) {
+    $author['path'] = $user->toUrl()->toString();
+  }
 
   if (!$user->get('field_media')->isEmpty()) {
     /** @var \Drupal\media\Entity\Media $media */

--- a/lib/themes/eic_community/patterns/components/author.html.twig
+++ b/lib/themes/eic_community/patterns/components/author.html.twig
@@ -54,23 +54,45 @@
     {% if image or name %}
       <div class="ecl-author__aside">
         {% if image is not empty %}
-          <a href="{{ path }}" class="ecl-author__media-wrapper">
-            {% include '@ecl-twig/ec-component-media-container/ecl-media-container.html.twig' with {
-              extra_classes: 'ecl-author__media',
-              description: false,
-              sources: [],
-              image: image.src,
-              alt: image.alt,
-            } only %}
-          </a>
+          {% if path is empty %}
+            <div class="ecl-author__media-wrapper">
+              {% include '@ecl-twig/ec-component-media-container/ecl-media-container.html.twig' with {
+                extra_classes: 'ecl-author__media',
+                description: false,
+                sources: [],
+                image: image.src,
+                alt: image.alt,
+              } only %}
+            </div>
+          {% else %}
+            <a href="{{ path }}" class="ecl-author__media-wrapper">
+              {% include '@ecl-twig/ec-component-media-container/ecl-media-container.html.twig' with {
+                extra_classes: 'ecl-author__media',
+                description: false,
+                sources: [],
+                image: image.src,
+                alt: image.alt,
+              } only %}
+            </a>
+          {% endif %}
         {% elseif name is not empty %}
-          <a href="{{ path }}" class="ecl-author__initials-wrapper">
-            <span class="ecl-author__initials">
-              {% for author in name|split(' ')|slice(0,2) %}
-                {{- author|first -}}
-              {% endfor %}
-            </span>
-          </a>
+          {% if path is empty %}
+            <div class="ecl-author__initials-wrapper">
+              <span class="ecl-author__initials">
+                {% for author in name|split(' ')|slice(0,2) %}
+                  {{- author|first -}}
+                {% endfor %}
+              </span>
+            </div>
+          {% else %}
+            <a href="{{ path }}" class="ecl-author__initials-wrapper">
+              <span class="ecl-author__initials">
+                {% for author in name|split(' ')|slice(0,2) %}
+                  {{- author|first -}}
+                {% endfor %}
+              </span>
+            </a>
+          {% endif %}
         {% endif %}
         {% if updates %}
           {% include "@theme/patterns/components/update-indicator.html.twig" with updates|default({})|merge({


### PR DESCRIPTION
### Improvements

- Add author profile URL in user teaser if the current user has access to view profile pages.

### Tests

- [ ] Go to the homepage and check if the authors avatars of the Latest News & Stories are not clickable for anonymous users

### Todo

- [ ] Fix storybook component `/patterns/components/author.html.twig` so that it does not print an empty `<a>` tag around the avatar when the path variable is empty. Currently it only checks if the name variable is presented but not the path.