### PR TITLE
Bugfix: Add missing dependencies in eic_search and eic_flags module

### DIFF
--- a/lib/modules/eic_flags/eic_flags.info.yml
+++ b/lib/modules/eic_flags/eic_flags.info.yml
@@ -9,3 +9,4 @@ dependencies:
   - flag:flag
   - drupal:views
   - drupal:node
+  - eic_search:eic_search

--- a/lib/modules/eic_search/eic_search.info.yml
+++ b/lib/modules/eic_search/eic_search.info.yml
@@ -5,3 +5,5 @@ package: European Innovation Council
 core: 8.x
 core_version_requirement: ^8 || ^9
 php: 7.3
+dependencies:
+  - flag:flag


### PR DESCRIPTION
### Fixes

- Add missing dependency (flag:flag) in eic_search module;
- Add missing dependency (eic_search:eic_search) in eic_flags module.