### PR TITLE
EICNET-1551: Add missing permission to view users email address.

### DIFF
--- a/config/sync/user.role.content_administrator.yml
+++ b/config/sync/user.role.content_administrator.yml
@@ -76,3 +76,4 @@ permissions:
   - 'view own unpublished content'
   - 'view own unpublished media'
   - 'view private content'
+  - 'view user email addresses'

--- a/config/sync/user.role.service_authentication.yml
+++ b/config/sync/user.role.service_authentication.yml
@@ -7,8 +7,10 @@ label: 'Service authentication'
 weight: -6
 is_admin: null
 permissions:
+  - 'access user profiles'
   - 'administer comments'
   - 'administer users'
   - 'restful post eic_webservices_user_update'
   - 'use news_stories transition archived'
   - 'view own unpublished content'
+  - 'view user email addresses'

--- a/config/sync/user.role.site_admin.yml
+++ b/config/sync/user.role.site_admin.yml
@@ -84,3 +84,4 @@ permissions:
   - 'view own unpublished profile'
   - 'view private content'
   - 'view the administration theme'
+  - 'view user email addresses'

--- a/config/sync/user.role.trusted_user.yml
+++ b/config/sync/user.role.trusted_user.yml
@@ -50,3 +50,4 @@ permissions:
   - 'view own unpublished media'
   - 'view private content'
   - 'view recommend_group'
+  - 'view user email addresses'


### PR DESCRIPTION
### Tests

- [x] Login as SA, SCM or TU
- [x] Edit any CT that has the `Related Contributors` field (such as dicussion)
- [x] Select `Platform member`
- [x] Search for a user in the autocomplete
- [x] Make sure you get results