### PR TITLE
Feature/eicnet 1329 sort last liked

### DIFF
--- a/config/sync/context.context.group_discussions_overviews.yml
+++ b/config/sync/context.context.group_discussions_overviews.yml
@@ -51,6 +51,7 @@ reactions:
           its_flag_highlight_content: its_flag_highlight_content
           timestamp: timestamp
           ss_global_title: ss_global_title
+          its_last_flagged_like_content: its_last_flagged_like_content
         source_type: Drupal\eic_search\Search\Sources\DiscussionSourceType
         enable_search: 1
         page_options: normal

--- a/config/sync/context.context.group_files_overviews.yml
+++ b/config/sync/context.context.group_files_overviews.yml
@@ -38,6 +38,7 @@ reactions:
           its_flag_highlight_content: its_flag_highlight_content
           ss_global_created_date: ss_global_created_date
           ss_global_title: ss_global_title
+          its_last_flagged_like_content: its_last_flagged_like_content
         source_type: Drupal\eic_search\Search\Sources\LibrarySourceType
         enable_search: 1
         page_options: normal

--- a/config/sync/context.context.group_search.yml
+++ b/config/sync/context.context.group_search.yml
@@ -3,7 +3,9 @@ langcode: en
 status: true
 dependencies:
   module:
+    - eic_search
     - route_condition
+    - system
 name: group_search
 label: 'Group - Search'
 group: Groups
@@ -47,6 +49,7 @@ reactions:
         sort_options:
           ss_global_created_date: ss_global_created_date
           ss_global_title: ss_global_title
+          its_last_flagged_like_content: its_last_flagged_like_content
           ss_group_user_fullname: 0
         source_type: Drupal\eic_search\Search\Sources\GlobalSourceType
         enable_search: 1
@@ -61,6 +64,7 @@ reactions:
         unique: 0
         context_id: group_search
         uuid: dab9cf38-964e-498f-bf72-416ff2f5a891
+        third_party_settings: {  }
     id: blocks
     saved: false
     uuid: 8505c4ba-7948-4741-9628-279e035d4c6e

--- a/lib/modules/eic_flags/eic_flags.services.yml
+++ b/lib/modules/eic_flags/eic_flags.services.yml
@@ -18,3 +18,9 @@ services:
     arguments: [ '@eic_flags.handler_collector' ]
     tags:
       - { name: access_check, applies_to: _request_send_access }
+
+  eic_flags.event_subscriber:
+    class: Drupal\eic_flags\EventSubscriber\FlagEventSubscriber
+    arguments: ['@eic_search.solr_document_processor']
+    tags:
+      - { name: event_subscriber }

--- a/lib/modules/eic_flags/src/EventSubscriber/FlagEventSubscriber.php
+++ b/lib/modules/eic_flags/src/EventSubscriber/FlagEventSubscriber.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Drupal\eic_flags\EventSubscriber;
+
+use Drupal\eic_flags\FlagType;
+use Drupal\eic_search\Service\SolrDocumentProcessor;
+use Drupal\flag\Event\FlagEvents;
+use Drupal\flag\Event\FlaggingEvent;
+use Drupal\flag\Event\UnflaggingEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * EIC Flags subscriber.
+ */
+class FlagEventSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The EIC Search Solr Document Processor.
+   *
+   * @var \Drupal\eic_search\Service\SolrDocumentProcessor
+   */
+  private $solrDocumentProcessor;
+
+  /**
+   * FlagEventSubscriber constructor.
+   *
+   * @param \Drupal\eic_search\Service\SolrDocumentProcessor $solr_document_processor
+   *   The EIC Search Solr Document Processor.
+   */
+  public function __construct(SolrDocumentProcessor $solr_document_processor) {
+    $this->solrDocumentProcessor = $solr_document_processor;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events[FlagEvents::ENTITY_FLAGGED] = ['onFlag', 50];
+    $events[FlagEvents::ENTITY_UNFLAGGED] = ['onUnflag', 50];
+    return $events;
+  }
+
+  /**
+   * React to flagging event.
+   *
+   * @param \Drupal\flag\Event\FlaggingEvent $event
+   *   The flagging event.
+   */
+  public function onFlag(FlaggingEvent $event) {
+    /** @var \Drupal\flag\FlaggingInterface $flagging */
+    $flagging = $event->getFlagging();
+
+    $reindex_triggers = [
+      FlagType::LIKE_CONTENT,
+    ];
+
+    // Some custom variables need to be updated in Solr, so we trigger the
+    // re-index of the parent entity.
+    if (in_array($flagging->getFlagId(), $reindex_triggers)) {
+      // Get the flagged entity to be updated.
+      $parent_entity = $flagging->getFlaggable();
+      $this->solrDocumentProcessor->reIndexEntities([$parent_entity]);
+    }
+  }
+
+  /**
+   * React to unflagging event.
+   *
+   * @param \Drupal\flag\Event\UnflaggingEvent $event
+   *   The unflagging event.
+   */
+  public function onUnflag(UnflaggingEvent $event) {
+
+  }
+
+}

--- a/lib/modules/eic_flags/src/FlagType.php
+++ b/lib/modules/eic_flags/src/FlagType.php
@@ -17,4 +17,6 @@ final class FlagType {
 
   const FOLLOW_USER = 'follow_user';
 
+  const LIKE_CONTENT = 'like_content';
+
 }

--- a/lib/modules/eic_search/eic_search.module
+++ b/lib/modules/eic_search/eic_search.module
@@ -88,6 +88,7 @@ function eic_search_search_api_solr_documents_alter(
     $solr_document_processor->processDiscussionData($document, $fields);
     $solr_document_processor->processDocumentData($document, $fields);
     $solr_document_processor->processGroupUserData($document, $fields);
+    $solr_document_processor->processFlaggingData($document, $fields);
     $solr_document_processor->processGroupVisibilityData($document, $fields, $items, $group_helper);
   }
 }

--- a/lib/modules/eic_search/eic_search.services.yml
+++ b/lib/modules/eic_search/eic_search.services.yml
@@ -33,3 +33,4 @@ services:
       - { name: eic_search.source }
   eic_search.solr_document_processor:
     class: Drupal\eic_search\Service\SolrDocumentProcessor
+    arguments: ['@search_api.post_request_indexing']

--- a/lib/modules/eic_search/eic_search.services.yml
+++ b/lib/modules/eic_search/eic_search.services.yml
@@ -33,4 +33,4 @@ services:
       - { name: eic_search.source }
   eic_search.solr_document_processor:
     class: Drupal\eic_search\Service\SolrDocumentProcessor
-    arguments: ['@search_api.post_request_indexing']
+    arguments: ['@database', '@flag.count', '@search_api.post_request_indexing']

--- a/lib/modules/eic_search/src/Search/Sources/DiscussionSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/DiscussionSourceType.php
@@ -3,6 +3,8 @@
 namespace Drupal\eic_search\Search\Sources;
 
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\eic_flags\FlagType;
+use Drupal\eic_search\Service\SolrDocumentProcessor;
 
 /**
  * Class DiscussionSourceType
@@ -64,6 +66,10 @@ class DiscussionSourceType extends SourceType {
         'label' => $this->t('Title', [], ['context' => 'eic_search']),
         'ASC' => $this->t('Title A-Z', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Title Z-A', [], ['context' => 'eic_search']),
+      ],
+      'its_' . SolrDocumentProcessor::LAST_FLAGGED_KEY . '_' . FlagType::LIKE_CONTENT => [
+        'label' => $this->t('Last liked', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Last liked', [], ['context' => 'eic_search']),
       ],
     ];
   }

--- a/lib/modules/eic_search/src/Search/Sources/GlobalSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/GlobalSourceType.php
@@ -3,6 +3,8 @@
 namespace Drupal\eic_search\Search\Sources;
 
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\eic_flags\FlagType;
+use Drupal\eic_search\Service\SolrDocumentProcessor;
 
 /**
  * Class GlobalSourceType
@@ -73,6 +75,10 @@ class GlobalSourceType extends SourceType {
         'label' => $this->t('Download', [], ['context' => 'eic_search']),
         'ASC' => $this->t('Min download', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Max download', [], ['context' => 'eic_search']),
+      ],
+      'its_' . SolrDocumentProcessor::LAST_FLAGGED_KEY . '_' . FlagType::LIKE_CONTENT => [
+        'label' => $this->t('Last liked', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Last liked', [], ['context' => 'eic_search']),
       ],
     ];
   }

--- a/lib/modules/eic_search/src/Search/Sources/GroupSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/GroupSourceType.php
@@ -3,6 +3,8 @@
 namespace Drupal\eic_search\Search\Sources;
 
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\eic_flags\FlagType;
+use Drupal\eic_search\Service\SolrDocumentProcessor;
 
 /**
  * Class GroupSourceType
@@ -64,6 +66,10 @@ class GroupSourceType extends SourceType {
         'label' => $this->t('Fullname', [], ['context' => 'eic_search']),
         'ASC' => $this->t('Fullname A-Z', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Fullname Z-A', [], ['context' => 'eic_search']),
+      ],
+      'its_' . SolrDocumentProcessor::LAST_FLAGGED_KEY . '_' . FlagType::LIKE_CONTENT => [
+        'label' => $this->t('Last liked', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Last liked', [], ['context' => 'eic_search']),
       ],
     ];
   }

--- a/lib/modules/eic_search/src/Search/Sources/LibrarySourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/LibrarySourceType.php
@@ -3,6 +3,8 @@
 namespace Drupal\eic_search\Search\Sources;
 
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\eic_flags\FlagType;
+use Drupal\eic_search\Service\SolrDocumentProcessor;
 
 /**
  * Class LibrarySourceType
@@ -68,6 +70,10 @@ class LibrarySourceType extends SourceType {
         'label' => $this->t('Title', [], ['context' => 'eic_search']),
         'ASC' => $this->t('Title A-Z', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Title Z-A', [], ['context' => 'eic_search']),
+      ],
+      'its_' . SolrDocumentProcessor::LAST_FLAGGED_KEY . '_' . FlagType::LIKE_CONTENT => [
+        'label' => $this->t('Last liked', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Last liked', [], ['context' => 'eic_search']),
       ],
     ];
   }

--- a/lib/modules/eic_search/src/SolrIndexes.php
+++ b/lib/modules/eic_search/src/SolrIndexes.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Drupal\eic_search;
+
+/**
+ * EIC Solr indexes.
+ *
+ * @package Drupal\eic_search
+ */
+final class SolrIndexes {
+
+  /**
+   * The global index.
+   *
+   * @var string
+   */
+  const GLOBAL = 'global';
+
+}


### PR DESCRIPTION
### Tests

- [ ] Add 2 likes with 2 different users on a discussion
- [ ] Add 1 like with one user on another discussion
- [ ] Sort by "Last liked" on the discussion overview of the group, discussion with 2 likes should be displayed first

Repeat for groups.

### Remarks

- For now, you will see "undefined" in the sort options dropdown because this sort doesn't implement an ASC direction, only DESC. This will be fixed in React later.