### PR TITLE
EICNET-1467: Groups - Specific user not saved in visibility Custom restriction

### DIFF
--- a/lib/modules/oec_group_flex/src/Entity/Form/GroupForm.php
+++ b/lib/modules/oec_group_flex/src/Entity/Form/GroupForm.php
@@ -165,7 +165,8 @@ class GroupForm extends GroupFormBase {
         ];
         try {
           $defaultOptions = $this->groupFlex->getDefaultJoiningMethods($group);
-        } catch (MissingDataException $e) {
+        }
+        catch (MissingDataException $e) {
           $defaultOptions = [];
         }
         $form['footer']['group_joining_methods']['#default_value'] = !empty($defaultOptions) ? reset($defaultOptions) : array_key_first($methodOptions);
@@ -243,8 +244,18 @@ class GroupForm extends GroupFormBase {
             break;
           }
 
-          // Extract array into variables.
-          $this->groupFlexSaver->saveGroupVisibility($group, $value['plugin_id']);
+          $visibility_options = [];
+
+          // Gets group visibility options.
+          if (isset($value['visibility_options'])) {
+            $visibility_options = $value['visibility_options'];
+          }
+
+          // Saves the group visibility. Note that Group flex service is being
+          // decorated by OECGroupFlexGroupSaverDecorator and the method
+          // saveGroupVisibility can receive a 3rd argument in case we need to
+          // save extra visibility options.
+          $this->groupFlexSaver->saveGroupVisibility($group, $value['plugin_id'], $visibility_options);
           break;
 
         case 'joining_methods':
@@ -390,7 +401,8 @@ class GroupForm extends GroupFormBase {
       if ($value !== NULL) {
         try {
           $store->delete("$storeId:$key");
-        } catch (TempStoreException $exception) {
+        }
+        catch (TempStoreException $exception) {
           return;
         }
       }
@@ -409,7 +421,8 @@ class GroupForm extends GroupFormBase {
       if ($value !== NULL) {
         try {
           $store->set("$storeId:$key", $value);
-        } catch (TempStoreException $exception) {
+        }
+        catch (TempStoreException $exception) {
           return;
         }
       }

--- a/lib/modules/oec_group_flex/src/Plugin/CustomRestrictedVisibility/RestrictedUsers.php
+++ b/lib/modules/oec_group_flex/src/Plugin/CustomRestrictedVisibility/RestrictedUsers.php
@@ -54,6 +54,7 @@ class RestrictedUsers extends CustomRestrictedVisibilityBase {
         ],
       ],
       '#weight' => $this->getWeight() + 1,
+      '#maxlength' => NULL,
     ];
     return $form;
   }


### PR DESCRIPTION
### Fixes

- Fix regression where custom restricted options where not saved after saving the group;
- Disable maxlength when selecting restricted users;

### Tests

- [x] Create a new custom restricted group, restrict by users and select multiple users
- [x] Save the group
- [x] Go to the group edit form and make sure the visibility options were saved correctly