### PR TITLE
EICNET-1537: Group - main menu: search not showing

### DIFF
--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -73,7 +73,7 @@ function eic_groups_theme($existing, $type, $theme, $path) {
         'discussion_id' => 0,
         'contributors' => [],
         'is_anonymous' => TRUE,
-      ]
+      ],
     ],
   ];
 }
@@ -405,6 +405,13 @@ function eic_groups_preprocess_block__group_content_menu(&$variables) {
   $block_manager = \Drupal::service('plugin.manager.block');
   $plugin_block = $block_manager->createInstance('eic_groups_search_menu_group', []);
   $variables['search_block'] = $plugin_block->build();
+}
+
+/**
+ * Implements hook_preprocess_block__HOOK().
+ */
+function eic_groups_preprocess_block__eic_group_content_menu(&$variables) {
+  eic_groups_preprocess_block__group_content_menu($variables);
 }
 
 /**


### PR DESCRIPTION
### Fixes

- Show search form in group main menu.

### Tests

- [ ] Go to the group homepage and make sure the search box in next to the group menu
- [ ] Navigate in the group overviews + content detail pages and make sure the search is always presented in the group menu