### PR TITLE
EICNET-1489: Groups - For an anonymous user, avatars are clickable & some profile avatars are not shown

### DIFF
--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/GroupResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/GroupResultItem.js
@@ -55,10 +55,14 @@ class GroupResultItem extends React.Component {
                 <div className="ecl-author ecl-author--is-tiny  ecl-teaser__meta">
                   <div className="ecl-author__information">
                     <span className="ecl-author__label ">
-                          <a href={this.props.result.ss_global_user_url}
-                             className="ecl-link ecl-link--standalone ecl-author__link">
-                            {this.props.result.ss_group_user_first_name} {this.props.result.ss_group_user_last_name}
-                          </a>
+                      {!this.props.isAnonymous ? (
+                        <a href={this.props.result.ss_global_user_url}
+                            className="ecl-link ecl-link--standalone ecl-author__link">
+                          {this.props.result.ss_group_user_first_name} {this.props.result.ss_group_user_last_name}
+                        </a>
+                      ) : (
+                        [this.props.result.ss_group_user_first_name, this.props.result.ss_group_user_last_name].join(' ')
+                      )}
                     </span>
                   </div>
                   <div className="ecl-author__aside">


### PR DESCRIPTION
### Fixes

- Make group profile avatars not clickable for anonymous users.

### Tests

- [ ] As TU, go to groups overview page `/groups` and make sure group avatars + usernames are clickable;
- [ ] As anonymous user, go to groups overview page `/groups` and make sure group avatars + usernames are **NOT** clickable;