### PR TITLE
EICNET-1283: As a GM I can edit every wiki page from my groups

### DIFF
--- a/lib/modules/eic_groups/src/EICGroupsHelper.php
+++ b/lib/modules/eic_groups/src/EICGroupsHelper.php
@@ -9,6 +9,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\eic_groups\Constants\GroupJoiningMethodType;
@@ -384,6 +385,41 @@ class EICGroupsHelper implements EICGroupsHelperInterface {
         GroupsModerationHelper::GROUP_DRAFT_STATE,
       ]
     );
+  }
+
+  /**
+   * Checks if a user is a group admin of a given group.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group entity.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The user account object.
+   *
+   * @return bool
+   *   TRUE if user is a group admin.
+   */
+  public static function userIsGroupAdmin(GroupInterface $group, AccountInterface $account) {
+    $membership = $group->getMember($account);
+    $membership_roles = $membership->getRoles();
+    $is_admin = FALSE;
+
+    foreach ($membership_roles as $role) {
+      $is_admin = in_array(
+        $role->id(),
+        [
+          self::GROUP_ADMINISTRATOR_ROLE,
+          self::GROUP_OWNER_ROLE,
+        ]
+      );
+
+      if (!$is_admin) {
+        continue;
+      }
+
+      break;
+    }
+
+    return $is_admin;
   }
 
 }


### PR DESCRIPTION
### Improvements

- Create static method in `EICGroupsHelper `to check if a user is a GO/GA of a given group.

### Tests

- [ ] As GO, create a new group
- [ ] As SA/SCM, publish the group
- [ ] As TU, join the group
- [ ] As TU, create a new wiki page and **uncheck** the option "Editable by members"
- [ ] As GO/GA, make sure you can edit the wiki page and be able change the option "Editable by members"
- [ ] As GO/GA, create another wiki page and **check** the option "Editable by members"
- [ ] As TU, make sure you can edit the wiki page but you **cannot** change the option "Editable by members" (the option should not be visible at all)
- [ ] As GO/GA, edit the wiki page and **uncheck** the option "Editable by members"
- [ ] As TU, make sure you **cannot** edit the wiki page anymore