### PR TITLE
EICNET-1271: Error when viewing News page with uploaded video

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/content/node--news--story.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--news--story.inc
@@ -294,7 +294,7 @@ function _eic_community_story_video_field(&$variables) {
           'timestamp' => eic_community_get_teaser_time_display($media->get('changed')->getString()),
           'filesize' => format_size($file->get('filesize')->getString()),
           'highlight' => FALSE,
-          'path' => $download_url->toString(),
+          'path' => $download_url,
           'icon_file_path' => $variables['eic_icon_path'],
           'icon' => [
             'type' => 'general',


### PR DESCRIPTION
### Fixes

- Fix error "Call to a member function toString() on string in _eic_community_story_video_field()" when user is viewing a News page that contains an uploaded video

### Tests

- [ ] Create or edit a News
- [ ] Upload a video and save it
- [ ] Go to the News detail page and make sure there are no errors like: `The website encountered an unexpected error. Please try again later.`
- [ ] Go to /admin/reports/dblog and check if there are no errors like: `Error: Call to a member function toString() on string in _eic_community_story_video_field()`.