### PR TITLE
EICNET-1133: Fix the group menu active item

### DIFF
--- a/config/sync/context.context.group_global.yml
+++ b/config/sync/context.context.group_global.yml
@@ -2,7 +2,10 @@ uuid: 092acf4e-0ac9-4e24-bad6-5ade6eab25d5
 langcode: en
 status: true
 dependencies:
+  config:
+    - group_content_menu.group_content_menu_type.group_main_menu
   module:
+    - eic_groups
     - group
     - route_condition
 name: group_global
@@ -29,24 +32,6 @@ conditions:
 reactions:
   blocks:
     blocks:
-      8c64fa91-2806-4f88-a5f2-723a137c6b72:
-        id: 'group_content_menu:group_main_menu'
-        label: 'Group - Main menu'
-        provider: group_content_menu
-        label_display: '0'
-        level: '1'
-        depth: '0'
-        expand_all_items: 0
-        region: page_header
-        weight: '1'
-        context_mapping:
-          group: '@group.group_route_context:group'
-        custom_id: group_content_menu_group_main_menu
-        theme: eic_community
-        css_class: ''
-        unique: 0
-        context_id: group_global
-        uuid: 8c64fa91-2806-4f88-a5f2-723a137c6b72
       6ebffc8d-ce4c-45ab-b138-e6dd4e22db28:
         id: eic_group_header
         label: 'EIC Group header'
@@ -62,6 +47,25 @@ reactions:
         unique: 1
         context_id: group_global
         uuid: 6ebffc8d-ce4c-45ab-b138-e6dd4e22db28
+      75a8b5e9-e237-4385-877d-0a462e12e2d7:
+        id: 'eic_group_content_menu:group_main_menu'
+        label: 'Group - Main menu'
+        provider: eic_groups
+        label_display: '0'
+        level: '1'
+        depth: '0'
+        expand_all_items: 0
+        region: page_header
+        weight: '1'
+        context_mapping:
+          group: '@group.group_route_context:group'
+        custom_id: eic_group_content_menu_group_main_menu
+        theme: eic_community
+        css_class: ''
+        unique: 0
+        context_id: group_global
+        third_party_settings: {  }
+        uuid: 75a8b5e9-e237-4385-877d-0a462e12e2d7
     id: blocks
     saved: false
     uuid: eee2af2a-bea1-4c9a-8012-20aa5543365a

--- a/lib/modules/eic_groups/src/Plugin/Block/GroupMenuBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/GroupMenuBlock.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace Drupal\eic_groups\Plugin\Block;
+
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\eic_overviews\GroupOverviewPages;
+use Drupal\group\Entity\GroupContent;
+use Drupal\group\Entity\GroupInterface;
+use Drupal\group_content_menu\Plugin\Block\GroupMenuBlock as GroupMenuBlockBase;
+use Drupal\node\NodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a custom group content menu block.
+ *
+ * @Block(
+ *   id = "eic_group_content_menu",
+ *   admin_label = @Translation("EIC Group Menu"),
+ *   category = @Translation("European Innovation Council"),
+ *   deriver = "Drupal\group_content_menu\Plugin\Derivative\GroupMenuBlock",
+ *   context_definitions = {
+ *     "group" = @ContextDefinition("entity:group", required = FALSE)
+ *   }
+ * )
+ */
+class GroupMenuBlock extends GroupMenuBlockBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The EIC Groups helper service.
+   *
+   * @var \Drupal\eic_groups\EICGroupsHelperInterface
+   */
+  protected $eicGroupsHelper;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    $block_plugin = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $block_plugin->eicGroupsHelper = $container->get('eic_groups.helper');
+    return $block_plugin;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $build = parent::build();
+
+    $menu_name = $this->getMenuName();
+    $parameters = $this->menuTree->getCurrentRouteMenuTreeParameters($menu_name);
+
+    // If there is no menu link in the active trail, we try to set the active
+    // trail based on the current node.
+    if (count($parameters->activeTrail) === 1 && empty($parameters->activeTrail[0])) {
+      $this->setMenuTreeActiveTrail($build['#items']);
+    }
+
+    return $build;
+  }
+
+  /**
+   * Sets active trail for the menu tree based on the current page.
+   *
+   * For group content nodes that don't have a menu link, we need to set the
+   * active trail on the first level of the menu based on the node bundle.
+   *
+   * @param array $tree
+   *   Array of menu links.
+   */
+  private function setMenuTreeActiveTrail(array &$tree) {
+    // Do nothing if no group was found in the context or in the current route.
+    if ((!$group = $this->getContextValue('group')) || !$group->id()) {
+      $group = $this->eicGroupsHelper->getGroupFromRoute();
+    }
+
+    if (!$group || !$group instanceof GroupInterface) {
+      return;
+    }
+
+    if (\Drupal::routeMatch()->getRouteName() !== 'entity.node.canonical') {
+      return;
+    }
+
+    $node = \Drupal::routeMatch()->getParameter('node');
+    if (!$node instanceof NodeInterface) {
+      return;
+    }
+
+    $group_contents = GroupContent::loadByEntity($node);
+
+    if (empty($group_contents)) {
+      return;
+    }
+
+    $group_content = reset($group_contents);
+
+    if ($group_content->getGroup()->id() !== $group->id()) {
+      return;
+    }
+
+    $url = FALSE;
+
+    switch ($node->bundle()) {
+      case 'discussion':
+        // Gets group discussions overview page url.
+        $url = GroupOverviewPages::getGroupOverviewPageUrl(
+          'discussions',
+          $group
+        );
+        break;
+
+      case 'document':
+      case 'gallery':
+      case 'video':
+        // Gets group files overview page url.
+        $url = GroupOverviewPages::getGroupOverviewPageUrl(
+          'files',
+          $group
+        );
+        break;
+
+      case 'wiki_page':
+        // Gets group wiki url.
+        $group_book_page_nid = $this->eicGroupsHelper->getGroupBookPage($group);
+        $group_book_page_node = $this->entityTypeManager->getStorage('node')->load($group_book_page_nid);
+        $url = $group_book_page_node->toUrl();
+        break;
+
+      default:
+        return;
+    }
+
+    foreach ($tree as $key => $value) {
+      if ($value['url']->toString() === $url->toString()) {
+        $tree[$key]['in_active_trail'] = TRUE;
+        break;
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheContexts() {
+    // Vary by url path context.
+    $contexts = ['url.path'];
+    return Cache::mergeContexts(parent::getCacheContexts(), $contexts);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMenuInstance() {
+    $entity = $this->getContext('group')->getContextData()->getValue();
+    // Don't load menu for group entities that are new/unsaved.
+    if (!$entity || $entity->isNew()) {
+      return NULL;
+    }
+
+    // Group menu plugin ID that will be used to load the group content entity.
+    $group_menu_plugin_id = 'group_content_menu:group_main_menu';
+
+    /** @var \Drupal\group\Entity\Storage\GroupContentStorage $groupStorage */
+    $groupStorage = $this->entityTypeManager->getStorage('group_content');
+    $contentPluginId = $groupStorage->loadByContentPluginId($group_menu_plugin_id);
+
+    if (empty($contentPluginId)) {
+      return NULL;
+    }
+
+    $instances = $groupStorage->loadByGroup($entity, $group_menu_plugin_id);
+    if ($instances) {
+      return array_pop($instances)->getEntity();
+    }
+    return NULL;
+  }
+
+}

--- a/lib/themes/eic_community/includes/preprocess/blocks/block.inc
+++ b/lib/themes/eic_community/includes/preprocess/blocks/block.inc
@@ -51,7 +51,11 @@ function eic_community_preprocess_block(array &$variables) {
     $variables['#cache']['tags'] = $cache_tags;
   }
 
-  if ($variables['base_plugin_id'] === 'group_content_menu') {
+  // Preprocess group content menu plugin blocks.
+  if (in_array($variables['base_plugin_id'], [
+    'group_content_menu',
+    'eic_group_content_menu',
+  ])) {
     eic_community_preprocess_block__group_menu($variables);
   }
 }

--- a/lib/themes/eic_community/templates/blocks/block--eic-group-content-menu.html.twig
+++ b/lib/themes/eic_community/templates/blocks/block--eic-group-content-menu.html.twig
@@ -1,0 +1,9 @@
+{#
+/**
+ * @file
+ * Theme override for the group menu block.
+ *
+ * @see ./core/modules/system/templates/block.html.twig
+ */
+#}
+{% include '@eic_community/blocks/block--group-content-menu.html.twig' %}


### PR DESCRIPTION
### Fixes

- Create new custom block plugin that overrides GroupMenuBlock in order to set the menu active trails when viewing a group content node.

### Tests

- [x] Go to a group discussion page and check if the "Discussions" link is active in the group menu
- [x] Go to a group video, gallery and document page and check if the "Files" link is active in the group menu