### PR TITLE
EICNET-1493: Groups - Group owner in group teaser links to groups overview

### DIFF
--- a/lib/modules/eic_search/eic_search.module
+++ b/lib/modules/eic_search/eic_search.module
@@ -87,8 +87,8 @@ function eic_search_search_api_solr_documents_alter(
     $solr_document_processor->processGroupData($document, $fields);
     $solr_document_processor->processDiscussionData($document, $fields);
     $solr_document_processor->processDocumentData($document, $fields);
-    $solr_document_processor->processGroupUserData($document, $fields);
     $solr_document_processor->processFlaggingData($document, $fields);
     $solr_document_processor->processGroupVisibilityData($document, $fields, $items, $group_helper);
+    $solr_document_processor->processGroupUserData($document, $fields);
   }
 }

--- a/lib/modules/eic_search/src/Service/SolrDocumentProcessor.php
+++ b/lib/modules/eic_search/src/Service/SolrDocumentProcessor.php
@@ -143,11 +143,6 @@ class SolrDocumentProcessor {
         $geo = $fields['ss_group_field_vocab_geo_string'];
         $language = t('English', [], ['context' => 'eic_search'])->render();
         $user_url = '';
-        if (array_key_exists('its_group_owner_id', $fields)) {
-          $user = User::load($fields['its_group_owner_id']);
-          $user_url = $user instanceof UserInterface ? $user->toUrl()
-            ->toString() : '';
-        }
         break;
       case 'entity:message':
         $user_url = '';
@@ -442,6 +437,14 @@ class SolrDocumentProcessor {
 
         $document->setField('itm_user__group_content__uid_gid', $grp_ids);
       }
+    }
+
+    // We update the ss_global_user_url field based on the group owner.
+    if (array_key_exists('its_group_owner_id', $document->getFields())) {
+      $user = User::load($document->getFields()['its_group_owner_id']);
+      $user_url = $user instanceof UserInterface ? $user->toUrl()
+        ->toString() : '';
+      $document->setField('ss_global_user_url', $user_url);
     }
   }
 

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/GroupResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/GroupResultItem.js
@@ -66,12 +66,24 @@ class GroupResultItem extends React.Component {
                     </span>
                   </div>
                   <div className="ecl-author__aside">
-                    <div className="ecl-author__media-wrapper">
-                      <figure className="ecl-media-container ecl-author__media"><img alt=""
-                                                                                     className="ecl-media-container__media"
-                                                                                     src={this.props.result.ss_group_user_image}/>
-                      </figure>
-                    </div>
+                    {!this.props.isAnonymous ? (
+                      <a href={this.props.result.ss_global_user_url}
+                          className="ecl-author__media-wrapper">
+                        <figure className="ecl-media-container ecl-author__media">
+                          <img alt=""
+                            className="ecl-media-container__media"
+                            src={this.props.result.ss_group_user_image}/>
+                        </figure>
+                      </a>
+                    ): (
+                      <div className="ecl-author__media-wrapper">
+                        <figure className="ecl-media-container ecl-author__media">
+                          <img alt=""
+                              className="ecl-media-container__media"
+                              src={this.props.result.ss_group_user_image}/>
+                        </figure>
+                      </div>
+                    )}
                   </div>
                 </div>
 


### PR DESCRIPTION
### Fixes

- Fix group owner url in groups overview.

### Tests

- [x] Re-index solr
- [x] As TU, go to the groups overview `/groups`
- [x] Click in the avatar or name of a group owner and make sure you get redirected to the user detail page