### PR TITLE
EICNET-1410: Unexpected error when viewing About page of public group as TU

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/groups/group.inc
+++ b/lib/themes/eic_community/includes/preprocess/groups/group.inc
@@ -87,10 +87,17 @@ function _group_about_group_tab($variables, &$sections) {
 
   if (count($variables['elements']['admins']) > 0) {
     $admins = array_map(function ($admin) {
-      return [
-        'title' => $admin->getText(),
-        'path' => $admin->getUrl(),
-      ];
+      if ($admin instanceof Markup) {
+        return [
+          'title' => $admin,
+        ];
+      }
+      else {
+        return [
+          'title' => $admin->getText(),
+          'path' => $admin->getUrl(),
+        ];
+      }
     }, $variables['elements']['admins']);
 
     $about_items[] = [


### PR DESCRIPTION
### Fixes

- Fix issue when showing group administrators in the group about page for anonymous users.

### Tests

- [x] As SA/SCM, create a new public group and add some administrators
- [x] As anonymous user, try to access the group about page and make sure you have no errors like `The website encountered an unexpected error.`