### PR TITLE
Feature/eicnet 1323 sort by last commented

### DIFF
--- a/config/sync/context.context.group_discussions_overviews.yml
+++ b/config/sync/context.context.group_discussions_overviews.yml
@@ -51,6 +51,7 @@ reactions:
           its_flag_highlight_content: its_flag_highlight_content
           timestamp: timestamp
           ss_global_title: ss_global_title
+          its_last_comment_timestamp: its_last_comment_timestamp
           its_last_flagged_like_content: its_last_flagged_like_content
         source_type: Drupal\eic_search\Search\Sources\DiscussionSourceType
         enable_search: 1

--- a/config/sync/context.context.group_discussions_overviews.yml
+++ b/config/sync/context.context.group_discussions_overviews.yml
@@ -51,6 +51,7 @@ reactions:
           its_flag_highlight_content: its_flag_highlight_content
           timestamp: timestamp
           ss_global_title: ss_global_title
+          dm_aggregated_changed: dm_aggregated_changed
           its_last_comment_timestamp: its_last_comment_timestamp
           its_last_flagged_like_content: its_last_flagged_like_content
         source_type: Drupal\eic_search\Search\Sources\DiscussionSourceType

--- a/config/sync/context.context.group_files_overviews.yml
+++ b/config/sync/context.context.group_files_overviews.yml
@@ -8,7 +8,7 @@ dependencies:
 name: group_files_overviews
 label: 'Group - Files - Overviews'
 group: Groups
-description: ''
+description: 'This context is used for all group files overviews'
 requireAllConditions: false
 disabled: false
 conditions:
@@ -38,6 +38,7 @@ reactions:
           its_flag_highlight_content: its_flag_highlight_content
           ss_global_created_date: ss_global_created_date
           ss_global_title: ss_global_title
+          its_last_comment_timestamp: its_last_comment_timestamp
           its_last_flagged_like_content: its_last_flagged_like_content
         source_type: Drupal\eic_search\Search\Sources\LibrarySourceType
         enable_search: 1

--- a/config/sync/context.context.group_files_overviews.yml
+++ b/config/sync/context.context.group_files_overviews.yml
@@ -38,6 +38,7 @@ reactions:
           its_flag_highlight_content: its_flag_highlight_content
           ss_global_created_date: ss_global_created_date
           ss_global_title: ss_global_title
+          dm_aggregated_changed: dm_aggregated_changed
           its_last_comment_timestamp: its_last_comment_timestamp
           its_last_flagged_like_content: its_last_flagged_like_content
         source_type: Drupal\eic_search\Search\Sources\LibrarySourceType

--- a/config/sync/context.context.group_search.yml
+++ b/config/sync/context.context.group_search.yml
@@ -49,6 +49,7 @@ reactions:
         sort_options:
           ss_global_created_date: ss_global_created_date
           ss_global_title: ss_global_title
+          dm_aggregated_changed: dm_aggregated_changed
           its_last_comment_timestamp: its_last_comment_timestamp
           its_last_flagged_like_content: its_last_flagged_like_content
           ss_group_user_fullname: 0

--- a/config/sync/context.context.group_search.yml
+++ b/config/sync/context.context.group_search.yml
@@ -49,6 +49,7 @@ reactions:
         sort_options:
           ss_global_created_date: ss_global_created_date
           ss_global_title: ss_global_title
+          its_last_comment_timestamp: its_last_comment_timestamp
           its_last_flagged_like_content: its_last_flagged_like_content
           ss_group_user_fullname: 0
         source_type: Drupal\eic_search\Search\Sources\GlobalSourceType

--- a/config/sync/search_api.index.global.yml
+++ b/config/sync/search_api.index.global.yml
@@ -108,6 +108,15 @@ name: Global
 description: ''
 read_only: false
 field_settings:
+  aggregated_changed:
+    label: '[Aggregated] Changed on'
+    property_path: aggregated_field
+    type: date
+    configuration:
+      type: union
+      fields:
+        - 'entity:group/changed'
+        - 'entity:node/changed'
   aggregated_created:
     label: '[Aggregated] Created on'
     property_path: aggregated_field

--- a/config/sync/search_api.index.global.yml
+++ b/config/sync/search_api.index.global.yml
@@ -717,6 +717,14 @@ field_settings:
       module:
         - group
         - user
+  last_comment_timestamp:
+    label: '[Content] Comments » Last comment timestamp'
+    datasource_id: 'entity:node'
+    property_path: 'field_comments:last_comment_timestamp'
+    type: integer
+    dependencies:
+      config:
+        - field.storage.node.field_comments
   message_id:
     label: 'Message ID'
     datasource_id: 'entity:message'

--- a/lib/modules/eic_search/src/Search/Sources/DiscussionSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/DiscussionSourceType.php
@@ -67,6 +67,10 @@ class DiscussionSourceType extends SourceType {
         'ASC' => $this->t('Title A-Z', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Title Z-A', [], ['context' => 'eic_search']),
       ],
+      'its_last_comment_timestamp' => [
+        'label' => $this->t('Last commented', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Last commented', [], ['context' => 'eic_search']),
+      ],
       'its_' . SolrDocumentProcessor::LAST_FLAGGED_KEY . '_' . FlagType::LIKE_CONTENT => [
         'label' => $this->t('Last liked', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Last liked', [], ['context' => 'eic_search']),

--- a/lib/modules/eic_search/src/Search/Sources/DiscussionSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/DiscussionSourceType.php
@@ -67,6 +67,10 @@ class DiscussionSourceType extends SourceType {
         'ASC' => $this->t('Title A-Z', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Title Z-A', [], ['context' => 'eic_search']),
       ],
+      'dm_aggregated_changed' => [
+        'label' => $this->t('Last updated', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Last updated', [], ['context' => 'eic_search']),
+      ],
       'its_last_comment_timestamp' => [
         'label' => $this->t('Last commented', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Last commented', [], ['context' => 'eic_search']),

--- a/lib/modules/eic_search/src/Search/Sources/GlobalSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/GlobalSourceType.php
@@ -76,6 +76,10 @@ class GlobalSourceType extends SourceType {
         'ASC' => $this->t('Min download', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Max download', [], ['context' => 'eic_search']),
       ],
+      'its_last_comment_timestamp' => [
+        'label' => $this->t('Last commented', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Last commented', [], ['context' => 'eic_search']),
+      ],
       'its_' . SolrDocumentProcessor::LAST_FLAGGED_KEY . '_' . FlagType::LIKE_CONTENT => [
         'label' => $this->t('Last liked', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Last liked', [], ['context' => 'eic_search']),

--- a/lib/modules/eic_search/src/Search/Sources/GlobalSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/GlobalSourceType.php
@@ -76,6 +76,10 @@ class GlobalSourceType extends SourceType {
         'ASC' => $this->t('Min download', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Max download', [], ['context' => 'eic_search']),
       ],
+      'dm_aggregated_changed' => [
+        'label' => $this->t('Last updated', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Last updated', [], ['context' => 'eic_search']),
+      ],
       'its_last_comment_timestamp' => [
         'label' => $this->t('Last commented', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Last commented', [], ['context' => 'eic_search']),

--- a/lib/modules/eic_search/src/Search/Sources/LibrarySourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/LibrarySourceType.php
@@ -71,6 +71,10 @@ class LibrarySourceType extends SourceType {
         'ASC' => $this->t('Title A-Z', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Title Z-A', [], ['context' => 'eic_search']),
       ],
+      'its_last_comment_timestamp' => [
+        'label' => $this->t('Last commented', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Last commented', [], ['context' => 'eic_search']),
+      ],
       'its_' . SolrDocumentProcessor::LAST_FLAGGED_KEY . '_' . FlagType::LIKE_CONTENT => [
         'label' => $this->t('Last liked', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Last liked', [], ['context' => 'eic_search']),

--- a/lib/modules/eic_search/src/Search/Sources/LibrarySourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/LibrarySourceType.php
@@ -71,6 +71,10 @@ class LibrarySourceType extends SourceType {
         'ASC' => $this->t('Title A-Z', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Title Z-A', [], ['context' => 'eic_search']),
       ],
+      'dm_aggregated_changed' => [
+        'label' => $this->t('Last updated', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Last updated', [], ['context' => 'eic_search']),
+      ],
       'its_last_comment_timestamp' => [
         'label' => $this->t('Last commented', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Last commented', [], ['context' => 'eic_search']),

--- a/lib/modules/eic_search/src/Search/Sources/StorySourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/StorySourceType.php
@@ -70,6 +70,10 @@ class StorySourceType extends SourceType {
         'DESC' => $this->t('Most liked', [], ['context' => 'eic_search']),
         'ASC' => $this->t('Less liked', [], ['context' => 'eic_search']),
       ],
+      'its_last_comment_timestamp' => [
+        'label' => $this->t('Last commented', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Last commented', [], ['context' => 'eic_search']),
+      ],
       'its_content_comment_count' => [
         'label' => $this->t('Total comment', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Most commented', [], ['context' => 'eic_search']),

--- a/lib/modules/eic_search/src/Search/Sources/StorySourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/StorySourceType.php
@@ -70,6 +70,10 @@ class StorySourceType extends SourceType {
         'DESC' => $this->t('Most liked', [], ['context' => 'eic_search']),
         'ASC' => $this->t('Less liked', [], ['context' => 'eic_search']),
       ],
+      'dm_aggregated_changed' => [
+        'label' => $this->t('Last updated', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Last updated', [], ['context' => 'eic_search']),
+      ],
       'its_last_comment_timestamp' => [
         'label' => $this->t('Last commented', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Last commented', [], ['context' => 'eic_search']),


### PR DESCRIPTION
### Tests

**Last commented**

- [ ] Add a comment to any content in a group
- [ ] Sort by "Last commented"
- [ ] First item should be the one you commented

**Last updated**

- [ ] Update any content in a group
- [ ] Sort by "Last updtaed"
- [ ] First item should be the one you updated

### Remarks

- By default when you ceated a content, the last_commented timestamp is already filled in with the content creation timestamp event if there's no comment (this seems Drupal out-of-the-box feature)