### PR TITLE
EICNET-1379: Send message upon user actions and subscribe users to it using the correct flags

### DIFF
--- a/config/sync/core.entity_form_display.message.sub_group_content_updated.default.yml
+++ b/config/sync/core.entity_form_display.message.sub_group_content_updated.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.message.sub_group_content_updated.field_event_executing_user
+    - field.field.message.sub_group_content_updated.field_referenced_node
     - message.template.sub_group_content_updated
 id: message.sub_group_content_updated.default
 targetEntityType: message
@@ -12,6 +13,16 @@ mode: default
 content:
   field_event_executing_user:
     weight: 0
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+  field_referenced_node:
+    weight: 1
     settings:
       match_operator: CONTAINS
       match_limit: 10

--- a/config/sync/core.entity_form_display.message.sub_new_comment_on_content.default.yml
+++ b/config/sync/core.entity_form_display.message.sub_new_comment_on_content.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.message.sub_new_comment_on_content.field_event_executing_user
+    - field.field.message.sub_new_comment_on_content.field_referenced_comment
     - message.template.sub_new_comment_on_content
 id: message.sub_new_comment_on_content.default
 targetEntityType: message
@@ -12,6 +13,16 @@ mode: default
 content:
   field_event_executing_user:
     weight: 0
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+  field_referenced_comment:
+    weight: 1
     settings:
       match_operator: CONTAINS
       match_limit: 10

--- a/config/sync/core.entity_form_display.message.sub_new_comment_reply.default.yml
+++ b/config/sync/core.entity_form_display.message.sub_new_comment_reply.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.message.sub_new_comment_reply.field_event_executing_user
+    - field.field.message.sub_new_comment_reply.field_referenced_comment
     - message.template.sub_new_comment_reply
 id: message.sub_new_comment_reply.default
 targetEntityType: message
@@ -12,6 +13,16 @@ mode: default
 content:
   field_event_executing_user:
     weight: 0
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+  field_referenced_comment:
+    weight: 1
     settings:
       match_operator: CONTAINS
       match_limit: 10

--- a/config/sync/core.entity_form_display.message.sub_new_group_content_published.default.yml
+++ b/config/sync/core.entity_form_display.message.sub_new_group_content_published.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.message.sub_new_group_content_published.field_event_executing_user
+    - field.field.message.sub_new_group_content_published.field_referenced_node
     - message.template.sub_new_group_content_published
 id: message.sub_new_group_content_published.default
 targetEntityType: message
@@ -12,6 +13,16 @@ mode: default
 content:
   field_event_executing_user:
     weight: 0
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+  field_referenced_node:
+    weight: 1
     settings:
       match_operator: CONTAINS
       match_limit: 10

--- a/config/sync/core.entity_view_display.message.sub_group_content_updated.default.yml
+++ b/config/sync/core.entity_view_display.message.sub_group_content_updated.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.message.sub_group_content_updated.field_event_executing_user
+    - field.field.message.sub_group_content_updated.field_referenced_node
     - message.template.sub_group_content_updated
 id: message.sub_group_content_updated.default
 targetEntityType: message
@@ -12,6 +13,14 @@ mode: default
 content:
   field_event_executing_user:
     weight: 1
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_referenced_node:
+    weight: 2
     label: above
     settings:
       link: true

--- a/config/sync/core.entity_view_display.message.sub_group_content_updated.notify_daily_digest.yml
+++ b/config/sync/core.entity_view_display.message.sub_group_content_updated.notify_daily_digest.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.message.notify_daily_digest
     - field.field.message.sub_group_content_updated.field_event_executing_user
+    - field.field.message.sub_group_content_updated.field_referenced_node
     - message.template.sub_group_content_updated
 id: message.sub_group_content_updated.notify_daily_digest
 targetEntityType: message
@@ -18,6 +19,7 @@ content:
     third_party_settings: {  }
 hidden:
   field_event_executing_user: true
+  field_referenced_node: true
   partial_0: true
   partial_1: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.sub_group_content_updated.notify_email_body.yml
+++ b/config/sync/core.entity_view_display.message.sub_group_content_updated.notify_email_body.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.message.notify_email_body
     - field.field.message.sub_group_content_updated.field_event_executing_user
+    - field.field.message.sub_group_content_updated.field_referenced_node
     - message.template.sub_group_content_updated
 id: message.sub_group_content_updated.notify_email_body
 targetEntityType: message
@@ -18,6 +19,7 @@ content:
     third_party_settings: {  }
 hidden:
   field_event_executing_user: true
+  field_referenced_node: true
   partial_0: true
   partial_2: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.sub_group_content_updated.notify_email_subject.yml
+++ b/config/sync/core.entity_view_display.message.sub_group_content_updated.notify_email_subject.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.message.notify_email_subject
     - field.field.message.sub_group_content_updated.field_event_executing_user
+    - field.field.message.sub_group_content_updated.field_referenced_node
     - message.template.sub_group_content_updated
 id: message.sub_group_content_updated.notify_email_subject
 targetEntityType: message
@@ -18,6 +19,7 @@ content:
     third_party_settings: {  }
 hidden:
   field_event_executing_user: true
+  field_referenced_node: true
   partial_1: true
   partial_2: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.sub_group_content_updated.notify_monthly_digest.yml
+++ b/config/sync/core.entity_view_display.message.sub_group_content_updated.notify_monthly_digest.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.message.notify_monthly_digest
     - field.field.message.sub_group_content_updated.field_event_executing_user
+    - field.field.message.sub_group_content_updated.field_referenced_node
     - message.template.sub_group_content_updated
 id: message.sub_group_content_updated.notify_monthly_digest
 targetEntityType: message
@@ -18,6 +19,7 @@ content:
     third_party_settings: {  }
 hidden:
   field_event_executing_user: true
+  field_referenced_node: true
   partial_0: true
   partial_1: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.sub_group_content_updated.notify_weekly_digest.yml
+++ b/config/sync/core.entity_view_display.message.sub_group_content_updated.notify_weekly_digest.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.message.notify_weekly_digest
     - field.field.message.sub_group_content_updated.field_event_executing_user
+    - field.field.message.sub_group_content_updated.field_referenced_node
     - message.template.sub_group_content_updated
 id: message.sub_group_content_updated.notify_weekly_digest
 targetEntityType: message
@@ -18,6 +19,7 @@ content:
     third_party_settings: {  }
 hidden:
   field_event_executing_user: true
+  field_referenced_node: true
   partial_0: true
   partial_1: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.sub_new_comment_on_content.default.yml
+++ b/config/sync/core.entity_view_display.message.sub_new_comment_on_content.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.message.sub_new_comment_on_content.field_event_executing_user
+    - field.field.message.sub_new_comment_on_content.field_referenced_comment
     - message.template.sub_new_comment_on_content
 id: message.sub_new_comment_on_content.default
 targetEntityType: message
@@ -12,6 +13,14 @@ mode: default
 content:
   field_event_executing_user:
     weight: 1
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_referenced_comment:
+    weight: 2
     label: above
     settings:
       link: true

--- a/config/sync/core.entity_view_display.message.sub_new_comment_on_content.notify_daily_digest.yml
+++ b/config/sync/core.entity_view_display.message.sub_new_comment_on_content.notify_daily_digest.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.message.notify_daily_digest
     - field.field.message.sub_new_comment_on_content.field_event_executing_user
+    - field.field.message.sub_new_comment_on_content.field_referenced_comment
     - message.template.sub_new_comment_on_content
 id: message.sub_new_comment_on_content.notify_daily_digest
 targetEntityType: message
@@ -18,6 +19,7 @@ content:
     third_party_settings: {  }
 hidden:
   field_event_executing_user: true
+  field_referenced_comment: true
   partial_0: true
   partial_1: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.sub_new_comment_on_content.notify_email_body.yml
+++ b/config/sync/core.entity_view_display.message.sub_new_comment_on_content.notify_email_body.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.message.notify_email_body
     - field.field.message.sub_new_comment_on_content.field_event_executing_user
+    - field.field.message.sub_new_comment_on_content.field_referenced_comment
     - message.template.sub_new_comment_on_content
 id: message.sub_new_comment_on_content.notify_email_body
 targetEntityType: message
@@ -18,6 +19,7 @@ content:
     third_party_settings: {  }
 hidden:
   field_event_executing_user: true
+  field_referenced_comment: true
   partial_0: true
   partial_2: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.sub_new_comment_on_content.notify_email_subject.yml
+++ b/config/sync/core.entity_view_display.message.sub_new_comment_on_content.notify_email_subject.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.message.notify_email_subject
     - field.field.message.sub_new_comment_on_content.field_event_executing_user
+    - field.field.message.sub_new_comment_on_content.field_referenced_comment
     - message.template.sub_new_comment_on_content
 id: message.sub_new_comment_on_content.notify_email_subject
 targetEntityType: message
@@ -18,6 +19,7 @@ content:
     third_party_settings: {  }
 hidden:
   field_event_executing_user: true
+  field_referenced_comment: true
   partial_1: true
   partial_2: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.sub_new_comment_on_content.notify_monthly_digest.yml
+++ b/config/sync/core.entity_view_display.message.sub_new_comment_on_content.notify_monthly_digest.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.message.notify_monthly_digest
     - field.field.message.sub_new_comment_on_content.field_event_executing_user
+    - field.field.message.sub_new_comment_on_content.field_referenced_comment
     - message.template.sub_new_comment_on_content
 id: message.sub_new_comment_on_content.notify_monthly_digest
 targetEntityType: message
@@ -18,6 +19,7 @@ content:
     third_party_settings: {  }
 hidden:
   field_event_executing_user: true
+  field_referenced_comment: true
   partial_0: true
   partial_1: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.sub_new_comment_on_content.notify_weekly_digest.yml
+++ b/config/sync/core.entity_view_display.message.sub_new_comment_on_content.notify_weekly_digest.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.message.notify_weekly_digest
     - field.field.message.sub_new_comment_on_content.field_event_executing_user
+    - field.field.message.sub_new_comment_on_content.field_referenced_comment
     - message.template.sub_new_comment_on_content
 id: message.sub_new_comment_on_content.notify_weekly_digest
 targetEntityType: message
@@ -18,6 +19,7 @@ content:
     third_party_settings: {  }
 hidden:
   field_event_executing_user: true
+  field_referenced_comment: true
   partial_0: true
   partial_1: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.sub_new_comment_reply.default.yml
+++ b/config/sync/core.entity_view_display.message.sub_new_comment_reply.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.message.sub_new_comment_reply.field_event_executing_user
+    - field.field.message.sub_new_comment_reply.field_referenced_comment
     - message.template.sub_new_comment_reply
 id: message.sub_new_comment_reply.default
 targetEntityType: message
@@ -12,6 +13,14 @@ mode: default
 content:
   field_event_executing_user:
     weight: 1
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_referenced_comment:
+    weight: 2
     label: above
     settings:
       link: true

--- a/config/sync/core.entity_view_display.message.sub_new_comment_reply.notify_daily_digest.yml
+++ b/config/sync/core.entity_view_display.message.sub_new_comment_reply.notify_daily_digest.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.message.notify_daily_digest
     - field.field.message.sub_new_comment_reply.field_event_executing_user
+    - field.field.message.sub_new_comment_reply.field_referenced_comment
     - message.template.sub_new_comment_reply
 id: message.sub_new_comment_reply.notify_daily_digest
 targetEntityType: message
@@ -18,6 +19,7 @@ content:
     third_party_settings: {  }
 hidden:
   field_event_executing_user: true
+  field_referenced_comment: true
   partial_0: true
   partial_1: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.sub_new_comment_reply.notify_email_body.yml
+++ b/config/sync/core.entity_view_display.message.sub_new_comment_reply.notify_email_body.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.message.notify_email_body
     - field.field.message.sub_new_comment_reply.field_event_executing_user
+    - field.field.message.sub_new_comment_reply.field_referenced_comment
     - message.template.sub_new_comment_reply
 id: message.sub_new_comment_reply.notify_email_body
 targetEntityType: message
@@ -18,6 +19,7 @@ content:
     third_party_settings: {  }
 hidden:
   field_event_executing_user: true
+  field_referenced_comment: true
   partial_0: true
   partial_2: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.sub_new_comment_reply.notify_email_subject.yml
+++ b/config/sync/core.entity_view_display.message.sub_new_comment_reply.notify_email_subject.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.message.notify_email_subject
     - field.field.message.sub_new_comment_reply.field_event_executing_user
+    - field.field.message.sub_new_comment_reply.field_referenced_comment
     - message.template.sub_new_comment_reply
 id: message.sub_new_comment_reply.notify_email_subject
 targetEntityType: message
@@ -18,6 +19,7 @@ content:
     third_party_settings: {  }
 hidden:
   field_event_executing_user: true
+  field_referenced_comment: true
   partial_1: true
   partial_2: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.sub_new_comment_reply.notify_monthly_digest.yml
+++ b/config/sync/core.entity_view_display.message.sub_new_comment_reply.notify_monthly_digest.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.message.notify_monthly_digest
     - field.field.message.sub_new_comment_reply.field_event_executing_user
+    - field.field.message.sub_new_comment_reply.field_referenced_comment
     - message.template.sub_new_comment_reply
 id: message.sub_new_comment_reply.notify_monthly_digest
 targetEntityType: message
@@ -18,6 +19,7 @@ content:
     third_party_settings: {  }
 hidden:
   field_event_executing_user: true
+  field_referenced_comment: true
   partial_0: true
   partial_1: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.sub_new_comment_reply.notify_weekly_digest.yml
+++ b/config/sync/core.entity_view_display.message.sub_new_comment_reply.notify_weekly_digest.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.message.notify_weekly_digest
     - field.field.message.sub_new_comment_reply.field_event_executing_user
+    - field.field.message.sub_new_comment_reply.field_referenced_comment
     - message.template.sub_new_comment_reply
 id: message.sub_new_comment_reply.notify_weekly_digest
 targetEntityType: message
@@ -18,6 +19,7 @@ content:
     third_party_settings: {  }
 hidden:
   field_event_executing_user: true
+  field_referenced_comment: true
   partial_0: true
   partial_1: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.sub_new_group_content_published.default.yml
+++ b/config/sync/core.entity_view_display.message.sub_new_group_content_published.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.message.sub_new_group_content_published.field_event_executing_user
+    - field.field.message.sub_new_group_content_published.field_referenced_node
     - message.template.sub_new_group_content_published
 id: message.sub_new_group_content_published.default
 targetEntityType: message
@@ -12,6 +13,14 @@ mode: default
 content:
   field_event_executing_user:
     weight: 1
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_referenced_node:
+    weight: 2
     label: above
     settings:
       link: true

--- a/config/sync/core.entity_view_display.message.sub_new_group_content_published.notify_daily_digest.yml
+++ b/config/sync/core.entity_view_display.message.sub_new_group_content_published.notify_daily_digest.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.message.notify_daily_digest
     - field.field.message.sub_new_group_content_published.field_event_executing_user
+    - field.field.message.sub_new_group_content_published.field_referenced_node
     - message.template.sub_new_group_content_published
 id: message.sub_new_group_content_published.notify_daily_digest
 targetEntityType: message
@@ -18,6 +19,7 @@ content:
     third_party_settings: {  }
 hidden:
   field_event_executing_user: true
+  field_referenced_node: true
   partial_0: true
   partial_1: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.sub_new_group_content_published.notify_email_body.yml
+++ b/config/sync/core.entity_view_display.message.sub_new_group_content_published.notify_email_body.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.message.notify_email_body
     - field.field.message.sub_new_group_content_published.field_event_executing_user
+    - field.field.message.sub_new_group_content_published.field_referenced_node
     - message.template.sub_new_group_content_published
 id: message.sub_new_group_content_published.notify_email_body
 targetEntityType: message
@@ -18,6 +19,7 @@ content:
     third_party_settings: {  }
 hidden:
   field_event_executing_user: true
+  field_referenced_node: true
   partial_0: true
   partial_2: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.sub_new_group_content_published.notify_email_subject.yml
+++ b/config/sync/core.entity_view_display.message.sub_new_group_content_published.notify_email_subject.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.message.notify_email_subject
     - field.field.message.sub_new_group_content_published.field_event_executing_user
+    - field.field.message.sub_new_group_content_published.field_referenced_node
     - message.template.sub_new_group_content_published
 id: message.sub_new_group_content_published.notify_email_subject
 targetEntityType: message
@@ -18,6 +19,7 @@ content:
     third_party_settings: {  }
 hidden:
   field_event_executing_user: true
+  field_referenced_node: true
   partial_1: true
   partial_2: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.sub_new_group_content_published.notify_monthly_digest.yml
+++ b/config/sync/core.entity_view_display.message.sub_new_group_content_published.notify_monthly_digest.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.message.notify_monthly_digest
     - field.field.message.sub_new_group_content_published.field_event_executing_user
+    - field.field.message.sub_new_group_content_published.field_referenced_node
     - message.template.sub_new_group_content_published
 id: message.sub_new_group_content_published.notify_monthly_digest
 targetEntityType: message
@@ -18,6 +19,7 @@ content:
     third_party_settings: {  }
 hidden:
   field_event_executing_user: true
+  field_referenced_node: true
   partial_0: true
   partial_1: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.sub_new_group_content_published.notify_weekly_digest.yml
+++ b/config/sync/core.entity_view_display.message.sub_new_group_content_published.notify_weekly_digest.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.message.notify_weekly_digest
     - field.field.message.sub_new_group_content_published.field_event_executing_user
+    - field.field.message.sub_new_group_content_published.field_referenced_node
     - message.template.sub_new_group_content_published
 id: message.sub_new_group_content_published.notify_weekly_digest
 targetEntityType: message
@@ -18,6 +19,7 @@ content:
     third_party_settings: {  }
 hidden:
   field_event_executing_user: true
+  field_referenced_node: true
   partial_0: true
   partial_1: true
   search_api_excerpt: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -51,6 +51,7 @@ module:
   eic_media_document: 0
   eic_media_statistics: 0
   eic_media_video: 0
+  eic_message_subscriptions: 0
   eic_messages: 0
   eic_migrate: 0
   eic_overviews: 0

--- a/config/sync/field.field.message.sub_group_content_updated.field_referenced_node.yml
+++ b/config/sync/field.field.message.sub_group_content_updated.field_referenced_node.yml
@@ -1,0 +1,41 @@
+uuid: b3078b5a-88f2-4263-abaf-8940d0f497b0
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_referenced_node
+    - message.template.sub_group_content_updated
+    - node.type.discussion
+    - node.type.document
+    - node.type.gallery
+    - node.type.news
+    - node.type.story
+    - node.type.video
+    - node.type.wiki_page
+id: message.sub_group_content_updated.field_referenced_node
+field_name: field_referenced_node
+entity_type: message
+bundle: sub_group_content_updated
+label: 'Referenced node'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      discussion: discussion
+      document: document
+      gallery: gallery
+      news: news
+      story: story
+      video: video
+      wiki_page: wiki_page
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: discussion
+field_type: entity_reference

--- a/config/sync/field.field.message.sub_new_comment_on_content.field_referenced_comment.yml
+++ b/config/sync/field.field.message.sub_new_comment_on_content.field_referenced_comment.yml
@@ -1,0 +1,29 @@
+uuid: cfbfc66f-cc9e-4116-a51f-6a0a2e538a29
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.node_comment
+    - field.storage.message.field_referenced_comment
+    - message.template.sub_new_comment_on_content
+id: message.sub_new_comment_on_content.field_referenced_comment
+field_name: field_referenced_comment
+entity_type: message
+bundle: sub_new_comment_on_content
+label: 'Referenced comment'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:comment'
+  handler_settings:
+    target_bundles:
+      node_comment: node_comment
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.message.sub_new_comment_reply.field_referenced_comment.yml
+++ b/config/sync/field.field.message.sub_new_comment_reply.field_referenced_comment.yml
@@ -1,0 +1,29 @@
+uuid: fb582e38-a60a-485e-b04c-d6d54b3ca981
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.node_comment
+    - field.storage.message.field_referenced_comment
+    - message.template.sub_new_comment_reply
+id: message.sub_new_comment_reply.field_referenced_comment
+field_name: field_referenced_comment
+entity_type: message
+bundle: sub_new_comment_reply
+label: 'Referenced comment'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:comment'
+  handler_settings:
+    target_bundles:
+      node_comment: node_comment
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.message.sub_new_group_content_published.field_referenced_node.yml
+++ b/config/sync/field.field.message.sub_new_group_content_published.field_referenced_node.yml
@@ -1,0 +1,41 @@
+uuid: 1ac99022-e96b-4991-a86c-6bbd16e661ac
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_referenced_node
+    - message.template.sub_new_group_content_published
+    - node.type.discussion
+    - node.type.document
+    - node.type.gallery
+    - node.type.news
+    - node.type.story
+    - node.type.video
+    - node.type.wiki_page
+id: message.sub_new_group_content_published.field_referenced_node
+field_name: field_referenced_node
+entity_type: message
+bundle: sub_new_group_content_published
+label: 'Referenced node'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      discussion: discussion
+      document: document
+      gallery: gallery
+      news: news
+      story: story
+      video: video
+      wiki_page: wiki_page
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: discussion
+field_type: entity_reference

--- a/lib/modules/eic_flags/eic_flags.services.yml
+++ b/lib/modules/eic_flags/eic_flags.services.yml
@@ -24,3 +24,7 @@ services:
     arguments: ['@eic_search.solr_document_processor']
     tags:
       - { name: event_subscriber }
+
+  eic_flags.helper:
+    class: Drupal\eic_flags\FlagHelper
+    arguments: ['@flag', '@entity_type.manager']

--- a/lib/modules/eic_flags/src/FlagHelper.php
+++ b/lib/modules/eic_flags/src/FlagHelper.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Drupal\eic_flags;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\flag\FlagServiceInterface;
+
+/**
+ * Provides helper methods for flags.
+ */
+class FlagHelper {
+
+  /**
+   * The flag service.
+   *
+   * @var \Drupal\flag\FlagServiceInterface
+   */
+  protected $flagService;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a FlagHelper object.
+   *
+   * @param \Drupal\flag\FlagServiceInterface $flag_service
+   *   The flag service.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   */
+  public function __construct(FlagServiceInterface $flag_service, EntityTypeManagerInterface $entity_type_manager) {
+    $this->flagService = $flag_service;
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * Get a list of users that have flagged an entity with a given flag ID.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The flagged entity.
+   * @param array $flag_ids
+   *   Array of flag machine names.
+   *
+   * @return array
+   *   An array of users who have flagged the entity.
+   */
+  public function getFlaggingUsersByFlagIds(EntityInterface $entity, array $flag_ids = []) {
+    if (empty($flag_ids)) {
+      return $this->flagService->getFlaggingUsers($entity);
+    }
+
+    $query = $this->entityTypeManager->getStorage('flagging')->getQuery();
+    $query->condition('entity_type', $entity->getEntityTypeId())
+      ->condition('entity_id', $entity->id());
+
+    if (!empty($flag_ids)) {
+      $query->condition('flag_id', $flag_ids, 'IN');
+    }
+
+    $ids = $query->execute();
+
+    // Load the flaggings.
+    $flaggings = $this->entityTypeManager->getStorage('flagging')->loadMultiple($ids);
+
+    $users = [];
+    foreach ($flaggings as $flagging) {
+      $user_id = $flagging->get('uid')->first()->getValue()['target_id'];
+      $users[$user_id] = $this->entityTypeManager->getStorage('user')->load($user_id);
+    }
+
+    return $users;
+  }
+
+}

--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
@@ -343,23 +343,14 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
         continue;
       }
 
+      // Check if we have a flagging for this user and entity. If we have one we
+      // check if the user can unflag, otherwise we check if the user can flag.
       $user_flag = $this->flagService->getFlagging($flag, $group);
-
-      // We need to create a fake flag if the user never flagged the content,
-      // otherwise we can't do an access check.
-      if (!$user_flag) {
-        $user_flag = $this->entityTypeManager->getStorage('flagging')->create([
-          'uid' => $this->currentUser->id(),
-          'flag_id' => $flag->id(),
-          'entity_id' => $group->id(),
-          'entity_type' => $group->getEntityTypeId(),
-          'global' => $flag->isGlobal(),
-        ]);
-      }
+      $action = $user_flag ? 'unflag' : 'flag';
 
       // If user has access to view the flag we add it to the results so that
       // it can be shown in the group header.
-      if ($user_flag->access('view')) {
+      if ($flag->actionAccess($action)) {
         $group_flags[$flag_id] = [
           '#lazy_builder' => [
             'flag.link_builder:build',

--- a/lib/modules/eic_messages/eic_messages.services.yml
+++ b/lib/modules/eic_messages/eic_messages.services.yml
@@ -16,3 +16,6 @@ services:
   eic_messages.message_creator.comment:
     class: Drupal\eic_messages\Service\CommentMessageCreator
     arguments: ['@entity_type.manager', '@eic_messages.helper', '@eic_user.helper', '@eic_content.helper']
+  eic_messages.message_creator.node:
+    class: Drupal\eic_messages\Service\NodeMessageCreator
+    arguments: ['@entity_type.manager', '@eic_messages.helper', '@eic_user.helper', '@eic_content.helper']

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/eic_message_subscriptions.info.yml
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/eic_message_subscriptions.info.yml
@@ -1,0 +1,9 @@
+name: EIC Message Subscriptions
+type: module
+description: Handles email notifications on EIC.
+package: European Innovation Council
+core: 8.x
+core_version_requirement: ^8 || ^9
+php: 7.3
+dependencies:
+  - eic_messages:eic_messages

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/eic_message_subscriptions.module
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/eic_message_subscriptions.module
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @file
+ * Primary module hooks for EIC Message Notifications module.
+ */
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\eic_message_subscriptions\Hooks\EntityOperations;
+
+/**
+ * Implements hook_entity_insert().
+ */
+function eic_message_subscriptions_entity_insert(EntityInterface $entity) {
+  switch ($entity->getEntityTypeId()) {
+    case 'comment':
+      \Drupal::classResolver(EntityOperations::class)
+        ->entityInsert($entity);
+      break;
+
+  }
+}

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/eic_message_subscriptions.module
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/eic_message_subscriptions.module
@@ -21,6 +21,11 @@ function eic_message_subscriptions_entity_insert(EntityInterface $entity) {
         ->entityInsert($entity);
       break;
 
+    case 'group_content':
+      \Drupal::classResolver(EntityOperations::class)
+        ->entityInsert($entity);
+      break;
+
   }
 }
 

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/eic_message_subscriptions.module
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/eic_message_subscriptions.module
@@ -14,8 +14,43 @@ use Drupal\eic_message_subscriptions\Hooks\EntityOperations;
 function eic_message_subscriptions_entity_insert(EntityInterface $entity) {
   switch ($entity->getEntityTypeId()) {
     case 'comment':
+    case 'group_content':
       \Drupal::classResolver(EntityOperations::class)
         ->entityInsert($entity);
+      break;
+
+    case 'node':
+      if (!in_array($entity->bundle(), ['news', 'story'])) {
+        return;
+      }
+
+      \Drupal::classResolver(EntityOperations::class)
+        ->entityInsert($entity);
+      break;
+
+  }
+}
+
+/**
+ * Implements hook_entity_insert().
+ */
+function eic_message_subscriptions_entity_update(EntityInterface $entity) {
+  switch ($entity->getEntityTypeId()) {
+    case 'node':
+      $old_vid = $entity->original->vid->value;
+      $new_vid = $entity->vid->value;
+
+      // A node is only added to a group content after the node already been
+      // created in the DB. This means that in the hook_entity_insert we cannot
+      // know if the node belongs to a group. Here, we are making sure that the
+      // revision didn't change which means the node is being inserted.
+      if ($old_vid === $new_vid) {
+        return;
+      }
+
+      \Drupal::classResolver(EntityOperations::class)
+        ->entityUpdate($entity);
+
       break;
 
   }

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/eic_message_subscriptions.module
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/eic_message_subscriptions.module
@@ -6,7 +6,10 @@
  */
 
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\eic_message_subscriptions\Hooks\EntityOperations;
+use Drupal\eic_message_subscriptions\Hooks\FormOperations;
+use Drupal\node\Entity\NodeType;
 
 /**
  * Implements hook_entity_insert().
@@ -14,16 +17,6 @@ use Drupal\eic_message_subscriptions\Hooks\EntityOperations;
 function eic_message_subscriptions_entity_insert(EntityInterface $entity) {
   switch ($entity->getEntityTypeId()) {
     case 'comment':
-    case 'group_content':
-      \Drupal::classResolver(EntityOperations::class)
-        ->entityInsert($entity);
-      break;
-
-    case 'node':
-      if (!in_array($entity->bundle(), ['news', 'story'])) {
-        return;
-      }
-
       \Drupal::classResolver(EntityOperations::class)
         ->entityInsert($entity);
       break;
@@ -32,26 +25,28 @@ function eic_message_subscriptions_entity_insert(EntityInterface $entity) {
 }
 
 /**
- * Implements hook_entity_insert().
+ * Implements hook_entity_extra_field_info().
  */
-function eic_message_subscriptions_entity_update(EntityInterface $entity) {
-  switch ($entity->getEntityTypeId()) {
-    case 'node':
-      $old_vid = $entity->original->vid->value;
-      $new_vid = $entity->vid->value;
+function eic_message_subscriptions_entity_extra_field_info() {
+  $extra = [];
 
-      // A node is only added to a group content after the node already been
-      // created in the DB. This means that in the hook_entity_insert we cannot
-      // know if the node belongs to a group. Here, we are making sure that the
-      // revision didn't change which means the node is being inserted.
-      if ($old_vid === $new_vid) {
-        return;
-      }
-
-      \Drupal::classResolver(EntityOperations::class)
-        ->entityUpdate($entity);
-
-      break;
-
+  // We add the extra field for all content types. The display will be handled
+  // in the hook_form_BASE_FORM_ID_alter() function.
+  foreach (NodeType::loadMultiple() as $bundle) {
+    $extra['node'][$bundle->id()]['form']['field_send_notification'] = [
+      'label' => t('Send notification'),
+      'description' => '',
+      'visible' => TRUE,
+    ];
   }
+
+  return $extra;
+}
+
+/**
+ * Implements hook_form_BASE_FORM_ID_alter().
+ */
+function eic_message_subscriptions_form_node_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  \Drupal::classResolver(FormOperations::class)
+    ->entityFormAlter($form, $form_state, $form_id);
 }

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/eic_message_subscriptions.module
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/eic_message_subscriptions.module
@@ -55,3 +55,11 @@ function eic_message_subscriptions_form_node_form_alter(&$form, FormStateInterfa
   \Drupal::classResolver(FormOperations::class)
     ->entityFormAlter($form, $form_state, $form_id);
 }
+
+/**
+ * Implements hook_form_BASE_FORM_ID_alter().
+ */
+function eic_message_subscriptions_form_node_edit_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  \Drupal::classResolver(FormOperations::class)
+    ->entityFormAlter($form, $form_state, $form_id);
+}

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/eic_message_subscriptions.services.yml
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/eic_message_subscriptions.services.yml
@@ -1,3 +1,9 @@
 services:
+  eic_message_subscriptions.event_subscriber:
+    class: Drupal\eic_message_subscriptions\EventSubscriber\MessageSubscriptionEventSubscriber
+    arguments: ['@message_notify.sender', '@eic_messages.message_creator.comment', '@eic_messages.message_creator.group_content']
+    tags:
+      - { name: event_subscriber }
+
   eic_message_subscriptions.helper:
     class: Drupal\eic_message_subscriptions\MessageSubscriptionHelper

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/eic_message_subscriptions.services.yml
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/eic_message_subscriptions.services.yml
@@ -1,7 +1,7 @@
 services:
   eic_message_subscriptions.event_subscriber:
     class: Drupal\eic_message_subscriptions\EventSubscriber\MessageSubscriptionEventSubscriber
-    arguments: ['@message_notify.sender', '@eic_messages.message_creator.comment', '@eic_messages.message_creator.group_content']
+    arguments: ['@message_notify.sender', '@eic_messages.message_creator.comment', '@eic_messages.message_creator.group_content', '@eic_flags.helper']
     tags:
       - { name: event_subscriber }
 

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/eic_message_subscriptions.services.yml
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/eic_message_subscriptions.services.yml
@@ -1,0 +1,3 @@
+services:
+  eic_message_subscriptions.helper:
+    class: Drupal\eic_message_subscriptions\MessageSubscriptionHelper

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/eic_message_subscriptions.services.yml
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/eic_message_subscriptions.services.yml
@@ -1,7 +1,7 @@
 services:
   eic_message_subscriptions.event_subscriber:
     class: Drupal\eic_message_subscriptions\EventSubscriber\MessageSubscriptionEventSubscriber
-    arguments: ['@message_notify.sender', '@eic_messages.message_creator.comment', '@eic_messages.message_creator.group_content', '@eic_flags.helper']
+    arguments: ['@message_notify.sender', '@eic_messages.message_creator.comment', '@eic_messages.message_creator.group_content', '@eic_messages.message_creator.node', '@eic_flags.helper']
     tags:
       - { name: event_subscriber }
 

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Event/MessageSubscriptionEvent.php
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Event/MessageSubscriptionEvent.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\eic_message_subscriptions\Event;
+
+use Drupal\Component\EventDispatcher\Event;
+use Drupal\Core\Entity\EntityInterface;
+
+/**
+ * Event for when a flagging is created.
+ */
+class MessageSubscriptionEvent extends Event {
+
+  /**
+   * The entity object.
+   *
+   * @var \Drupal\Core\Entity\EntityInterface
+   */
+  protected $entity;
+
+  /**
+   * Builds a new MessageSubscriptionEvent.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity.
+   */
+  public function __construct(EntityInterface $entity) {
+    $this->entity = $entity;
+  }
+
+  /**
+   * Returns the entity associated with the Event.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface
+   *   The entity object.
+   */
+  public function getEntity() {
+    return $this->entity;
+  }
+
+}

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Event/MessageSubscriptionEvent.php
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Event/MessageSubscriptionEvent.php
@@ -6,7 +6,7 @@ use Drupal\Component\EventDispatcher\Event;
 use Drupal\Core\Entity\EntityInterface;
 
 /**
- * Event for when a flagging is created.
+ * Event for when an entity is created and needs to generate message.
  */
 class MessageSubscriptionEvent extends Event {
 

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Event/MessageSubscriptionEvents.php
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Event/MessageSubscriptionEvents.php
@@ -43,13 +43,4 @@ final class MessageSubscriptionEvents {
    */
   const NODE_INSERT = 'eic_message_subscriptions.node_insert';
 
-  /**
-   * Event ID for when a group content is updated.
-   *
-   * @Event
-   *
-   * @var string
-   */
-  const NODE_UPDATE = 'eic_message_subscriptions.node_update';
-
 }

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Event/MessageSubscriptionEvents.php
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Event/MessageSubscriptionEvents.php
@@ -34,4 +34,22 @@ final class MessageSubscriptionEvents {
    */
   const COMMENT_INSERT = 'eic_message_subscriptions.comment_insert';
 
+  /**
+   * Event ID for when a group content is updated.
+   *
+   * @Event
+   *
+   * @var string
+   */
+  const NODE_INSERT = 'eic_message_subscriptions.node_insert';
+
+  /**
+   * Event ID for when a group content is updated.
+   *
+   * @Event
+   *
+   * @var string
+   */
+  const NODE_UPDATE = 'eic_message_subscriptions.node_update';
+
 }

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Event/MessageSubscriptionEvents.php
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Event/MessageSubscriptionEvents.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\eic_message_subscriptions\Event;
+
+/**
+ * Contains all events thrown in the eic_message_subscription module.
+ */
+final class MessageSubscriptionEvents {
+
+  /**
+   * Event ID for when a group content is created.
+   *
+   * @Event
+   *
+   * @var string
+   */
+  const GROUP_CONTENT_INSERT = 'eic_message_subscriptions.group_content_insert';
+
+  /**
+   * Event ID for when a group content is updated.
+   *
+   * @Event
+   *
+   * @var string
+   */
+  const GROUP_CONTENT_UPDATE = 'eic_message_subscriptions.group_content_update';
+
+  /**
+   * Event ID for when a comment is created.
+   *
+   * @Event
+   *
+   * @var string
+   */
+  const COMMENT_INSERT = 'eic_message_subscriptions.comment_insert';
+
+}

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/src/EventSubscriber/MessageSubscriptionEventSubscriber.php
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/src/EventSubscriber/MessageSubscriptionEventSubscriber.php
@@ -1,0 +1,229 @@
+<?php
+
+namespace Drupal\eic_message_subscriptions\EventSubscriber;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\eic_flags\FlagHelper;
+use Drupal\eic_message_subscriptions\Event\MessageSubscriptionEvent;
+use Drupal\eic_message_subscriptions\Event\MessageSubscriptionEvents;
+use Drupal\eic_message_subscriptions\SubscriptionOperationTypes;
+use Drupal\eic_messages\Service\CommentMessageCreator;
+use Drupal\eic_messages\Service\GroupContentMessageCreator;
+use Drupal\group\Entity\GroupContent;
+use Drupal\message_notify\MessageNotifier;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * EIC Message Notifications event subscriber.
+ */
+class MessageSubscriptionEventSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The message notifier.
+   *
+   * @var \Drupal\message_notify\MessageNotifier
+   */
+  protected $notifier;
+
+  /**
+   * The Comment Message Creator service.
+   *
+   * @var \Drupal\eic_messages\Service\CommentMessageCreator
+   */
+  protected $commentMessageCreator;
+
+  /**
+   * The GroupContent Message Creator service.
+   *
+   * @var \Drupal\eic_messages\Service\GroupContentMessageCreator
+   */
+  protected $groupContentMessageCreator;
+
+  /**
+   * The EIC Flag Helper service.
+   *
+   * @var \Drupal\eic_flags\FlagHelper
+   */
+  protected $eicFlagsHelper;
+
+  /**
+   * Constructs a new EntityOperations object.
+   *
+   * @param \Drupal\message_notify\MessageNotifier $notifier
+   *   The message notifier.
+   * @param \Drupal\eic_messages\Service\CommentMessageCreator $comment_message_creator
+   *   The Comment Message Creator service.
+   * @param \Drupal\eic_messages\Service\GroupContentMessageCreator $group_content_message_creator
+   *   The GroupContent Message Creator service.
+   * @param \Drupal\eic_flags\FlagHelper $eic_flags_helper
+   *   The EIC Flag Helper service.
+   */
+  public function __construct(
+    MessageNotifier $notifier,
+    CommentMessageCreator $comment_message_creator,
+    GroupContentMessageCreator $group_content_message_creator,
+    FlagHelper $eic_flags_helper
+  ) {
+    $this->notifier = $notifier;
+    $this->commentMessageCreator = $comment_message_creator;
+    $this->groupContentMessageCreator = $group_content_message_creator;
+    $this->eicFlagsHelper = $eic_flags_helper;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      MessageSubscriptionEvents::COMMENT_INSERT => ['commentCreated'],
+      MessageSubscriptionEvents::GROUP_CONTENT_INSERT => ['groupContentCreated'],
+      MessageSubscriptionEvents::GROUP_CONTENT_UPDATE => ['groupContentUpdated'],
+    ];
+  }
+
+  /**
+   * Comment created event handler.
+   *
+   * @param \Drupal\eic_message_subscriptions\Event\MessageSubscriptionEvent $event
+   *   The MessageSubscription event.
+   */
+  public function commentCreated(MessageSubscriptionEvent $event) {
+    $entity = $event->getEntity();
+
+    $subscribed_users = $this->getSubscribedUsers($entity);
+
+    // Set the subscription operation.
+    $operation = SubscriptionOperationTypes::NEW_ENTITY;
+
+    // If comment is a reply we set the operation to 'comment_reply'.
+    if ($entity->hasParentComment()) {
+      $operation = SubscriptionOperationTypes::COMMENT_REPLY;
+    }
+
+    $message = $this->commentMessageCreator->createCommentSubscription(
+      $entity,
+      $operation
+    );
+
+    foreach ($subscribed_users as $user) {
+      $message->setOwnerId($user->id());
+      // @todo Send message to a queue to be processed later by cron.
+      $this->notifier->send($message);
+    }
+  }
+
+  /**
+   * Group content created event handler.
+   *
+   * @param \Drupal\eic_message_subscriptions\Event\MessageSubscriptionEvent $event
+   *   The MessageSubscription event.
+   */
+  public function groupContentCreated(MessageSubscriptionEvent $event) {
+    $entity = $event->getEntity();
+
+    $group_contents = GroupContent::loadByEntity($entity);
+
+    if (empty($group_contents)) {
+      // @todo Get list of users subscribed to topics of this node.
+      return;
+    }
+
+    // Default operation when new entity is added.
+    $operation = SubscriptionOperationTypes::NEW_ENTITY;
+
+    $group_content = reset($group_contents);
+
+    $group = $group_content->getGroup();
+
+    // When a group content is created we need grab the users subscribed to the
+    // group instead of the node.
+    $subscribed_users = $this->getSubscribedUsers($group);
+
+    $message = $this->groupContentMessageCreator->createGroupContentSubscription(
+      $entity,
+      $group,
+      $operation
+    );
+
+    foreach ($subscribed_users as $user) {
+      $message->setOwnerId($user->id());
+      // @todo Send message to a queue to be processed later by cron.
+      $this->notifier->send($message);
+    }
+  }
+
+  /**
+   * Group content update event handler.
+   *
+   * @param \Drupal\eic_message_subscriptions\Event\MessageSubscriptionEvent $event
+   *   The MessageSubscription event.
+   */
+  public function groupContentUpdated(MessageSubscriptionEvent $event) {
+    $entity = $event->getEntity();
+
+    $group_contents = GroupContent::loadByEntity($entity);
+
+    if (empty($group_contents)) {
+      // @todo Get list of users subscribed to topics of this node.
+      return;
+    }
+
+    // Set the subscription operation.
+    $operation = SubscriptionOperationTypes::UPDATED_ENTITY;
+
+    // Get the users subscribed to the node.
+    $subscribed_users = $this->getSubscribedUsers($entity);
+
+    $group_content = reset($group_contents);
+
+    $group = $group_content->getGroup();
+
+    $message = $this->groupContentMessageCreator->createGroupContentSubscription(
+      $entity,
+      $group,
+      $operation
+    );
+
+    foreach ($subscribed_users as $user) {
+      $message->setOwnerId($user->id());
+      // @todo Send message to a queue to be processed later by cron.
+      $this->notifier->send($message);
+    }
+  }
+
+  /**
+   * Get users who subscribed to a given entity.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The subscribed entity.
+   *
+   * @return array
+   *   An array of users who have flagged the entity.
+   */
+  private function getSubscribedUsers(EntityInterface $entity) {
+    $users = [];
+
+    switch ($entity->getEntityTypeId()) {
+      case 'comment':
+        $commented_entity = $entity->getCommentedEntity();
+        // Get users who are following the commented entity.
+        $users = $this->eicFlagsHelper->getFlaggingUsersByFlagIds($commented_entity, ['follow_content']);
+        break;
+
+      case 'node':
+        // Get users who are following the node.
+        $users = $this->eicFlagsHelper->getFlaggingUsersByFlagIds($entity, ['follow_content']);
+        // @todo Get users who are following topics of the node.
+        break;
+
+      case 'group':
+        // Get users who are following the group.
+        $users = $this->eicFlagsHelper->getFlaggingUsersByFlagIds($entity, ['follow_group']);
+        break;
+
+    }
+
+    return $users;
+  }
+
+}

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Hooks/EntityOperations.php
@@ -83,6 +83,14 @@ class EntityOperations implements ContainerInjectionInterface {
    */
   public function entityInsert(EntityInterface $entity) {
     if (!$this->messageSubscriptionHelper->isMessageSubscriptionApplicable($entity)) {
+      if ($entity->getEntityTypeId() === 'group_content') {
+        $group_content_entity = $entity->getEntity();
+        // Cache ID that identifies if an entity needs to trigger a
+        // subscription notification.
+        $cid = "eic_message_subscriptions:entity_notify:{$group_content_entity->getEntityTypeId()}:{$group_content_entity->id()}";
+        // Deletes the cache.
+        $this->cacheBackend->delete($cid);
+      }
       return;
     }
 

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Hooks/EntityOperations.php
@@ -5,8 +5,12 @@ namespace Drupal\eic_message_subscriptions\Hooks;
 use Drupal\content_moderation\ModerationInformationInterface;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\eic_groups\GroupsModerationHelper;
+use Drupal\eic_message_subscriptions\MessageSubscriptionType;
 use Drupal\flag\FlagServiceInterface;
+use Drupal\group\Entity\GroupContent;
 use Drupal\message\Entity\Message;
 use Drupal\message_notify\MessageNotifier;
 use Drupal\user\UserInterface;
@@ -17,7 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * Implementations of entity hooks.
  *
- * @package Drupal\eic_flags\Hooks
+ * @package Drupal\eic_message_subscriptions\Hooks
  */
 class EntityOperations implements ContainerInjectionInterface {
 
@@ -45,6 +49,13 @@ class EntityOperations implements ContainerInjectionInterface {
   protected $notifier;
 
   /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
    * Constructs a new EntityOperations object.
    *
    * @param \Drupal\content_moderation\ModerationInformationInterface $moderation_information
@@ -53,15 +64,19 @@ class EntityOperations implements ContainerInjectionInterface {
    *   The Flag sevice.
    * @param \Drupal\message_notify\MessageNotifier $notifier
    *   The message notifier.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
    */
   public function __construct(
     ModerationInformationInterface $moderation_information,
     FlagServiceInterface $flag_service,
-    MessageNotifier $notifier
+    MessageNotifier $notifier,
+    EntityTypeManagerInterface $entity_type_manager
   ) {
     $this->moderationInformation = $moderation_information;
     $this->flagService = $flag_service;
     $this->notifier = $notifier;
+    $this->entityTypeManager = $entity_type_manager;
   }
 
   /**
@@ -71,7 +86,8 @@ class EntityOperations implements ContainerInjectionInterface {
     return new static(
       $container->get('content_moderation.moderation_information'),
       $container->get('flag'),
-      $container->get('message_notify.sender')
+      $container->get('message_notify.sender'),
+      $container->get('entity_type.manager')
     );
   }
 
@@ -86,21 +102,34 @@ class EntityOperations implements ContainerInjectionInterface {
     /** @var \Drupal\user\Entity\User[] $subscribed_users */
     $subscribed_users = [];
 
+    if (!$this->isMessageSubscriptionApplicable($entity)) {
+      return;
+    }
+
     switch ($entity->getEntityTypeId()) {
       case 'comment':
         // Default message type when new comment is added.
-        $subscription_message_type = 'sub_new_comment_on_content';
+        $subscription_message_type = MessageSubscriptionType::NEW_COMMENT;
 
         // If comment is a reply we set the message type to
         // "sub_new_comment_reply".
         if ($entity->hasParentComment()) {
-          $subscription_message_type = 'sub_new_comment_reply';
+          $subscription_message_type = MessageSubscriptionType::NEW_COMMENT_REPLY;
         }
 
         // Get commented entity.
         $commented_entity = $entity->getCommentedEntity();
         // Get users who are following the commented entity.
         $subscribed_users = $this->getFlaggingUsersByFlagId($commented_entity, 'follow_content');
+        break;
+
+      case 'group_content':
+        // Default message type when new group content is added.
+        $subscription_message_type = MessageSubscriptionType::NEW_GROUP_CONTENT_PUBLISHED;
+        // Get the group entity.
+        $group = $entity->getGroup();
+        // Get users who are following the commented entity.
+        $subscribed_users = $this->getFlaggingUsersByFlagId($group, 'follow_group');
         break;
 
     }
@@ -141,18 +170,35 @@ class EntityOperations implements ContainerInjectionInterface {
       'uid' => $user->id(),
     ]);
 
-    // Adds the reference to the owner of the entity.
+    // Adds the reference to the user who created/updated the entity.
     if ($message->hasField('field_event_executing_user')) {
-      $message->set('field_event_executing_user', $entity->getOwnerId());
+      $executing_user_id = $entity->getOwnerId();
+
+      $vid = $this->entityTypeManager->getStorage($entity->getEntityTypeId())
+        ->getLatestRevisionId($entity->id());
+
+      if ($vid) {
+        $latest_revision = $this->entityTypeManager->getStorage($entity->getEntityTypeId())
+          ->loadRevision($vid);
+        $executing_user_id = $latest_revision->getOwnerId();
+      }
+
+      $message->set('field_event_executing_user', $executing_user_id);
     }
 
     switch ($message_type) {
-      case 'sub_new_comment_on_content':
+      case MessageSubscriptionType::NEW_COMMENT:
         // @todo Set values for the missing fields.
         break;
 
-      default:
-        return FALSE;
+      case MessageSubscriptionType::NEW_COMMENT_REPLY:
+        // @todo Set values for the missing fields.
+        break;
+
+      case MessageSubscriptionType::NEW_GROUP_CONTENT_PUBLISHED:
+        // @todo Set values for the missing fields.
+        break;
+
     }
 
     return $message;
@@ -188,6 +234,93 @@ class EntityOperations implements ContainerInjectionInterface {
     }
 
     return $result;
+  }
+
+  /**
+   * Check if an entity can trigger message subscriptions.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity object.
+   *
+   * @return bool
+   *   TRUE if the entity can trigger message subscriptions.
+   */
+  private function isMessageSubscriptionApplicable(EntityInterface $entity) {
+    $is_applicable = TRUE;
+    $in_group_context = FALSE;
+
+    switch ($entity->getEntityTypeId()) {
+      case 'comment':
+        // Get commented entity.
+        $commented_entity = $entity->getCommentedEntity();
+
+        // Loads group contents for the commented entity.
+        $group_contents = GroupContent::loadByEntity($commented_entity);
+
+        if (!empty($group_contents)) {
+          break;
+        }
+
+        $group_content = reset($group_contents);
+
+        $in_group_context = TRUE;
+        break;
+
+      case 'node':
+        // Loads group contents for the node.
+        $group_contents = GroupContent::loadByEntity($entity);
+
+        if (!empty($group_contents)) {
+          break;
+        }
+
+        $group_content = reset($group_contents);
+
+        $in_group_context = TRUE;
+        break;
+
+      case 'group_content':
+        $group_content = $entity;
+        $in_group_context = TRUE;
+        break;
+
+    }
+
+    // If the entity is in the context of a group we need to make sure the
+    // group is not in pending or draft state.
+    if ($in_group_context && isset($group_content)) {
+      $group_content_plugin_id = $entity->getContentPlugin()->getPluginId();
+
+      // Group content plugins other than group_node cannot trigger
+      // notifications.
+      if (strpos($group_content_plugin_id, 'group_node:') === FALSE) {
+        return FALSE;
+      }
+
+      // Group book pages cannot trigger notifications.
+      if (strpos($group_content_plugin_id, 'group_node:book') !== FALSE) {
+        return FALSE;
+      }
+
+      // If entity is not publish, it cannot trigger notifications.
+      if (!$group_content->getEntity()->isPublished()) {
+        return FALSE;
+      }
+
+      $group = $entity->getGroup();
+
+      $moderation_state = $group->get('moderation_state')->value;
+
+      $is_applicable = !in_array(
+        $moderation_state,
+        [
+          GroupsModerationHelper::GROUP_PENDING_STATE,
+          GroupsModerationHelper::GROUP_DRAFT_STATE,
+        ]
+      );
+    }
+
+    return $is_applicable;
   }
 
 }

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Hooks/EntityOperations.php
@@ -2,24 +2,21 @@
 
 namespace Drupal\eic_message_subscriptions\Hooks;
 
-use Drupal\content_moderation\ModerationInformationInterface;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
-use Drupal\eic_groups\GroupsModerationHelper;
-use Drupal\eic_message_subscriptions\MessageSubscriptionType;
-use Drupal\flag\FlagServiceInterface;
-use Drupal\group\Entity\GroupContent;
-use Drupal\message\Entity\Message;
+use Drupal\eic_flags\FlagHelper;
+use Drupal\eic_message_subscriptions\MessageSubscriptionHelper;
+use Drupal\eic_message_subscriptions\SubscriptionOperationType;
+use Drupal\eic_messages\Service\CommentMessageCreator;
 use Drupal\message_notify\MessageNotifier;
-use Drupal\user\UserInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Class EntityOperations.
  *
- * Implementations of entity hooks.
+ * Implementations of form hooks.
  *
  * @package Drupal\eic_message_subscriptions\Hooks
  */
@@ -28,18 +25,11 @@ class EntityOperations implements ContainerInjectionInterface {
   use StringTranslationTrait;
 
   /**
-   * The moderation information service.
+   * The EIC Flags helper sevice.
    *
-   * @var \Drupal\content_moderation\ModerationInformationInterface
+   * @var \Drupal\eic_flags\FlagHelper
    */
-  protected $moderationInformation;
-
-  /**
-   * The Flag sevice.
-   *
-   * @var \Drupal\flag\FlagServiceInterface
-   */
-  protected $flagService;
+  protected $eicFlagsHelper;
 
   /**
    * The message notifier.
@@ -56,27 +46,45 @@ class EntityOperations implements ContainerInjectionInterface {
   protected $entityTypeManager;
 
   /**
+   * The message subscription helper service.
+   *
+   * @var \Drupal\eic_message_subscriptions\MessageSubscriptionHelper
+   */
+  protected $messageSubscriptionHelper;
+
+  /**
+   * The Comment Message Creator service.
+   *
+   * @var \Drupal\eic_messages\Service\CommentMessageCreator
+   */
+  protected $commentMessageCreator;
+
+  /**
    * Constructs a new EntityOperations object.
    *
-   * @param \Drupal\content_moderation\ModerationInformationInterface $moderation_information
-   *   The moderation information service.
-   * @param \Drupal\flag\FlagServiceInterface $flag_service
-   *   The Flag sevice.
+   * @param \Drupal\eic_flags\FlagHelper $eic_flags_helper
+   *   The EIC Flags helper sevice.
    * @param \Drupal\message_notify\MessageNotifier $notifier
    *   The message notifier.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
+   * @param \Drupal\eic_message_subscriptions\MessageSubscriptionHelper $message_subscription_helper
+   *   The message subscription helper service.
+   * @param \Drupal\eic_messages\Service\CommentMessageCreator $comment_message_creator
+   *   The Comment Message Creator service.
    */
   public function __construct(
-    ModerationInformationInterface $moderation_information,
-    FlagServiceInterface $flag_service,
+    FlagHelper $eic_flags_helper,
     MessageNotifier $notifier,
-    EntityTypeManagerInterface $entity_type_manager
+    EntityTypeManagerInterface $entity_type_manager,
+    MessageSubscriptionHelper $message_subscription_helper,
+    CommentMessageCreator $comment_message_creator
   ) {
-    $this->moderationInformation = $moderation_information;
-    $this->flagService = $flag_service;
+    $this->eicFlagsHelper = $eic_flags_helper;
     $this->notifier = $notifier;
     $this->entityTypeManager = $entity_type_manager;
+    $this->messageSubscriptionHelper = $message_subscription_helper;
+    $this->commentMessageCreator = $comment_message_creator;
   }
 
   /**
@@ -84,10 +92,11 @@ class EntityOperations implements ContainerInjectionInterface {
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('content_moderation.moderation_information'),
-      $container->get('flag'),
+      $container->get('eic_flags.helper'),
       $container->get('message_notify.sender'),
-      $container->get('entity_type.manager')
+      $container->get('entity_type.manager'),
+      $container->get('eic_message_subscriptions.helper'),
+      $container->get('eic_messages.message_creator.comment')
     );
   }
 
@@ -98,49 +107,50 @@ class EntityOperations implements ContainerInjectionInterface {
    *   The entity object.
    */
   public function entityInsert(EntityInterface $entity) {
-    $subscription_message_type = FALSE;
+    $operation = FALSE;
     /** @var \Drupal\user\Entity\User[] $subscribed_users */
     $subscribed_users = [];
 
-    if (!$this->isMessageSubscriptionApplicable($entity)) {
+    if (!$this->messageSubscriptionHelper->isMessageSubscriptionApplicable($entity)) {
       return;
     }
 
     switch ($entity->getEntityTypeId()) {
       case 'comment':
-        // Default message type when new comment is added.
-        $subscription_message_type = MessageSubscriptionType::NEW_COMMENT;
+        // Default operation when new comment is added.
+        $operation = SubscriptionOperationType::NEW_ENTITY;
 
-        // If comment is a reply we set the message type to
-        // "sub_new_comment_reply".
+        // If comment is a reply we set the operation to 'comment_reply'..
         if ($entity->hasParentComment()) {
-          $subscription_message_type = MessageSubscriptionType::NEW_COMMENT_REPLY;
+          $operation = SubscriptionOperationType::COMMENT_REPLY;
         }
 
         // Get commented entity.
         $commented_entity = $entity->getCommentedEntity();
         // Get users who are following the commented entity.
-        $subscribed_users = $this->getFlaggingUsersByFlagId($commented_entity, 'follow_content');
-        break;
-
-      case 'group_content':
-        // Default message type when new group content is added.
-        $subscription_message_type = MessageSubscriptionType::NEW_GROUP_CONTENT_PUBLISHED;
-        // Get the group entity.
-        $group = $entity->getGroup();
-        // Get users who are following the commented entity.
-        $subscribed_users = $this->getFlaggingUsersByFlagId($group, 'follow_group');
+        $subscribed_users = $this->eicFlagsHelper->getFlaggingUsersByFlagIds($commented_entity, ['follow_content']);
         break;
 
     }
 
     // No message type defined so we do nothing.
-    if (!$subscription_message_type) {
+    if (!$operation) {
       return;
     }
 
     foreach ($subscribed_users as $user) {
-      $message = $this->prepareMessage($subscription_message_type, $entity, $user);
+      $message = NULL;
+
+      switch ($entity->getEntityTypeId()) {
+        case 'comment':
+          $message = $this->commentMessageCreator->createCommentSubscription(
+            $entity,
+            $user,
+            $operation
+          );
+          break;
+
+      }
 
       if (!$message) {
         continue;
@@ -149,178 +159,6 @@ class EntityOperations implements ContainerInjectionInterface {
       // @todo Send message to a queue to be processed later by cron.
       $this->notifier->send($message);
     }
-  }
-
-  /**
-   * Prepares a new message entity.
-   *
-   * @param string $message_type
-   *   The message type ID.
-   * @param \Drupal\Core\Entity\EntityInterface $entity
-   *   The entity which triggered the message.
-   * @param \Drupal\user\UserInterface $user
-   *   The owner of the message.
-   *
-   * @return \Drupal\message\MessageInterface
-   *   The message entity to be sent out.
-   */
-  private function prepareMessage($message_type, EntityInterface $entity, UserInterface $user) {
-    $message = Message::create([
-      'template' => $message_type,
-      'uid' => $user->id(),
-    ]);
-
-    // Adds the reference to the user who created/updated the entity.
-    if ($message->hasField('field_event_executing_user')) {
-      $executing_user_id = $entity->getOwnerId();
-
-      $vid = $this->entityTypeManager->getStorage($entity->getEntityTypeId())
-        ->getLatestRevisionId($entity->id());
-
-      if ($vid) {
-        $latest_revision = $this->entityTypeManager->getStorage($entity->getEntityTypeId())
-          ->loadRevision($vid);
-        $executing_user_id = $latest_revision->getOwnerId();
-      }
-
-      $message->set('field_event_executing_user', $executing_user_id);
-    }
-
-    switch ($message_type) {
-      case MessageSubscriptionType::NEW_COMMENT:
-        // @todo Set values for the missing fields.
-        break;
-
-      case MessageSubscriptionType::NEW_COMMENT_REPLY:
-        // @todo Set values for the missing fields.
-        break;
-
-      case MessageSubscriptionType::NEW_GROUP_CONTENT_PUBLISHED:
-        // @todo Set values for the missing fields.
-        break;
-
-    }
-
-    return $message;
-  }
-
-  /**
-   * Get a list of users that have flagged an entity with a given flag ID.
-   *
-   * @param \Drupal\Core\Entity\EntityInterface $entity
-   *   The flagged entity.
-   * @param string $flag_id
-   *   The flag machine name.
-   *
-   * @return array
-   *   An array of users who have flagged the entity.
-   */
-  private function getFlaggingUsersByFlagId(EntityInterface $entity, $flag_id) {
-    if (empty($flag_id)) {
-      return $this->flagService->getFlaggingUsers($entity);
-    }
-
-    $flag = $this->flagService->getFlagById($flag_id);
-
-    if (!$flag) {
-      return [];
-    }
-
-    $result = [];
-    $flagging_users = $this->flagService->getFlaggingUsers($entity, $flag);
-
-    foreach ($flagging_users as $user) {
-      $result[$user->id()] = $user;
-    }
-
-    return $result;
-  }
-
-  /**
-   * Check if an entity can trigger message subscriptions.
-   *
-   * @param \Drupal\Core\Entity\EntityInterface $entity
-   *   The entity object.
-   *
-   * @return bool
-   *   TRUE if the entity can trigger message subscriptions.
-   */
-  private function isMessageSubscriptionApplicable(EntityInterface $entity) {
-    $is_applicable = TRUE;
-    $in_group_context = FALSE;
-
-    switch ($entity->getEntityTypeId()) {
-      case 'comment':
-        // Get commented entity.
-        $commented_entity = $entity->getCommentedEntity();
-
-        // Loads group contents for the commented entity.
-        $group_contents = GroupContent::loadByEntity($commented_entity);
-
-        if (!empty($group_contents)) {
-          break;
-        }
-
-        $group_content = reset($group_contents);
-
-        $in_group_context = TRUE;
-        break;
-
-      case 'node':
-        // Loads group contents for the node.
-        $group_contents = GroupContent::loadByEntity($entity);
-
-        if (!empty($group_contents)) {
-          break;
-        }
-
-        $group_content = reset($group_contents);
-
-        $in_group_context = TRUE;
-        break;
-
-      case 'group_content':
-        $group_content = $entity;
-        $in_group_context = TRUE;
-        break;
-
-    }
-
-    // If the entity is in the context of a group we need to make sure the
-    // group is not in pending or draft state.
-    if ($in_group_context && isset($group_content)) {
-      $group_content_plugin_id = $entity->getContentPlugin()->getPluginId();
-
-      // Group content plugins other than group_node cannot trigger
-      // notifications.
-      if (strpos($group_content_plugin_id, 'group_node:') === FALSE) {
-        return FALSE;
-      }
-
-      // Group book pages cannot trigger notifications.
-      if (strpos($group_content_plugin_id, 'group_node:book') !== FALSE) {
-        return FALSE;
-      }
-
-      // If entity is not publish, it cannot trigger notifications.
-      if (!$group_content->getEntity()->isPublished()) {
-        return FALSE;
-      }
-
-      $group = $entity->getGroup();
-
-      $moderation_state = $group->get('moderation_state')->value;
-
-      $is_applicable = !in_array(
-        $moderation_state,
-        [
-          GroupsModerationHelper::GROUP_PENDING_STATE,
-          GroupsModerationHelper::GROUP_DRAFT_STATE,
-        ]
-      );
-    }
-
-    return $is_applicable;
   }
 
 }

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Hooks/EntityOperations.php
@@ -138,24 +138,24 @@ class EntityOperations implements ContainerInjectionInterface {
       return;
     }
 
+    $message = NULL;
+
+    switch ($entity->getEntityTypeId()) {
+      case 'comment':
+        $message = $this->commentMessageCreator->createCommentSubscription(
+          $entity,
+          $operation
+        );
+        break;
+
+    }
+
+    if (!$message) {
+      return;
+    }
+
     foreach ($subscribed_users as $user) {
-      $message = NULL;
-
-      switch ($entity->getEntityTypeId()) {
-        case 'comment':
-          $message = $this->commentMessageCreator->createCommentSubscription(
-            $entity,
-            $user,
-            $operation
-          );
-          break;
-
-      }
-
-      if (!$message) {
-        continue;
-      }
-
+      $message->setOwnerId($user->id());
       // @todo Send message to a queue to be processed later by cron.
       $this->notifier->send($message);
     }

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Hooks/EntityOperations.php
@@ -8,7 +8,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\eic_flags\FlagHelper;
 use Drupal\eic_message_subscriptions\MessageSubscriptionHelper;
-use Drupal\eic_message_subscriptions\SubscriptionOperationType;
+use Drupal\eic_message_subscriptions\SubscriptionOperationTypes;
 use Drupal\eic_messages\Service\CommentMessageCreator;
 use Drupal\message_notify\MessageNotifier;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -118,11 +118,11 @@ class EntityOperations implements ContainerInjectionInterface {
     switch ($entity->getEntityTypeId()) {
       case 'comment':
         // Default operation when new comment is added.
-        $operation = SubscriptionOperationType::NEW_ENTITY;
+        $operation = SubscriptionOperationTypes::NEW_ENTITY;
 
         // If comment is a reply we set the operation to 'comment_reply'..
         if ($entity->hasParentComment()) {
-          $operation = SubscriptionOperationType::COMMENT_REPLY;
+          $operation = SubscriptionOperationTypes::COMMENT_REPLY;
         }
 
         // Get commented entity.

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Hooks/EntityOperations.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Drupal\eic_message_subscriptions\Hooks;
+
+use Drupal\content_moderation\ModerationInformationInterface;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\flag\FlagServiceInterface;
+use Drupal\message\Entity\Message;
+use Drupal\message_notify\MessageNotifier;
+use Drupal\user\UserInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class EntityOperations.
+ *
+ * Implementations of entity hooks.
+ *
+ * @package Drupal\eic_flags\Hooks
+ */
+class EntityOperations implements ContainerInjectionInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The moderation information service.
+   *
+   * @var \Drupal\content_moderation\ModerationInformationInterface
+   */
+  protected $moderationInformation;
+
+  /**
+   * The Flag sevice.
+   *
+   * @var \Drupal\flag\FlagServiceInterface
+   */
+  protected $flagService;
+
+  /**
+   * The message notifier.
+   *
+   * @var \Drupal\message_notify\MessageNotifier
+   */
+  protected $notifier;
+
+  /**
+   * Constructs a new EntityOperations object.
+   *
+   * @param \Drupal\content_moderation\ModerationInformationInterface $moderation_information
+   *   The moderation information service.
+   * @param \Drupal\flag\FlagServiceInterface $flag_service
+   *   The Flag sevice.
+   * @param \Drupal\message_notify\MessageNotifier $notifier
+   *   The message notifier.
+   */
+  public function __construct(
+    ModerationInformationInterface $moderation_information,
+    FlagServiceInterface $flag_service,
+    MessageNotifier $notifier
+  ) {
+    $this->moderationInformation = $moderation_information;
+    $this->flagService = $flag_service;
+    $this->notifier = $notifier;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('content_moderation.moderation_information'),
+      $container->get('flag'),
+      $container->get('message_notify.sender')
+    );
+  }
+
+  /**
+   * Implements hook_entity_insert().
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity object.
+   */
+  public function entityInsert(EntityInterface $entity) {
+    $subscription_message_type = FALSE;
+    /** @var \Drupal\user\Entity\User[] $subscribed_users */
+    $subscribed_users = [];
+
+    switch ($entity->getEntityTypeId()) {
+      case 'comment':
+        // Default message type when new comment is added.
+        $subscription_message_type = 'sub_new_comment_on_content';
+
+        // If comment is a reply we set the message type to
+        // "sub_new_comment_reply".
+        if ($entity->hasParentComment()) {
+          $subscription_message_type = 'sub_new_comment_reply';
+        }
+
+        // Get commented entity.
+        $commented_entity = $entity->getCommentedEntity();
+        // Get users who are following the commented entity.
+        $subscribed_users = $this->getFlaggingUsersByFlagId($commented_entity, 'follow_content');
+        break;
+
+    }
+
+    // No message type defined so we do nothing.
+    if (!$subscription_message_type) {
+      return;
+    }
+
+    foreach ($subscribed_users as $user) {
+      $message = $this->prepareMessage($subscription_message_type, $entity, $user);
+
+      if (!$message) {
+        continue;
+      }
+
+      // @todo Send message to a queue to be processed later by cron.
+      $this->notifier->send($message);
+    }
+  }
+
+  /**
+   * Prepares a new message entity.
+   *
+   * @param string $message_type
+   *   The message type ID.
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity which triggered the message.
+   * @param \Drupal\user\UserInterface $user
+   *   The owner of the message.
+   *
+   * @return \Drupal\message\MessageInterface
+   *   The message entity to be sent out.
+   */
+  private function prepareMessage($message_type, EntityInterface $entity, UserInterface $user) {
+    $message = Message::create([
+      'template' => $message_type,
+      'uid' => $user->id(),
+    ]);
+
+    // Adds the reference to the owner of the entity.
+    if ($message->hasField('field_event_executing_user')) {
+      $message->set('field_event_executing_user', $entity->getOwnerId());
+    }
+
+    switch ($message_type) {
+      case 'sub_new_comment_on_content':
+        // @todo Set values for the missing fields.
+        break;
+
+      default:
+        return FALSE;
+    }
+
+    return $message;
+  }
+
+  /**
+   * Get a list of users that have flagged an entity with a given flag ID.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The flagged entity.
+   * @param string $flag_id
+   *   The flag machine name.
+   *
+   * @return array
+   *   An array of users who have flagged the entity.
+   */
+  private function getFlaggingUsersByFlagId(EntityInterface $entity, $flag_id) {
+    if (empty($flag_id)) {
+      return $this->flagService->getFlaggingUsers($entity);
+    }
+
+    $flag = $this->flagService->getFlagById($flag_id);
+
+    if (!$flag) {
+      return [];
+    }
+
+    $result = [];
+    $flagging_users = $this->flagService->getFlaggingUsers($entity, $flag);
+
+    foreach ($flagging_users as $user) {
+      $result[$user->id()] = $user;
+    }
+
+    return $result;
+  }
+
+}

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Hooks/FormOperations.php
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Hooks/FormOperations.php
@@ -1,0 +1,235 @@
+<?php
+
+namespace Drupal\eic_message_subscriptions\Hooks;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\DependencyInjection\DependencySerializationTrait;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\eic_content\EICContentHelper;
+use Drupal\eic_flags\FlagHelper;
+use Drupal\eic_message_subscriptions\SubscriptionOperationType;
+use Drupal\eic_messages\Service\GroupContentMessageCreator;
+use Drupal\message_notify\MessageNotifier;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class FormAlter.
+ *
+ * Implementations for entity hooks.
+ *
+ * @package Drupal\eic_message_subscriptions\Hooks
+ */
+class FormOperations implements ContainerInjectionInterface {
+
+  use DependencySerializationTrait;
+  use StringTranslationTrait;
+
+  /**
+   * The current route match service.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
+   * The EIC content helper service.
+   *
+   * @var \Drupal\eic_content\EICContentHelper
+   */
+  protected $eicContentHelper;
+
+  /**
+   * The GroupContent Message Creator service.
+   *
+   * @var \Drupal\eic_messages\Service\GroupContentMessageCreator
+   */
+  protected $groupContentMessageCreator;
+
+  /**
+   * The EIC Flags helper sevice.
+   *
+   * @var \Drupal\eic_flags\FlagHelper
+   */
+  protected $eicFlagsHelper;
+
+  /**
+   * The message notifier.
+   *
+   * @var \Drupal\message_notify\MessageNotifier
+   */
+  protected $notifier;
+
+  /**
+   * Constructs a new EntityOperations object.
+   *
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The current route match service.
+   * @param \Drupal\eic_content\EICContentHelper $content_helper
+   *   The EIC content helper service.
+   * @param \Drupal\eic_messages\Service\GroupContentMessageCreator $group_content_message_creator
+   *   The GroupContent Message Creator service.
+   * @param \Drupal\eic_flags\FlagHelper $eic_flags_helper
+   *   The EIC Flags helper sevice.
+   * @param \Drupal\message_notify\MessageNotifier $notifier
+   *   The message notifier.
+   */
+  public function __construct(
+    RouteMatchInterface $route_match,
+    EICContentHelper $content_helper,
+    GroupContentMessageCreator $group_content_message_creator,
+    FlagHelper $eic_flags_helper,
+    MessageNotifier $notifier
+  ) {
+    $this->routeMatch = $route_match;
+    $this->eicContentHelper = $content_helper;
+    $this->groupContentMessageCreator = $group_content_message_creator;
+    $this->eicFlagsHelper = $eic_flags_helper;
+    $this->notifier = $notifier;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('current_route_match'),
+      $container->get('eic_content.helper'),
+      $container->get('eic_messages.message_creator.group_content'),
+      $container->get('eic_flags.helper'),
+      $container->get('message_notify.sender')
+    );
+  }
+
+  /**
+   * Implements hook_form_BASE_FORM_ID_alter().
+   */
+  public function entityFormAlter(&$form, FormStateInterface $form_state, $form_id) {
+    $this->handleFieldSendNotification($form, $form_state, $form_id);
+  }
+
+  /**
+   * Handles the field_post_activity.
+   *
+   * @param array $form
+   *   The form array.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The FormState object.
+   * @param string $form_id
+   *   The form ID.
+   */
+  protected function handleFieldSendNotification(
+    array &$form,
+    FormStateInterface $form_state,
+    string $form_id
+  ) {
+    /** @var \Drupal\Core\Entity\EntityInterface $entity */
+    $entity = $form_state->getFormObject()->getEntity();
+    $show_notification_field = FALSE;
+
+    switch ($entity->getEntityTypeId()) {
+      case 'node':
+        $show_notification_field = TRUE;
+        break;
+
+    }
+
+    if ($show_notification_field) {
+      $form['field_send_notification'] = [
+        '#title' => $this->t('Send notifiaction'),
+        '#type' => 'checkbox',
+        '#default_value' => $entity->isNew(),
+      ];
+      $form['actions']['submit']['#submit'][] = [
+        $this,
+        'sendNotificationSubmit',
+      ];
+    }
+  }
+
+  /**
+   * Handles the node form submit for the field_post_activity.
+   *
+   * @param array $form
+   *   The form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The FormState object.
+   */
+  public function sendNotificationSubmit(array $form, FormStateInterface $form_state) {
+    /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
+    $entity = $form_state->getFormObject()->getEntity();
+
+    // If field is empty we do nothing.
+    if (empty($form_state->getValue('field_send_notification'))) {
+      return;
+    }
+
+    $subscribed_users = [];
+    $is_group_content = FALSE;
+
+    $operation = $form_state->getFormObject()->getOperation() === 'edit'
+      ? SubscriptionOperationType::UPDATED_ENTITY
+      : SubscriptionOperationType::NEW_ENTITY;
+
+    $form_id = $form_state->getFormObject()->getFormId();
+    $route_name = $this->routeMatch->getRouteName();
+
+    switch ($entity->getEntityTypeId()) {
+      case 'node':
+        $group_contents = $this->eicContentHelper->getGroupContentByEntity($entity);
+
+        if (empty($group_contents)) {
+          // If we are creating a new group content, we handle the notification
+          // at a later stage because at this point we don't have the group
+          // content ID that is associated with this node.
+          if ($form_id === "node_{$entity->bundle()}_form" && $route_name === 'entity.group_content.create_form') {
+            // @todo Add this node to a queue so that the notification can be
+            // sent out after the group_content entity has been inserted in DB.
+            break;
+          }
+
+          // @todo Get list of users subscribed to topics of this node.
+          break;
+        }
+
+        $group_content = reset($group_contents);
+        $group = $group_content->getGroup();
+        // Get users who are following the group.
+        $subscribed_users = $this->eicFlagsHelper->getFlaggingUsersByFlagIds($group, ['follow_group']);
+        $is_group_content = TRUE;
+        break;
+
+    }
+
+    foreach ($subscribed_users as $user) {
+      $message = FALSE;
+
+      if (!$entity->isPublished()) {
+        continue;
+      }
+
+      switch ($entity->getEntityTypeId()) {
+        case 'node':
+          if ($is_group_content) {
+            $message = $this->groupContentMessageCreator->createGroupContentSubscription(
+              $entity,
+              $group,
+              $user,
+              $operation
+            );
+          }
+          break;
+
+      }
+
+      if (!$message) {
+        continue;
+      }
+
+      // @todo Send message to a queue to be processed later by cron.
+      $this->notifier->send($message);
+    }
+  }
+
+}

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Hooks/FormOperations.php
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Hooks/FormOperations.php
@@ -9,7 +9,7 @@ use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\eic_content\EICContentHelper;
 use Drupal\eic_flags\FlagHelper;
-use Drupal\eic_message_subscriptions\SubscriptionOperationType;
+use Drupal\eic_message_subscriptions\SubscriptionOperationTypes;
 use Drupal\eic_messages\Service\GroupContentMessageCreator;
 use Drupal\message_notify\MessageNotifier;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -169,8 +169,8 @@ class FormOperations implements ContainerInjectionInterface {
     $is_group_content = FALSE;
 
     $operation = $form_state->getFormObject()->getOperation() === 'edit'
-      ? SubscriptionOperationType::UPDATED_ENTITY
-      : SubscriptionOperationType::NEW_ENTITY;
+      ? SubscriptionOperationTypes::UPDATED_ENTITY
+      : SubscriptionOperationTypes::NEW_ENTITY;
 
     $form_id = $form_state->getFormObject()->getFormId();
     $route_name = $this->routeMatch->getRouteName();

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/src/MessageSubscriptionHelper.php
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/src/MessageSubscriptionHelper.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Drupal\eic_message_subscriptions;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\eic_groups\GroupsModerationHelper;
+use Drupal\group\Entity\GroupContent;
+
+/**
+ * Provides helper methods for message subscriptions.
+ *
+ * @package Drupal\eic_message_subscriptions
+ */
+class MessageSubscriptionHelper {
+
+  /**
+   * Check if an entity can trigger message subscriptions.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity object.
+   *
+   * @return bool
+   *   TRUE if the entity can trigger message subscriptions.
+   */
+  public function isMessageSubscriptionApplicable(EntityInterface $entity) {
+    $is_applicable = TRUE;
+    $in_group_context = FALSE;
+
+    switch ($entity->getEntityTypeId()) {
+      case 'comment':
+        // Get commented entity.
+        $commented_entity = $entity->getCommentedEntity();
+
+        // Loads group contents for the commented entity.
+        $group_contents = GroupContent::loadByEntity($commented_entity);
+
+        if (!empty($group_contents)) {
+          break;
+        }
+
+        $group_content = reset($group_contents);
+
+        $in_group_context = TRUE;
+        break;
+
+    }
+
+    // If the entity is in the context of a group we need to make sure the
+    // group is not in pending or draft state.
+    if ($in_group_context && isset($group_content)) {
+      $group_content_plugin_id = $entity->getContentPlugin()->getPluginId();
+
+      // Group content plugins other than group_node cannot trigger
+      // notifications.
+      if (strpos($group_content_plugin_id, 'group_node:') === FALSE) {
+        return FALSE;
+      }
+
+      // Group book pages cannot trigger notifications.
+      if (strpos($group_content_plugin_id, 'group_node:book') !== FALSE) {
+        return FALSE;
+      }
+
+      // If entity is not publish, it cannot trigger notifications.
+      if (!$group_content->getEntity()->isPublished()) {
+        return FALSE;
+      }
+
+      $group = $entity->getGroup();
+
+      $moderation_state = $group->get('moderation_state')->value;
+
+      $is_applicable = !in_array(
+        $moderation_state,
+        [
+          GroupsModerationHelper::GROUP_PENDING_STATE,
+          GroupsModerationHelper::GROUP_DRAFT_STATE,
+        ]
+      );
+    }
+
+    return $is_applicable;
+  }
+
+}

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/src/MessageSubscriptionHelper.php
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/src/MessageSubscriptionHelper.php
@@ -39,7 +39,11 @@ class MessageSubscriptionHelper {
         }
 
         $group_content = reset($group_contents);
+        $in_group_context = TRUE;
+        break;
 
+      case 'group_content':
+        $group_content = $entity;
         $in_group_context = TRUE;
         break;
 
@@ -48,7 +52,7 @@ class MessageSubscriptionHelper {
     // If the entity is in the context of a group we need to make sure the
     // group is not in pending or draft state.
     if ($in_group_context && isset($group_content)) {
-      $group_content_plugin_id = $entity->getContentPlugin()->getPluginId();
+      $group_content_plugin_id = $group_content->getContentPlugin()->getPluginId();
 
       // Group content plugins other than group_node cannot trigger
       // notifications.

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/src/MessageSubscriptionType.php
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/src/MessageSubscriptionType.php
@@ -15,4 +15,6 @@ final class MessageSubscriptionType {
 
   const NEW_GROUP_CONTENT_PUBLISHED = 'sub_new_group_content_published';
 
+  const GROUP_CONTENT_UPDATED = 'sub_group_content_updated';
+
 }

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/src/MessageSubscriptionType.php
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/src/MessageSubscriptionType.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Drupal\eic_message_subscriptions;
+
+/**
+ * Represents Message Subscription types.
+ *
+ * @package Drupal\eic_message_subscriptions
+ */
+final class MessageSubscriptionType {
+
+  const NEW_COMMENT_REPLY = 'sub_new_comment_reply';
+
+  const NEW_COMMENT = 'sub_new_comment_on_content';
+
+  const NEW_GROUP_CONTENT_PUBLISHED = 'sub_new_group_content_published';
+
+}

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/src/MessageSubscriptionTypes.php
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/src/MessageSubscriptionTypes.php
@@ -17,4 +17,8 @@ final class MessageSubscriptionTypes {
 
   const GROUP_CONTENT_UPDATED = 'sub_group_content_updated';
 
+  const NODE_PUBLISHED = 'sub_content_interest_published';
+
+  const NODE_UPDATED = NULL;
+
 }

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/src/MessageSubscriptionTypes.php
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/src/MessageSubscriptionTypes.php
@@ -7,7 +7,7 @@ namespace Drupal\eic_message_subscriptions;
  *
  * @package Drupal\eic_message_subscriptions
  */
-final class MessageSubscriptionType {
+final class MessageSubscriptionTypes {
 
   const NEW_COMMENT_REPLY = 'sub_new_comment_reply';
 

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/src/SubscriptionOperationType.php
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/src/SubscriptionOperationType.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Drupal\eic_message_subscriptions;
+
+/**
+ * Represents entity operations to triggers message subscriptions.
+ *
+ * @package Drupal\eic_message_subscriptions
+ */
+final class SubscriptionOperationType {
+
+  const NEW_ENTITY = 'created';
+
+  const UPDATED_ENTITY = 'updated';
+
+  const COMMENT_REPLY = 'comment_reply';
+
+}

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/src/SubscriptionOperationTypes.php
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/src/SubscriptionOperationTypes.php
@@ -7,7 +7,7 @@ namespace Drupal\eic_message_subscriptions;
  *
  * @package Drupal\eic_message_subscriptions
  */
-final class SubscriptionOperationType {
+final class SubscriptionOperationTypes {
 
   const NEW_ENTITY = 'created';
 

--- a/lib/modules/eic_messages/src/Service/CommentMessageCreator.php
+++ b/lib/modules/eic_messages/src/Service/CommentMessageCreator.php
@@ -5,16 +5,24 @@ namespace Drupal\eic_messages\Service;
 use Drupal\comment\CommentInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\eic_content\EICContentHelperInterface;
+use Drupal\eic_message_subscriptions\MessageSubscriptionType;
+use Drupal\eic_message_subscriptions\SubscriptionOperationType;
 use Drupal\eic_messages\MessageHelper;
 use Drupal\eic_messages\Util\ActivityStreamMessageTemplates;
 use Drupal\eic_user\UserHelper;
+use Drupal\message\Entity\Message;
+use Drupal\user\UserInterface;
 
 /**
- * Class CommentMessageCreator.
+ * Provides a message creator class for comments.
+ *
+ * @package Drupal\eic_messages
  */
 class CommentMessageCreator extends MessageCreatorBase {
 
   /**
+   * The EIC Content helper service.
+   *
    * @var \Drupal\eic_content\EICContentHelperInterface
    */
   private $contentHelper;
@@ -23,9 +31,13 @@ class CommentMessageCreator extends MessageCreatorBase {
    * CommentMessageCreator constructor.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
    * @param \Drupal\eic_messages\MessageHelper $eic_messages_helper
+   *   The EIC Message helper service.
    * @param \Drupal\eic_user\UserHelper $eic_user_helper
+   *   The EIC User helper service.
    * @param \Drupal\eic_content\EICContentHelperInterface $content_helper
+   *   The EIC Content helper service.
    */
   public function __construct(
     EntityTypeManagerInterface $entity_type_manager,
@@ -39,12 +51,12 @@ class CommentMessageCreator extends MessageCreatorBase {
   }
 
   /**
-   * Creates an activity stream message for a comment on a content inside a group.
+   * Creates an activity stream message for a comment that belongs to a group.
    *
-   * @param CommentInterface $entity
+   * @param \Drupal\comment\CommentInterface $entity
    *   The group having this content.
    * @param string $operation
-   *   The type of the operation. See ActivityStreamOperationTypes
+   *   The type of the operation. See ActivityStreamOperationTypes.
    */
   public function createCommentActivity(
     CommentInterface $entity,
@@ -64,7 +76,7 @@ class CommentMessageCreator extends MessageCreatorBase {
 
     $group_content = reset($group_content);
     $group = $group_content->getGroup();
-    $message = \Drupal::entityTypeManager()->getStorage('message')->create([
+    $message = $this->entityTypeManager->getStorage('message')->create([
       'template' => ActivityStreamMessageTemplates::getTemplate($entity),
       'field_referenced_comment' => $entity,
       'field_referenced_node' => $commented_entity,
@@ -75,10 +87,75 @@ class CommentMessageCreator extends MessageCreatorBase {
 
     try {
       $message->save();
-    } catch (\Exception $e) {
+    }
+    catch (\Exception $e) {
       $logger = $this->getLogger('eic_messages');
       $logger->error($e->getMessage());
     }
+  }
+
+  /**
+   * Creates a subscription message for a comment.
+   *
+   * @param \Drupal\comment\CommentInterface $entity
+   *   The comment entity.
+   * @param \Drupal\user\UserInterface $user
+   *   The user entity that is subscribed to the content.
+   * @param string $operation
+   *   The type of the operation. See SubscriptionOperationType.
+   */
+  public function createCommentSubscription(
+    CommentInterface $entity,
+    UserInterface $user,
+    string $operation
+  ) {
+    $message_type = NULL;
+
+    switch ($operation) {
+      case SubscriptionOperationType::NEW_ENTITY:
+        $message_type = MessageSubscriptionType::NEW_COMMENT;
+        break;
+
+      case SubscriptionOperationType::COMMENT_REPLY:
+        $message_type = MessageSubscriptionType::NEW_COMMENT_REPLY;
+        break;
+
+    }
+
+    if (!$message_type) {
+      return NULL;
+    }
+
+    $message = Message::create([
+      'template' => $message_type,
+      'uid' => $user->id(),
+    ]);
+
+    // Adds the reference to the user who created/updated the entity.
+    if ($message->hasField('field_event_executing_user')) {
+      $executing_user_id = $entity->getOwnerId();
+
+      $vid = $this->entityTypeManager->getStorage($entity->getEntityTypeId())
+        ->getLatestRevisionId($entity->id());
+
+      if ($vid) {
+        $latest_revision = $this->entityTypeManager->getStorage($entity->getEntityTypeId())
+          ->loadRevision($vid);
+        $executing_user_id = $latest_revision->getOwnerId();
+      }
+
+      $message->set('field_event_executing_user', $executing_user_id);
+    }
+
+    try {
+      $message->save();
+    }
+    catch (\Exception $e) {
+      $logger = $this->getLogger('eic_messages');
+      $logger->error($e->getMessage());
+    }
+
+    return $message;
   }
 
 }

--- a/lib/modules/eic_messages/src/Service/CommentMessageCreator.php
+++ b/lib/modules/eic_messages/src/Service/CommentMessageCreator.php
@@ -129,6 +129,7 @@ class CommentMessageCreator extends MessageCreatorBase {
     $message = Message::create([
       'template' => $message_type,
       'uid' => $user->id(),
+      'field_referenced_comment' => $entity,
     ]);
 
     // Adds the reference to the user who created/updated the entity.
@@ -145,14 +146,6 @@ class CommentMessageCreator extends MessageCreatorBase {
       }
 
       $message->set('field_event_executing_user', $executing_user_id);
-    }
-
-    try {
-      $message->save();
-    }
-    catch (\Exception $e) {
-      $logger = $this->getLogger('eic_messages');
-      $logger->error($e->getMessage());
     }
 
     return $message;

--- a/lib/modules/eic_messages/src/Service/CommentMessageCreator.php
+++ b/lib/modules/eic_messages/src/Service/CommentMessageCreator.php
@@ -5,8 +5,8 @@ namespace Drupal\eic_messages\Service;
 use Drupal\comment\CommentInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\eic_content\EICContentHelperInterface;
-use Drupal\eic_message_subscriptions\MessageSubscriptionType;
-use Drupal\eic_message_subscriptions\SubscriptionOperationType;
+use Drupal\eic_message_subscriptions\MessageSubscriptionTypes;
+use Drupal\eic_message_subscriptions\SubscriptionOperationTypes;
 use Drupal\eic_messages\MessageHelper;
 use Drupal\eic_messages\Util\ActivityStreamMessageTemplates;
 use Drupal\eic_user\UserHelper;
@@ -102,7 +102,7 @@ class CommentMessageCreator extends MessageCreatorBase {
    * @param \Drupal\user\UserInterface $user
    *   The user entity that is subscribed to the content.
    * @param string $operation
-   *   The type of the operation. See SubscriptionOperationType.
+   *   The type of the operation. See SubscriptionOperationTypes.
    */
   public function createCommentSubscription(
     CommentInterface $entity,
@@ -112,12 +112,12 @@ class CommentMessageCreator extends MessageCreatorBase {
     $message_type = NULL;
 
     switch ($operation) {
-      case SubscriptionOperationType::NEW_ENTITY:
-        $message_type = MessageSubscriptionType::NEW_COMMENT;
+      case SubscriptionOperationTypes::NEW_ENTITY:
+        $message_type = MessageSubscriptionTypes::NEW_COMMENT;
         break;
 
-      case SubscriptionOperationType::COMMENT_REPLY:
-        $message_type = MessageSubscriptionType::NEW_COMMENT_REPLY;
+      case SubscriptionOperationTypes::COMMENT_REPLY:
+        $message_type = MessageSubscriptionTypes::NEW_COMMENT_REPLY;
         break;
 
     }

--- a/lib/modules/eic_messages/src/Service/CommentMessageCreator.php
+++ b/lib/modules/eic_messages/src/Service/CommentMessageCreator.php
@@ -11,7 +11,6 @@ use Drupal\eic_messages\MessageHelper;
 use Drupal\eic_messages\Util\ActivityStreamMessageTemplates;
 use Drupal\eic_user\UserHelper;
 use Drupal\message\Entity\Message;
-use Drupal\user\UserInterface;
 
 /**
  * Provides a message creator class for comments.
@@ -99,14 +98,11 @@ class CommentMessageCreator extends MessageCreatorBase {
    *
    * @param \Drupal\comment\CommentInterface $entity
    *   The comment entity.
-   * @param \Drupal\user\UserInterface $user
-   *   The user entity that is subscribed to the content.
    * @param string $operation
    *   The type of the operation. See SubscriptionOperationTypes.
    */
   public function createCommentSubscription(
     CommentInterface $entity,
-    UserInterface $user,
     string $operation
   ) {
     $message_type = NULL;
@@ -128,7 +124,6 @@ class CommentMessageCreator extends MessageCreatorBase {
 
     $message = Message::create([
       'template' => $message_type,
-      'uid' => $user->id(),
       'field_referenced_comment' => $entity,
     ]);
 

--- a/lib/modules/eic_messages/src/Service/GroupContentMessageCreator.php
+++ b/lib/modules/eic_messages/src/Service/GroupContentMessageCreator.php
@@ -4,8 +4,8 @@ namespace Drupal\eic_messages\Service;
 
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\eic_message_subscriptions\MessageSubscriptionType;
-use Drupal\eic_message_subscriptions\SubscriptionOperationType;
+use Drupal\eic_message_subscriptions\MessageSubscriptionTypes;
+use Drupal\eic_message_subscriptions\SubscriptionOperationTypes;
 use Drupal\eic_messages\Util\ActivityStreamMessageTemplates;
 use Drupal\group\Entity\GroupInterface;
 use Drupal\message\Entity\Message;
@@ -129,7 +129,7 @@ class GroupContentMessageCreator extends MessageCreatorBase {
    * @param \Drupal\user\UserInterface $user
    *   The user entity that is subscribed to the content.
    * @param string $operation
-   *   The type of the operations. See SubscriptionOperationType.
+   *   The type of the operations. See SubscriptionOperationTypes.
    */
   public function createGroupContentSubscription(
     ContentEntityInterface $entity,
@@ -141,9 +141,9 @@ class GroupContentMessageCreator extends MessageCreatorBase {
 
     switch ($entity->getEntityTypeId()) {
       case 'node':
-        $message_type = $operation === SubscriptionOperationType::UPDATED_ENTITY
-          ? MessageSubscriptionType::GROUP_CONTENT_UPDATED
-          : MessageSubscriptionType::NEW_GROUP_CONTENT_PUBLISHED;
+        $message_type = $operation === SubscriptionOperationTypes::UPDATED_ENTITY
+          ? MessageSubscriptionTypes::GROUP_CONTENT_UPDATED
+          : MessageSubscriptionTypes::NEW_GROUP_CONTENT_PUBLISHED;
 
         $message = Message::create([
           'template' => $message_type,

--- a/lib/modules/eic_messages/src/Service/GroupContentMessageCreator.php
+++ b/lib/modules/eic_messages/src/Service/GroupContentMessageCreator.php
@@ -4,13 +4,37 @@ namespace Drupal\eic_messages\Service;
 
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\eic_message_subscriptions\MessageSubscriptionType;
+use Drupal\eic_message_subscriptions\SubscriptionOperationType;
 use Drupal\eic_messages\Util\ActivityStreamMessageTemplates;
 use Drupal\group\Entity\GroupInterface;
+use Drupal\message\Entity\Message;
+use Drupal\user\UserInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides a message creator class for group content.
+ *
+ * @package Drupal\eic_messages
  */
 class GroupContentMessageCreator extends MessageCreatorBase {
+
+  /**
+   * The Flag sevice.
+   *
+   * @var \Drupal\flag\FlagServiceInterface
+   */
+  protected $flagService;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    /** @var static $service */
+    $service = parent::create($container);
+    $service->flagService = $container->get('flag');
+    return $service;
+  }
 
   /**
    * Implements hook_group_content_insert().
@@ -45,7 +69,7 @@ class GroupContentMessageCreator extends MessageCreatorBase {
       $relatedGroup = $entity->getGroup();
 
       // Prepare the message to the group owner.
-      $message = \Drupal::entityTypeManager()->getStorage('message')->create([
+      $message = $this->entityTypeManager->getStorage('message')->create([
         'template' => 'notify_new_membership_request',
         'uid' => $relatedGroup->getOwnerId(),
         'field_group_ref' => ['target_id' => $relatedGroup->id()],
@@ -76,7 +100,7 @@ class GroupContentMessageCreator extends MessageCreatorBase {
     $message = NULL;
     switch ($entity->getEntityTypeId()) {
       case 'node':
-        $message = \Drupal::entityTypeManager()->getStorage('message')->create([
+        $message = $this->entityTypeManager->getStorage('message')->create([
           'template' => ActivityStreamMessageTemplates::getTemplate($entity),
           'field_referenced_node' => $entity,
           'field_operation_type' => $operation,
@@ -93,6 +117,69 @@ class GroupContentMessageCreator extends MessageCreatorBase {
       $logger = $this->getLogger('eic_messages');
       $logger->error($e->getMessage());
     }
+  }
+
+  /**
+   * Creates an subscription message for an entity inside a group.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity object.
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group having this content.
+   * @param \Drupal\user\UserInterface $user
+   *   The user entity that is subscribed to the content.
+   * @param string $operation
+   *   The type of the operations. See SubscriptionOperationType.
+   */
+  public function createGroupContentSubscription(
+    ContentEntityInterface $entity,
+    GroupInterface $group,
+    UserInterface $user,
+    string $operation
+  ) {
+    $message = NULL;
+
+    switch ($entity->getEntityTypeId()) {
+      case 'node':
+        $message_type = $operation === SubscriptionOperationType::UPDATED_ENTITY
+          ? MessageSubscriptionType::GROUP_CONTENT_UPDATED
+          : MessageSubscriptionType::NEW_GROUP_CONTENT_PUBLISHED;
+
+        $message = Message::create([
+          'template' => $message_type,
+          'uid' => $user->id(),
+        ]);
+
+        // Adds the reference to the user who created/updated the entity.
+        if ($message->hasField('field_event_executing_user')) {
+          $executing_user_id = $entity->getOwnerId();
+
+          $vid = $this->entityTypeManager->getStorage($entity->getEntityTypeId())
+            ->getLatestRevisionId($entity->id());
+
+          if ($vid) {
+            $latest_revision = $this->entityTypeManager->getStorage($entity->getEntityTypeId())
+              ->loadRevision($vid);
+            $executing_user_id = $latest_revision->getOwnerId();
+          }
+
+          $message->set('field_event_executing_user', $executing_user_id);
+        }
+
+        // @todo Set values for the missing fields.
+        break;
+
+    }
+
+    try {
+      $message->save();
+    }
+    catch (\Exception $e) {
+      $logger = $this->getLogger('eic_messages');
+      $logger->error($e->getMessage());
+    }
+
+    return $message;
   }
 
 }

--- a/lib/modules/eic_messages/src/Service/GroupContentMessageCreator.php
+++ b/lib/modules/eic_messages/src/Service/GroupContentMessageCreator.php
@@ -148,6 +148,7 @@ class GroupContentMessageCreator extends MessageCreatorBase {
         $message = Message::create([
           'template' => $message_type,
           'uid' => $user->id(),
+          'field_referenced_node' => $entity,
         ]);
 
         // Adds the reference to the user who created/updated the entity.
@@ -169,14 +170,6 @@ class GroupContentMessageCreator extends MessageCreatorBase {
         // @todo Set values for the missing fields.
         break;
 
-    }
-
-    try {
-      $message->save();
-    }
-    catch (\Exception $e) {
-      $logger = $this->getLogger('eic_messages');
-      $logger->error($e->getMessage());
     }
 
     return $message;

--- a/lib/modules/eic_messages/src/Service/GroupContentMessageCreator.php
+++ b/lib/modules/eic_messages/src/Service/GroupContentMessageCreator.php
@@ -9,7 +9,6 @@ use Drupal\eic_message_subscriptions\SubscriptionOperationTypes;
 use Drupal\eic_messages\Util\ActivityStreamMessageTemplates;
 use Drupal\group\Entity\GroupInterface;
 use Drupal\message\Entity\Message;
-use Drupal\user\UserInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -126,15 +125,12 @@ class GroupContentMessageCreator extends MessageCreatorBase {
    *   The entity object.
    * @param \Drupal\group\Entity\GroupInterface $group
    *   The group having this content.
-   * @param \Drupal\user\UserInterface $user
-   *   The user entity that is subscribed to the content.
    * @param string $operation
    *   The type of the operations. See SubscriptionOperationTypes.
    */
   public function createGroupContentSubscription(
     ContentEntityInterface $entity,
     GroupInterface $group,
-    UserInterface $user,
     string $operation
   ) {
     $message = NULL;
@@ -147,7 +143,6 @@ class GroupContentMessageCreator extends MessageCreatorBase {
 
         $message = Message::create([
           'template' => $message_type,
-          'uid' => $user->id(),
           'field_referenced_node' => $entity,
         ]);
 

--- a/lib/modules/eic_messages/src/Service/GroupContentMessageCreator.php
+++ b/lib/modules/eic_messages/src/Service/GroupContentMessageCreator.php
@@ -9,7 +9,6 @@ use Drupal\eic_message_subscriptions\SubscriptionOperationTypes;
 use Drupal\eic_messages\Util\ActivityStreamMessageTemplates;
 use Drupal\group\Entity\GroupInterface;
 use Drupal\message\Entity\Message;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides a message creator class for group content.
@@ -17,23 +16,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @package Drupal\eic_messages
  */
 class GroupContentMessageCreator extends MessageCreatorBase {
-
-  /**
-   * The Flag sevice.
-   *
-   * @var \Drupal\flag\FlagServiceInterface
-   */
-  protected $flagService;
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    /** @var static $service */
-    $service = parent::create($container);
-    $service->flagService = $container->get('flag');
-    return $service;
-  }
 
   /**
    * Implements hook_group_content_insert().
@@ -119,7 +101,7 @@ class GroupContentMessageCreator extends MessageCreatorBase {
   }
 
   /**
-   * Creates an subscription message for an entity inside a group.
+   * Creates a subscription message for an entity inside a group.
    *
    * @param \Drupal\Core\Entity\ContentEntityInterface $entity
    *   The entity object.

--- a/lib/modules/eic_messages/src/Service/NodeMessageCreator.php
+++ b/lib/modules/eic_messages/src/Service/NodeMessageCreator.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Drupal\eic_messages\Service;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\eic_message_subscriptions\MessageSubscriptionTypes;
+use Drupal\eic_message_subscriptions\SubscriptionOperationTypes;
+use Drupal\group\Entity\GroupContent;
+use Drupal\message\Entity\Message;
+
+/**
+ * Provides a message creator class for group content.
+ *
+ * @package Drupal\eic_messages
+ */
+class NodeMessageCreator extends MessageCreatorBase {
+
+  /**
+   * Creates a subscription message for a node with terms of interest.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity object.
+   * @param string $operation
+   *   The type of the operations. See SubscriptionOperationTypes.
+   */
+  public function createTermsOfInterestNodeSubscription(
+    ContentEntityInterface $entity,
+    string $operation
+  ) {
+    $message = NULL;
+
+    switch ($entity->getEntityTypeId()) {
+      case 'node':
+        $message_type = $operation === SubscriptionOperationTypes::NEW_ENTITY
+          ? MessageSubscriptionTypes::NODE_PUBLISHED
+          : MessageSubscriptionTypes::NODE_UPDATED;
+
+        // We only create subscription message if the operation is 'created'.
+        if (!$message_type) {
+          break;
+        }
+
+        $message = Message::create([
+          'template' => $message_type,
+          'field_node_ref' => $entity,
+        ]);
+
+        $group_contents = GroupContent::loadByEntity($entity);
+
+        if (!empty($group_contents)) {
+          $group_content = reset($group_contents);
+          $group = $group_content->getGroup();
+          // Adds reference to group.
+          $message->set('field_group_ref', $group);
+        }
+
+        // Adds the reference to the user who created/updated the entity.
+        if ($message->hasField('field_event_executing_user')) {
+          $executing_user_id = $entity->getOwnerId();
+
+          $vid = $this->entityTypeManager->getStorage($entity->getEntityTypeId())
+            ->getLatestRevisionId($entity->id());
+
+          if ($vid) {
+            $latest_revision = $this->entityTypeManager->getStorage($entity->getEntityTypeId())
+              ->loadRevision($vid);
+            $executing_user_id = $latest_revision->getOwnerId();
+          }
+
+          $message->set('field_event_executing_user', $executing_user_id);
+        }
+        break;
+
+    }
+
+    return $message;
+  }
+
+}

--- a/lib/themes/eic_community/includes/preprocess/common.inc
+++ b/lib/themes/eic_community/includes/preprocess/common.inc
@@ -51,19 +51,10 @@ function _eic_community_get_flag_access($flag_id, EntityInterface $entity) {
     return TRUE;
   }
 
+  // Check if we have a flagging for this user and entity. If we have one we
+  // check if the user can unflag, otherwise we check if the user can flag.
   $user_flag = $flag_service->getFlagging($flag, $entity);
+  $action = $user_flag ? 'unflag' : 'flag';
 
-  // We need to create a fake flag if the user never flagged the content,
-  // otherwise we can't do an access check.
-  if (!$user_flag) {
-    $user_flag = \Drupal::entityTypeManager()->getStorage('flagging')->create([
-      'uid' => \Drupal::currentUser()->id(),
-      'flag_id' => $flag->id(),
-      'entity_id' => $entity->id(),
-      'entity_type' => $entity->getEntityTypeId(),
-      'global' => $flag->isGlobal(),
-    ]);
-  }
-
-  return $user_flag->access('view');
+  return $flag->actionAccess($action);
 }


### PR DESCRIPTION
### New features

- Send subscription messages on comment creation (MT16, MT19);
- Send subscription messages on group content published/updated (MT18, MT20);
- Send subscription messages of Content published about Terms of Interest (MT23).

### Tests

- [x] Create a new public group and publish it
- [x] As TU, follow the group
- [x] As GO/GA, add new discussion and check the option to "Send notification"
- [x] Check if the TU received an email notification (SUBSCRIPTION :: MT18)
- [x] As GO/GA, edit the discussion and check the option to "Send notification"
- [x] As TU, follow the discussion node
- [x] Check if the TU received an email notification (SUBSCRIPTION :: MT20)
- [x] As GO/GA, add a new comment in the discussion
- [x] Make sure the TU didn't receive any notification
- [x] As TU, follow the discussion node
- [x] As GO/GA, add a new comment in the discussion
- [x] Check if the TU received an email notification (SUBSCRIPTION :: MT19)
- [x] As GO/GA, add a new comment **reply** in the discussion
- [x] Check if the TU received an email notification (SUBSCRIPTION :: MT16)

### Todo

- Define the notifications workflow for every message subscription type.

### Needs discussion

- Currently it is using a custom cache to save the group content nodes that will need to trigger a subscription after the node has been created. We could probably use state API instead. **Update**: this has been tackled in #668.