### PR TITLE
EICNET-975: Story attachment styling fixes.

### DIFF
--- a/lib/themes/eic_community/sass/components/_attachment.scss
+++ b/lib/themes/eic_community/sass/components/_attachment.scss
@@ -170,17 +170,15 @@
     margin-right: ecl-layout('gutter', 'controls');
     margin-bottom: ecl-layout('gutter', 'controls');
     color: ecl-typography('color', 'meta');
+    padding-right: ecl-layout('gutter', 'controls');
+    border-right: ecl-border();
     @include ecl-responsive-font('label');
 
     &--author {
+      border: none;
       #{$node}--has-compact-layout & {
         @include visually-hidden;
       }
-    }
-
-    & + & {
-      padding-right: ecl-layout('gutter', 'controls');
-      border-right: ecl-border();
     }
 
     &:nth-last-child(1),

--- a/lib/themes/eic_community/sass/components/_link.scss
+++ b/lib/themes/eic_community/sass/components/_link.scss
@@ -1,6 +1,13 @@
 .ecl-link {
   $node: &;
 
+  &--icon:focus, &--icon:hover {
+    text-decoration: none;
+    #{$node}__label {
+      text-decoration: underline;
+    }
+  }
+
   &--guest {
     color: ecl-typography('color', 'meta');
   }

--- a/lib/themes/eic_community/snippets/wysiwyg-example.html.twig
+++ b/lib/themes/eic_community/snippets/wysiwyg-example.html.twig
@@ -63,7 +63,7 @@
     language: 'English',
     filesize: '4,7 Mb',
     author: {
-      author: "John Doe",
+      name: "John Doe",
       path: "?author=johndoe"
     },
     icon_file_path: icon_file_path,


### PR DESCRIPTION
- Fixed styling for hover on links with icons (global fix for all ecl-links)
- Fixed separator between meta data (should work correctly even if author field is not present)