### PR TITLE
EICNET-1133: Fix error when trying to create a group as a TU

### DIFF
--- a/lib/modules/eic_groups/src/Plugin/Block/GroupMenuBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/GroupMenuBlock.php
@@ -53,7 +53,10 @@ class GroupMenuBlock extends GroupMenuBlockBase implements ContainerFactoryPlugi
 
     // If there is no menu link in the active trail, we try to set the active
     // trail based on the current node.
-    if (count($parameters->activeTrail) === 1 && empty($parameters->activeTrail[0])) {
+    if (count($parameters->activeTrail) === 1 &&
+      empty($parameters->activeTrail[0]) &&
+      !empty($build['#items'])
+    ) {
       $this->setMenuTreeActiveTrail($build['#items']);
     }
 


### PR DESCRIPTION
### Fixes

- Fix error when trying to create a group as a TU.

### Tests

- [x] As a TU, go to the group add form `/group/add/group` and make sure there is no error like `The website encountered an unexpected error. Please try again later.`