### PR TITLE
EICNET-1601: Increment event files in group file statistics

### DIFF
--- a/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.module
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.module
@@ -26,6 +26,7 @@ function eic_group_statistics_group_content_insert(EntityInterface $entity) {
     case 'group-group_membership':
     case 'group-group_node-discussion':
     case 'group-group_node-document':
+    case 'group-group_node-event':
     case 'group-group_node-gallery':
     case 'group-group_node-wiki_page':
       \Drupal::classResolver(EntityOperations::class)
@@ -55,6 +56,7 @@ function eic_group_statistics_node_delete(EntityInterface $entity) {
   switch ($entity->bundle()) {
     case 'discussion':
     case 'document':
+    case 'event':
     case 'gallery':
     case 'wiki_page':
       // We need to make sure the node belongs to a group content, otherwise we
@@ -144,6 +146,7 @@ function eic_group_statistics_node_update(EntityInterface $entity) {
   switch ($entity->bundle()) {
     case 'discussion':
     case 'document':
+    case 'event':
     case 'gallery':
     case 'wiki_page':
       // We need to make sure the node belongs to a group content, otherwise we

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/Hooks/EntityOperations.php
@@ -134,6 +134,7 @@ class EntityOperations implements ContainerInjectionInterface {
 
       case 'group-group_node-discussion':
       case 'group-group_node-document':
+      case 'group-group_node-event':
       case 'group-group_node-wiki_page':
       case 'group-group_node-gallery':
         $re_index = $this->updateGroupFileStatistics($entity->getEntity(), $entity);
@@ -205,8 +206,9 @@ class EntityOperations implements ContainerInjectionInterface {
     switch ($entity->bundle()) {
       case 'discussion':
       case 'document':
-      case 'wiki_page':
+      case 'event':
       case 'gallery':
+      case 'wiki_page':
         $re_index = $this->updateGroupFileStatistics($entity, $group_content, self::GROUP_FILE_STATISTICS_DELETE_OPERATION);
         break;
 
@@ -241,8 +243,9 @@ class EntityOperations implements ContainerInjectionInterface {
     switch ($entity->bundle()) {
       case 'discussion':
       case 'document':
-      case 'wiki_page':
+      case 'event':
       case 'gallery':
+      case 'wiki_page':
         $re_index = $this->updateGroupFileStatistics($entity, $group_content, self::GROUP_FILE_STATISTICS_UPDATE_OPERATION);
         break;
 


### PR DESCRIPTION
### Features

- Increment/decrement group file statistics when uploading documents in CT Event.

### Tests

- [ ] As SA/SCM, go to a group and create a new Event
- [ ] Make sure you upload new documents in the Event (do not use existing ones)
- [ ] Save the Event
- [ ] Go to the group detail page and make sure the file statistics are updated
- [ ] Try to remove the documents from the event and also make sure the group file statistics are updated