### PR TITLE
Fix: correct color for public tag

### DIFF
--- a/lib/themes/eic_community/sass/components/_tag.scss
+++ b/lib/themes/eic_community/sass/components/_tag.scss
@@ -13,7 +13,7 @@
 
   &--is-public {
     background-color: map-get($ecl-colors, 'grey-15');
-    color: map-get($ecl-colors, 'white');
+    color: map-get($ecl-colors, 'grey');
   }
 
   &--is-restricted {


### PR DESCRIPTION
http://localhost:9000/?path=/story/bundles-group--overview-public
https://www.figma.com/file/WZH3qhNynnmm0H6FKmD3hi/EASME_v1?node-id=2949%3A0

**BEFORE**
- BG: Lightgrey
- TXT: White

**NOW**
- BG: Lightgrey
- TXT: Grey