### PR TITLE
EICNET-1343: Documents in Discussion are not shown

### DIFF
--- a/config/sync/core.entity_view_display.node.discussion.default.yml
+++ b/config/sync/core.entity_view_display.node.discussion.default.yml
@@ -60,9 +60,10 @@ content:
     weight: 105
     label: hidden
     settings:
-      link: true
+      view_mode: teaser
+      link: false
     third_party_settings: {  }
-    type: entity_reference_label
+    type: entity_reference_entity_view
     region: content
   field_related_downloads:
     weight: 109

--- a/config/sync/field.field.node.discussion.field_related_documents.yml
+++ b/config/sync/field.field.node.discussion.field_related_documents.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.storage.node.field_related_documents
     - node.type.discussion
+    - node.type.document
 id: node.discussion.field_related_documents
 field_name: field_related_documents
 entity_type: node
@@ -17,5 +18,12 @@ default_value: {  }
 default_value_callback: ''
 settings:
   handler: 'default:node'
-  handler_settings: {  }
+  handler_settings:
+    target_bundles:
+      document: document
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
 field_type: entity_reference

--- a/lib/themes/eic_community/templates/content/node--discussion--full.html.twig
+++ b/lib/themes/eic_community/templates/content/node--discussion--full.html.twig
@@ -41,6 +41,10 @@
             {% endif %}
           </div>
         {% endif %}
+        {% if content.field_related_documents[0] is not empty %}
+          <h2>{{ 'Documents'|t }}</h2>
+          {{ content.field_related_documents }}
+        {% endif %}
         {# {% if video_download %}
           {% include "@theme/patterns/components/attachment.html.twig" with video_download only %}
         {% else %} #}


### PR DESCRIPTION
### Improvements

- Show related documents in Discussion detail page.
- Allow only CT Documents when referencing entities in field_related_documents

### Tests

- [ ] As SA/SCM, create 2 documents in a group
- [ ] Create a new discussion in the group and reference those 2 documents in the field "Documents"
- [ ] Go to the discussion detail page and make sure the documents are shown 