### PR TITLE
EICNET-1412 Follow flag based on group status

### DIFF
--- a/lib/modules/eic_flags/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_flags/src/Hooks/EntityOperations.php
@@ -318,6 +318,11 @@ class EntityOperations implements ContainerInjectionInterface {
       return;
     }
 
+    // If entity is already flagged, we do nothing.
+    if ($this->flagService->getFlagging($flag, $flag_entity)) {
+      return;
+    }
+
     $this->flagService->flag($flag, $flag_entity);
   }
 

--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -27,7 +27,6 @@ use Drupal\eic_groups\Hooks\Pathauto;
 use Drupal\eic_groups\Hooks\Preprocess;
 use Drupal\eic_user\UserHelper;
 use Drupal\group\Entity\GroupContent;
-use Drupal\group\Entity\GroupInterface;
 use Drupal\eic_groups\EICGroupsHelper;
 use Drupal\group\Access\GroupAccessResult;
 
@@ -314,12 +313,6 @@ function eic_groups_flagging_access(EntityInterface $entity, $operation, Account
 
   $flagged_entity = $entity->get('flagged_entity')->entity;
 
-  if (!($flagged_entity instanceof GroupInterface)) {
-    return $access;
-  }
-
-  $moderation_state = $flagged_entity->get('moderation_state')->value;
-
   switch ($operation) {
     case 'view':
     case 'flag':
@@ -328,17 +321,38 @@ function eic_groups_flagging_access(EntityInterface $entity, $operation, Account
         // Default access.
         $access = AccessResult::allowed();
 
-        // Deny access to group flag if the group IS in pending or draft
-        // state.
-        if (in_array($moderation_state, [
-          GroupsModerationHelper::GROUP_PENDING_STATE,
-          GroupsModerationHelper::GROUP_DRAFT_STATE,
-        ])) {
+        // Deny access to flag if the group IS in pending or draft state.
+        if (!EICGroupsHelper::groupIsFlaggable($flagged_entity)) {
           $access = AccessResult::forbidden();
         }
 
         // Add cacheable dependencies.
         $access->addCacheableDependency($entity)
+          ->addCacheableDependency($flagged_entity);
+      }
+      elseif ($flagged_entity->getEntityTypeId() === 'node') {
+        // Get the group content entities related to the node.
+        $group_contents = GroupContent::loadByEntity($flagged_entity);
+
+        // Node does not belong to any group, so we do nothing.
+        if (empty($group_contents)) {
+          break;
+        }
+
+        // Load the first group content entity found.
+        $group_content = reset($group_contents);
+
+        // Load the group.
+        $group = $group_content->getGroup();
+
+        // Deny access to flag if the group IS in pending or draft state.
+        if (!EICGroupsHelper::groupIsFlaggable($group)) {
+          $access = AccessResult::forbidden();
+        }
+
+        // Add cacheable dependencies.
+        $access->addCacheableDependency($group)
+          ->addCacheableDependency($entity)
           ->addCacheableDependency($flagged_entity);
       }
       break;

--- a/lib/modules/eic_groups/src/Access/UnFlagAccessCheck.php
+++ b/lib/modules/eic_groups/src/Access/UnFlagAccessCheck.php
@@ -5,10 +5,11 @@ namespace Drupal\eic_groups\Access;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\eic_groups\GroupsModerationHelper;
+use Drupal\eic_groups\EICGroupsHelper;
 use Drupal\flag\Access\UnFlagAccessCheck as UnFlagAccessCheckBase;
 use Drupal\flag\FlagInterface;
 use Drupal\flag\FlagServiceInterface;
+use Drupal\group\Entity\GroupContent;
 
 /**
  * Extends UnFlagAccessCheck class providing extra logic for group flags.
@@ -58,24 +59,43 @@ class UnFlagAccessCheck extends UnFlagAccessCheckBase {
       return $access;
     }
 
-    // If the flaggable entity is not a group, we do nothing.
-    if ($flag->getFlaggableEntityTypeId() !== 'group') {
-      return $access;
-    }
-
     $flaggable_id = $route_match->getParameter('entity_id');
     $flaggable_entity = $this->flagService->getFlaggableById($flag, $flaggable_id);
 
-    $moderation_state = $flaggable_entity->get('moderation_state')->value;
+    switch ($flag->getFlaggableEntityTypeId()) {
+      case 'group':
+        // Deny access to flag if the group IS in pending or draft state.
+        if (!EICGroupsHelper::groupIsFlaggable($flaggable_entity)) {
+          $access = AccessResult::forbidden()
+            ->addCacheableDependency($flaggable_entity)
+            ->addCacheableDependency($flag);
+        }
+        break;
 
-    // Deny access to flag if the group IS in pending or draft state.
-    if (in_array($moderation_state, [
-      GroupsModerationHelper::GROUP_PENDING_STATE,
-      GroupsModerationHelper::GROUP_DRAFT_STATE,
-    ])) {
-      $access = AccessResult::forbidden()
-        ->addCacheableDependency($flaggable_entity)
-        ->addCacheableDependency($flag);
+      case 'node':
+        // Get the group content entities related to the node.
+        $group_contents = GroupContent::loadByEntity($flaggable_entity);
+
+        // Node does not belong to any group, so we do nothing.
+        if (empty($group_contents)) {
+          break;
+        }
+
+        // Load the first group content entity found.
+        $group_content = reset($group_contents);
+
+        // Load the group.
+        $group = $group_content->getGroup();
+
+        // Deny access to flag if the group IS in pending or draft state.
+        if (!EICGroupsHelper::groupIsFlaggable($group)) {
+          $access = AccessResult::forbidden()
+            ->addCacheableDependency($group)
+            ->addCacheableDependency($flaggable_entity)
+            ->addCacheableDependency($flag);
+        }
+        break;
+
     }
 
     return $access;

--- a/lib/modules/eic_groups/src/EICGroupsHelper.php
+++ b/lib/modules/eic_groups/src/EICGroupsHelper.php
@@ -366,4 +366,24 @@ class EICGroupsHelper implements EICGroupsHelperInterface {
     return !empty($query->execute()->fetchAll(\PDO::FETCH_OBJ));
   }
 
+  /**
+   * Check if a group can be flagged depending on the moderation state.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group entity.
+   *
+   * @return bool
+   *   TRUE if the group is not in Pending or Draft state.
+   */
+  public static function groupIsFlaggable(GroupInterface $group) {
+    $moderation_state = $group->get('moderation_state')->value;
+    return !in_array(
+      $moderation_state,
+      [
+        GroupsModerationHelper::GROUP_PENDING_STATE,
+        GroupsModerationHelper::GROUP_DRAFT_STATE,
+      ]
+    );
+  }
+
 }

--- a/lib/themes/eic_community/includes/preprocess/common.inc
+++ b/lib/themes/eic_community/includes/preprocess/common.inc
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Block\BlockPluginInterface;
+use Drupal\Core\Entity\EntityInterface;
 
 /**
  * Returns the build of the social share block.
@@ -25,4 +26,44 @@ function _eic_community_get_social_share_block() {
   $build = $share_block->build();
   $build['#title'] = t('Share');
   return $build;
+}
+
+/**
+ * Gets the access to flag an entity.
+ *
+ * @param string $flag_id
+ *   The flag ID.
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ *   The flaggable entity.
+ *
+ * @return bool
+ *   TRUE if the user can flag the entity.
+ */
+function _eic_community_get_flag_access($flag_id, EntityInterface $entity) {
+  /** @var \Drupal\flag\FlagService $flag_service */
+  $flag_service = \Drupal::service('flag');
+
+  // Load flag by ID.
+  $flag = $flag_service->getFlagById($flag_id);
+
+  // If flag does not exist, we skip it.
+  if (!$flag) {
+    return TRUE;
+  }
+
+  $user_flag = $flag_service->getFlagging($flag, $entity);
+
+  // We need to create a fake flag if the user never flagged the content,
+  // otherwise we can't do an access check.
+  if (!$user_flag) {
+    $user_flag = \Drupal::entityTypeManager()->getStorage('flagging')->create([
+      'uid' => \Drupal::currentUser()->id(),
+      'flag_id' => $flag->id(),
+      'entity_id' => $entity->id(),
+      'entity_type' => $entity->getEntityTypeId(),
+      'global' => $flag->isGlobal(),
+    ]);
+  }
+
+  return $user_flag->access('view');
 }

--- a/lib/themes/eic_community/includes/preprocess/content/node--discussion.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--discussion.inc
@@ -57,8 +57,14 @@ function _preprocess_discussion_full(&$variables, $discussion_type, $node) {
   $variables['author'] = eic_community_get_teaser_user_display($node->getOwner());
   $variables['timestamp']['label'] = eic_community_get_teaser_time_display($node->get('changed')->value);
 
-  $flags = array_filter($variables['elements'], function ($key) {
-    return strpos($key, 'flag') !== FALSE;
+  $flags = array_filter($variables['elements'], function ($key) use ($node) {
+
+    // If element is not a flag we skip it.
+    if (strpos($key, 'flag') === FALSE) {
+      return FALSE;
+    }
+
+    return _eic_community_get_flag_access(str_replace('flag_', '', $key), $node);
   }, ARRAY_FILTER_USE_KEY);
 
   $flags = array_map(function ($item) {

--- a/lib/themes/eic_community/includes/preprocess/content/node--document.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--document.inc
@@ -113,8 +113,13 @@ function eic_community_preprocess_node__document(array &$variables) {
       'download' => t('Download'),
     ];
     // Sidebar elements.
-    $flags = array_filter($variables['elements'], function ($key) {
-      return strpos($key, 'flag_') !== FALSE;
+    $flags = array_filter($variables['elements'], function ($key) use ($node) {
+      // If element is not a flag we skip it.
+      if (strpos($key, 'flag') === FALSE) {
+        return FALSE;
+      }
+
+      return _eic_community_get_flag_access(str_replace('flag_', '', $key), $node);
     }, ARRAY_FILTER_USE_KEY);
 
     foreach ($flags as $flag) {

--- a/lib/themes/eic_community/includes/preprocess/content/node--news--story.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--news--story.inc
@@ -133,8 +133,20 @@ function _eic_community_story_document_field(&$variables) {
  * Preprocess flags.
  */
 function _eic_community_display_flags(&$variables) {
-  $flags = array_filter($variables['elements'], function ($key) {
-    return strpos($key, 'flag_') !== FALSE;
+  if (!isset($variables['elements']['#entity_type'])) {
+    return;
+  }
+
+  $entity_type = $variables['elements']['#entity_type'];
+  $entity = $variables[$entity_type];
+
+  $flags = array_filter($variables['elements'], function ($key) use ($entity) {
+    // If element is not a flag we skip it.
+    if (strpos($key, 'flag') === FALSE) {
+      return FALSE;
+    }
+
+    return _eic_community_get_flag_access(str_replace('flag_', '', $key), $entity);
   }, ARRAY_FILTER_USE_KEY);
 
   foreach ($flags as $flag) {


### PR DESCRIPTION
### Improvements

- Re-factor access conditions to prevent users to flag group content of a group that is in pending/draft state;
- Show node flags in the frontend based on flag access;
- Invalidate group content node cache tags when group status has changed.

### Assumptions

- We disable/enable all flags (not just the follow flag) of the node depending on the group status.

### Tests

- [ ] Create a new public group and leave it in draft
- [ ] Create a new discussion in the group
- [ ] Go to the discussion detail page and check if the flags to **Follow**, **Like** and **Recommend** are not displayed.
- [ ] Publish the group
- [ ] Go to the discussion detail page and check if the flags to **Follow**, **Like** and **Recommend** are displayed and the user can trigger them
- [ ] Try to repeat the test with other content types