### PR TITLE
[EICNET] fix: Use Github releases to install yarn

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -54,11 +54,10 @@ RUN latest_drush_version=$(curl -s https://api.github.com/repos/drush-ops/drush/
 ENV YARN_VERSION=1.22.15
 COPY --from=node:14 /usr/local/lib/node_modules /usr/local/lib/node_modules
 COPY --from=node:14 /usr/local/bin/node /usr/local/bin/node
-COPY --from=node:14 /opt/yarn-v$YARN_VERSION /opt/yarn-v$YARN_VERSION
 RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
   && ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
-  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
-  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && wget https://github.com/yarnpkg/yarn/releases/download/v${YARN_VERSION}/yarn_${YARN_VERSION}_all.deb \
+  && dpkg -i yarn_${YARN_VERSION}_all.deb \
   # smoke test
   && node --version \
   && npm --version \


### PR DESCRIPTION
## To Test

- [ ] Rebuild docker images used locally
- [ ] run yarn --version: you should get 1.22.15