### PR TITLE
Bugfix: Missing eic_flags dependency in eic_groups module

### DIFF
--- a/lib/modules/eic_groups/eic_groups.info.yml
+++ b/lib/modules/eic_groups/eic_groups.info.yml
@@ -12,3 +12,4 @@ dependencies:
   - eic_user:eic_user
   - eic_content:eic_content_wiki_page
   - eic_statistics:eic_group_statistics
+  - eic_flags:eic_flags


### PR DESCRIPTION
### Fixes

- Add missing dependency (eic_flags:eic_flags) in eic_groups module.

### Test (Dev only)

- [ ] Try to fresh install the website and make sure there are no errors that breaks the installation.