### PR TITLE
EICNET-1365: Group description > leads to about page (rework)

### DIFF
--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
@@ -503,7 +503,16 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
 
     // Adds link to the group about page.
     if ($has_read_more) {
-      $link = Link::createFromRoute($this->t('Read more'), 'eic_groups.about_page', ['group' => $group->id()]);
+      $link = Link::createFromRoute(
+        $this->t('Read more'),
+        'eic_groups.about_page',
+        [
+          'group' => $group->id(),
+        ],
+        [
+          'fragment' => 'group-description-full',
+        ],
+      );
       $output .= ' ' . $link->toString();
     }
 

--- a/lib/themes/eic_community/includes/preprocess/field/field.inc
+++ b/lib/themes/eic_community/includes/preprocess/field/field.inc
@@ -15,6 +15,18 @@ function eic_community_preprocess_field(&$variables, $hook): void {
     $variables['attributes']['class'][] = 'ecl-editor';
   }
 
+  if ($variables['field_name'] === 'field_body') {
+    switch ($variables['element']['#entity_type']) {
+      case 'group':
+        // Add attributes on field_body for the group about page.
+        if ($variables['element']['#view_mode'] === 'about_page') {
+          $variables['attributes']['id'] = 'group-description-full';
+        }
+        break;
+
+    }
+  }
+
   // Add the ECL image class to the image fields.
   $field_name = $variables['field_name'];
   if (in_array($field_name, ['oe_media_avportal_photo'])) {


### PR DESCRIPTION
### Improvements

- Add ID attribute on the group field_body so that we can add an achor to the read more button in the group header.

### Tests

- [ ] Go to a group detail page of a group with a big description
- [ ] Click on the read more link in the group header and check if you are redirected to the about page and page is pushed down to the group description section