### PR TITLE
EICNET-1404: Story - Only 1st document is shown

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/content/node--news--story.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--news--story.inc
@@ -108,22 +108,27 @@ function _eic_community_story_image_field(&$variables) {
  * Preproccess document field for full news/story.
  */
 function _eic_community_story_document_field(&$variables) {
-  if (isset($variables['content']['field_document_media'][0])) {
-    $media = $variables['content']['field_document_media'][0]['#media'];
+  $node = $variables['node'];
+  $medias = $node->get('field_document_media')->referencedEntities();
+
+  foreach ($medias as $media) {
     $file = File::load($media->field_media_file->target_id);
     $file_description = isset($media->field_body) ? Markup::create(Xss::filter($media->get('field_body')->value)) : $media->getName();
+    $download_url = MediaHelper::formatMediaDownloadLink($media)->toString();
 
-    $variables['download'] = [
+    $file_type = strstr($file->get('filemime')->getString(), '/', TRUE);
+
+    $variables['downloads'][] = [
       'title' => $file_description,
       'language' => $media->language()->getName(),
       'timestamp' => eic_community_get_teaser_time_display($media->get('changed')->getString()),
       'filesize' => format_size($file->get('filesize')->getString()),
       'highlight' => FALSE,
-      'path' => file_create_url($file->getFileUri()),
+      'path' => $download_url,
       'icon_file_path' => $variables['eic_icon_path'],
       'icon' => [
-        'type' => 'custom',
-        'name' => substr(strrchr($file->get('filemime')->getString(), '/'), 1),
+        'type' => $file_type === 'video' ? 'general' : 'custom',
+        'name' => $file_type === 'video' ? $file_type : substr(strrchr($file->get('filemime')->getString(), '/'), 1),
       ],
     ];
   }

--- a/lib/themes/eic_community/includes/preprocess/field/field--media--eic-document.inc
+++ b/lib/themes/eic_community/includes/preprocess/field/field--media--eic-document.inc
@@ -57,7 +57,7 @@ function eic_community_preprocess_field__field_related_downloads(array &$variabl
       'timestamp' => eic_community_get_teaser_time_display($media->get('changed')->getString()),
       'filesize' => format_size($file->get('filesize')->getString()),
       'highlight' => FALSE,
-      'path' => $download_url->toString(),
+      'path' => $download_url,
       'icon_file_path' => $variables['eic_icon_path'],
       'icon' => [
         'type' => $file_type === 'video' ? 'general' : 'custom',

--- a/lib/themes/eic_community/templates/content/node--story--full.html.twig
+++ b/lib/themes/eic_community/templates/content/node--story--full.html.twig
@@ -11,9 +11,9 @@
       {% else %}
         {{ elements.field_video }}
       {% endif %}
-      {% if download %}
+      {% for download in downloads %}
         {% include "@theme/patterns/components/attachment.html.twig" with download only %}
-      {% endif %}
+      {% endfor %}
       {{ elements.field_disclaimer }}
     {% endblock %}
 


### PR DESCRIPTION
### Fixes

- Show all list of documents when viewing Story detail page;
- Fix error where toString() method is called twice in eic_community_preprocess_field__field_related_downloads().

### Tests

- [x] Create a Story and add multiple Documents;
- [x] Go to the story detail page and make sure the list with all documents is presented.