### PR TITLE
EICNET-1535: Basic file extensions for MT document

### DIFF
--- a/config/sync/field.field.media.eic_document.field_media_file.yml
+++ b/config/sync/field.field.media.eic_document.field_media_file.yml
@@ -19,7 +19,7 @@ default_value: {  }
 default_value_callback: ''
 settings:
   file_directory: '[date:custom:Y]-[date:custom:m]'
-  file_extensions: 'txt doc docx pdf'
+  file_extensions: 'txt pdf doc docx xls xlsx png bmp jpg jpeg pps ppsx ppt pptx odt ods odp odf gif pdt pdtx vsd vsdx zip'
   max_filesize: ''
   description_field: false
   handler: 'default:file'


### PR DESCRIPTION
### Changes

- Update allowed file extensions for MT Document.

### Tests

- [ ] As SA, try to add a document in a group
- [ ] When you try to upload a document make sure only the following extensions are allowed: `txt, pdf, doc, docx, xls, xlsx, png, bmp, jpg, jpeg, pps, ppsx, ppt, pptx, odt, ods, odp, odf, gif, pdt, pdtx, vsd, vsdx, zip`