### PR TITLE
Bugfix: Fix error in eic_community_preprocess_node__document()

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/content/node--document.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--document.inc
@@ -97,7 +97,7 @@ function eic_community_preprocess_node__document(array &$variables) {
           ],
         ],
         'mime_type' => substr(strrchr($download->get('filemime')->getString(), '/'), 1),
-        'path' => $download_url->toString(),
+        'path' => $download_url,
       ];
     }
 


### PR DESCRIPTION
### Fixes

- Call to a member function toString() on string in eic_community_preprocess_node__document().