### PR TITLE
[EICNET-1406] chore: switch to case insensitive search

### DIFF
--- a/config/sync/context.context.group_discussions_overviews.yml
+++ b/config/sync/context.context.group_discussions_overviews.yml
@@ -50,7 +50,7 @@ reactions:
         sort_options:
           its_flag_highlight_content: its_flag_highlight_content
           timestamp: timestamp
-          ss_global_title: ss_global_title
+          tm_global_title: tm_global_title
           its_last_flagged_bookmark_content: its_last_flagged_bookmark_content
           its_last_flagged_highlight_content: its_last_flagged_highlight_content
           dm_aggregated_changed: dm_aggregated_changed

--- a/config/sync/context.context.group_files_overviews.yml
+++ b/config/sync/context.context.group_files_overviews.yml
@@ -37,7 +37,7 @@ reactions:
         sort_options:
           its_flag_highlight_content: its_flag_highlight_content
           ss_global_created_date: ss_global_created_date
-          ss_global_title: ss_global_title
+          tm_global_title: tm_global_title
           its_last_flagged_bookmark_content: its_last_flagged_bookmark_content
           its_last_flagged_highlight_content: its_last_flagged_highlight_content
           dm_aggregated_changed: dm_aggregated_changed

--- a/config/sync/context.context.group_search.yml
+++ b/config/sync/context.context.group_search.yml
@@ -48,7 +48,7 @@ reactions:
           ss_group_user_fullname: 0
         sort_options:
           ss_global_created_date: ss_global_created_date
-          ss_global_title: ss_global_title
+          tm_global_title: tm_global_title
           its_last_flagged_bookmark_content: its_last_flagged_bookmark_content
           its_last_flagged_highlight_content: its_last_flagged_highlight_content
           dm_aggregated_changed: dm_aggregated_changed

--- a/config/sync/context.context.search.yml
+++ b/config/sync/context.context.search.yml
@@ -35,7 +35,7 @@ reactions:
           ss_group_user_fullname: 0
         sort_options:
           ss_global_created_date: ss_global_created_date
-          ss_global_title: ss_global_title
+          tm_global_title: tm_global_title
           ss_group_user_fullname: ss_group_user_fullname
           its_document_download_total: its_document_download_total
           its_last_flagged_like_content: its_last_flagged_like_content
@@ -59,7 +59,7 @@ reactions:
           ss_group_user_fullname: 0
         sort_options:
           ss_global_created_date: ss_global_created_date
-          ss_global_title: ss_global_title
+          tm_global_title: tm_global_title
           ss_group_user_fullname: ss_group_user_fullname
           its_document_download_total: its_document_download_total
           its_statistics_view: its_statistics_view
@@ -86,7 +86,7 @@ reactions:
           ss_group_user_fullname: 0
         sort_options:
           ss_global_created_date: ss_global_created_date
-          ss_global_title: ss_global_title
+          tm_global_title: tm_global_title
           ss_group_user_fullname: ss_group_user_fullname
           its_document_download_total: its_document_download_total
           its_statistics_view: its_statistics_view

--- a/docker/solr/7.x/schema_extra_fields.xml
+++ b/docker/solr/7.x/schema_extra_fields.xml
@@ -50,7 +50,7 @@
 <dynamicField name="ts_X3b_und_*" type="text_und" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="ts_*" type="text_und" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="false" />
 <dynamicField name="tm_X3b_und_*" type="text_und" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
-<dynamicField name="tm_*" type="text_und" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
+<dynamicField name="tm_*" type="text_lower_case" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="false" />
 <dynamicField name="tos_X3b_und_*" type="text_und" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="true" />
 <dynamicField name="tos_*" type="text_und" stored="true" indexed="true" multiValued="false" termVectors="true" omitNorms="true" />
 <dynamicField name="tom_X3b_und_*" type="text_und" stored="true" indexed="true" multiValued="true" termVectors="true" omitNorms="true" />

--- a/docker/solr/7.x/schema_extra_types.xml
+++ b/docker/solr/7.x/schema_extra_types.xml
@@ -226,3 +226,16 @@
     <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
   </analyzer>
 </fieldType>
+
+<fieldType name="text_lower_case" class="solr.TextField" positionIncrementGap="100">
+  <analyzer type="index">
+    <tokenizer class="solr.StandardTokenizerFactory"/>
+    <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords_en.txt" />
+    <filter class="solr.LowerCaseFilterFactory"/>
+  </analyzer>
+  <analyzer type="query">
+    <tokenizer class="solr.StandardTokenizerFactory"/>
+    <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords_en.txt" />
+    <filter class="solr.LowerCaseFilterFactory"/>
+  </analyzer>
+</fieldType>

--- a/lib/modules/eic_search/src/Search/Sources/DiscussionSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/DiscussionSourceType.php
@@ -62,7 +62,7 @@ class DiscussionSourceType extends SourceType {
         'ASC' => $this->t('Old', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Recent', [], ['context' => 'eic_search']),
       ],
-      'ss_global_title' => [
+      'tm_global_title' => [
         'label' => $this->t('Title', [], ['context' => 'eic_search']),
         'ASC' => $this->t('Title A-Z', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Title Z-A', [], ['context' => 'eic_search']),
@@ -95,7 +95,7 @@ class DiscussionSourceType extends SourceType {
    */
   public function getSearchFieldsId(): array {
     return [
-      'ss_global_title',
+      'tm_global_title',
       'ss_discussion_last_comment_text',
       'ss_discussion_last_comment_author',
       'ss_global_body_no_html',

--- a/lib/modules/eic_search/src/Search/Sources/GlobalSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/GlobalSourceType.php
@@ -62,7 +62,7 @@ class GlobalSourceType extends SourceType {
         'ASC' => $this->t('Old', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Recent', [], ['context' => 'eic_search']),
       ],
-      'ss_global_title' => [
+      'tm_global_title' => [
         'label' => $this->t('Title', [], ['context' => 'eic_search']),
         'ASC' => $this->t('Title A-Z', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Title Z-A', [], ['context' => 'eic_search']),
@@ -117,7 +117,7 @@ class GlobalSourceType extends SourceType {
   public function getSearchFieldsId(): array {
     return [
       'tm_X3b_en_rendered_item',
-      'ss_global_title',
+      'tm_global_title',
       'ss_global_group_parent_label',
       'sm_filename',
       'ss_global_fullname',

--- a/lib/modules/eic_search/src/Search/Sources/GroupSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/GroupSourceType.php
@@ -42,7 +42,7 @@ class GroupSourceType extends SourceType {
   public function getAvailableFacets(): array {
     return [
       'ss_group_topic_name' => $this->t('Topic', [], ['context' => 'eic_search']),
-      'ss_group_label_string' => $this->t('Group label', [], ['context' => 'eic_search']),
+      'tm_global_title' => $this->t('Group label', [], ['context' => 'eic_search']),
       'ss_group_user_fullname' => $this->t('Full name', [], ['context' => 'eic_search']),
     ];
   }
@@ -57,7 +57,7 @@ class GroupSourceType extends SourceType {
         'ASC' => $this->t('Old', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Recent', [], ['context' => 'eic_search']),
       ],
-      'ss_group_label_string' => [
+      'tm_global_title' => [
         'label' => $this->t('Group label', [], ['context' => 'eic_search']),
         'ASC' => $this->t('Group label A-Z', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Group label Z-A', [], ['context' => 'eic_search']),
@@ -79,7 +79,7 @@ class GroupSourceType extends SourceType {
    */
   public function getSearchFieldsId(): array {
     return [
-      'ss_group_label_string',
+      'tm_global_title',
     ];
   }
 

--- a/lib/modules/eic_search/src/Search/Sources/LibrarySourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/LibrarySourceType.php
@@ -66,7 +66,7 @@ class LibrarySourceType extends SourceType {
         'ASC' => $this->t('Old', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Recent', [], ['context' => 'eic_search']),
       ],
-      'ss_global_title' => [
+      'tm_global_title' => [
         'label' => $this->t('Title', [], ['context' => 'eic_search']),
         'ASC' => $this->t('Title A-Z', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Title Z-A', [], ['context' => 'eic_search']),
@@ -106,7 +106,7 @@ class LibrarySourceType extends SourceType {
    */
   public function getSearchFieldsId(): array {
     return [
-      'ss_global_title'
+      'tm_global_title'
     ];
   }
 

--- a/lib/modules/eic_search/src/Search/Sources/StorySourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/StorySourceType.php
@@ -57,7 +57,7 @@ class StorySourceType extends SourceType {
         'ASC' => $this->t('Old', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Recent', [], ['context' => 'eic_search']),
       ],
-      'ss_global_title' => [
+      'tm_global_title' => [
         'label' => $this->t('Title', [], ['context' => 'eic_search']),
         'ASC' => $this->t('Title A-Z', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Title Z-A', [], ['context' => 'eic_search']),
@@ -105,7 +105,7 @@ class StorySourceType extends SourceType {
    */
   public function getSearchFieldsId(): array {
     return [
-      'ss_global_title',
+      'tm_global_title',
       'tm_X3b_en_rendered_item',
       'ss_content_first_name',
       'ss_content_last_name',

--- a/lib/modules/eic_search/src/Service/SolrDocumentProcessor.php
+++ b/lib/modules/eic_search/src/Service/SolrDocumentProcessor.php
@@ -134,7 +134,7 @@ class SolrDocumentProcessor {
         }
         break;
       case 'entity:group':
-        $title = $fields['ss_group_label_string'];
+        $title = $fields['tm_X3b_en_group_label_fulltext'];
         $type = 'group';
         $date = $fields['ds_group_created'];
         $status = $fields['bs_group_status'];
@@ -203,7 +203,7 @@ class SolrDocumentProcessor {
     }
 
     //We need to use only one field key for the global search on the FE side
-    $document->addField('ss_global_title', $title);
+    $document->addField('tm_global_title', $title);
     $document->addField('ss_global_content_type', $type);
     $document->addField('ss_global_created_date', $date);
     $document->addField('bs_global_status', $status);

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/DiscussionResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/DiscussionResultItem.js
@@ -84,7 +84,7 @@ class DiscussionResultItem extends React.Component {
               </div>
 
               <h3 className="ecl-discussion-thread__title">
-                <a href={this.props.result.ss_url} className="ecl-link ecl-link--standalone">{this.props.result.ss_global_title}</a></h3>
+                <a href={this.props.result.ss_url} className="ecl-link ecl-link--standalone">{this.props.result.tm_global_title}</a></h3>
               <p className="ecl-discussion-thread__description">{this.props.result.ss_global_body_no_html && this.props.result.ss_global_body_no_html.replaceAll('/n', '')}</p>
             </div>
           </div>

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/GlobalResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/GlobalResultItem.js
@@ -36,7 +36,7 @@ class GlobalResultItem extends React.Component {
               <h2 className="ecl-teaser__title">
                 <a href={this.props.result.ss_url}>
 
-                  <span className="ecl-teaser__title-overflow"><span>{this.props.result.ss_global_title}</span></span>
+                  <span className="ecl-teaser__title-overflow"><span>{this.props.result.tm_global_title}</span></span>
 
                 </a>
               </h2>

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/GroupResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/GroupResultItem.js
@@ -25,13 +25,13 @@ class GroupResultItem extends React.Component {
     }
 
     return (
-      <div className="ecl-teaser-overview__item" key={this.props.result.ss_group_label_string}>
+      <div className="ecl-teaser-overview__item" key={this.props.result.tm_global_title}>
         <div className="ecl-teaser ecl-teaser--group  ecl-teaser--as-card ecl-teaser--as-card-grey">
           <figure className="ecl-teaser__image-wrapper">
             {this.props.result.ss_group_teaser_url_string !== undefined &&
               <img className="ecl-teaser__image"
                  src={this.props.result.ss_group_teaser_url_string}
-                 alt={this.props.result.ss_group_label_string}/>
+                 alt={this.props.result.tm_global_title}/>
             }
             {this.props.result.ss_group_teaser_url_string === undefined &&
               <div className="ecl-teaser__image-fallback-wrapper">
@@ -49,7 +49,7 @@ class GroupResultItem extends React.Component {
             <div className="ecl-teaser__content-wrapper">
               <div className="ecl-teaser__content">
                 <h2 className="ecl-teaser__title">
-                  <a href={this.props.result.ss_url}>{this.props.result.ss_group_label_string}</a>
+                  <a href={this.props.result.ss_url}>{this.props.result.tm_global_title}</a>
                 </h2>
 
                 <div className="ecl-author ecl-author--is-tiny  ecl-teaser__meta">

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Library/DocumentLibraryResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Library/DocumentLibraryResultItem.js
@@ -44,7 +44,7 @@ class DocumentLibraryResultItem extends React.Component {
           <div className="ecl-teaser__content">
             <h2 className="ecl-teaser__title">
               <a href={this.props.result.ss_url}>
-                <span className="ecl-teaser__title-overflow"><span>{this.props.result.ss_global_title}</span></span>
+                <span className="ecl-teaser__title-overflow"><span>{this.props.result.tm_global_title}</span></span>
               </a>
             </h2>
             <div className="ecl-teaser__tags">

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Library/GalleryLibraryResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Library/GalleryLibraryResultItem.js
@@ -65,7 +65,7 @@ class GalleryLibraryResultItem extends React.Component {
           <div className="ecl-teaser__content">
             <h2 className="ecl-teaser__title">
               <a href={this.props.result.ss_url}>
-                <span className="ecl-teaser__title-overflow"><span>{this.props.result.ss_global_title}</span></span>
+                <span className="ecl-teaser__title-overflow"><span>{this.props.result.tm_global_title}</span></span>
               </a>
             </h2>
             <div className="ecl-teaser__tags">

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Library/VideoLibraryResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Library/VideoLibraryResultItem.js
@@ -47,7 +47,7 @@ class VideoLibraryResultItem extends React.Component {
           <div className="ecl-teaser__content">
             <h2 className="ecl-teaser__title">
               <a href={this.props.result.ss_url}>
-                <span className="ecl-teaser__title-overflow"><span>{this.props.result.ss_global_title}</span></span>
+                <span className="ecl-teaser__title-overflow"><span>{this.props.result.tm_global_title}</span></span>
               </a>
             </h2>
             <div className="ecl-teaser__tags">

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/StoryResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/StoryResultItem.js
@@ -11,7 +11,7 @@ export default function StoryResultItem(props) {
 
     <div className="ecl-teaser ecl-teaser--story  ">
       <figure className="ecl-teaser__image-wrapper">
-        <img className="ecl-teaser__image" src={props.result.ss_content_image_url} alt={props.result.ss_global_title} />
+        <img className="ecl-teaser__image" src={props.result.ss_content_image_url} alt={props.result.tm_global_title} />
       </figure>
       <div className="ecl-teaser__main-wrapper">
         <div className="ecl-teaser__meta-header">
@@ -34,7 +34,7 @@ export default function StoryResultItem(props) {
         <div className="ecl-teaser__content">
           <h2 className="ecl-teaser__title">
             <a href={props.result.ss_url}>
-              <span className="ecl-teaser__title-overflow"><span>{props.result.ss_global_title}</span></span>
+              <span className="ecl-teaser__title-overflow"><span>{props.result.tm_global_title}</span></span>
             </a>
           </h2>
           <p className="ecl-teaser__description" dangerouslySetInnerHTML={{__html: text}} />

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/UserGalleryResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/UserGalleryResultItem.js
@@ -23,7 +23,7 @@ class UserGalleryResultItem extends React.Component {
     }
 
     return (
-      <div className="ecl-teaser-overview__item " key={this.props.result.ss_group_label_string}>
+      <div className="ecl-teaser-overview__item " key={this.props.result.tm_global_title}>
         <div className="ecl-teaser ecl-teaser--member ecl-teaser--as-card ecl-teaser--as-card-grey">
           <div className="ecl-teaser__main-wrapper">
             <div className="ecl-teaser__meta-header ecl-teaser__meta-header--is-hidden" aria-hidden="true">

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/UserListResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/UserListResultItem.js
@@ -23,7 +23,7 @@ class UserListResultItem extends React.Component {
     }
 
     return (
-      <div className="ecl-teaser-overview__item " key={this.props.result.ss_group_label_string}>
+      <div className="ecl-teaser-overview__item " key={this.props.result.tm_global_title}>
         <div className="ecl-teaser ecl-teaser--member">
           <div className="ecl-teaser__main-wrapper">
             <div className="ecl-teaser__meta-header ecl-teaser__meta-header--is-hidden" aria-hidden="true">


### PR DESCRIPTION
This PR introduces a case insensitive search using entity titles
We now define the tm_* Solr dynamic field's type as 'text_lower_case' which has different filters & tokenizer properties to make the search case insensitive

## To Test

- [ ] Update your local & re-index
- [ ] Go to /solr/#/eic/schema?field=tm_global_title and make sure you have the field definition with type = 'text_lower_case'
- [ ] Go to /groups (or any other search block)
- [ ] Make uppercase and lowercase searches (e.g: GROUP, group, GrOUp, etc.)
- [ ] You should have matching results