### PR TITLE
EICNET-1602: Fix main menu active trail when viewing group pages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "drupal/group_flex": "^1.0@beta",
         "drupal/group_permissions": "^1.0@alpha",
         "drupal/media_entity_download": "^2.1",
+        "drupal/menu_trail_by_path": "^1.3",
         "drupal/message": "^1.2",
         "drupal/message_notify": "^1.2",
         "drupal/message_subscribe": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bd27bc63588abb9d850823edf5869bac",
+    "content-hash": "66f55a862299dafa713d4640c6970bc7",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4234,6 +4234,69 @@
             }
         },
         {
+            "name": "drupal/menu_trail_by_path",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/menu_trail_by_path.git",
+                "reference": "8.x-1.3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/menu_trail_by_path-8.x-1.3.zip",
+                "reference": "8.x-1.3",
+                "shasum": "64ba3a163302ff132c29a75b75ca4f6cce6b24dd"
+            },
+            "require": {
+                "drupal/core": "^8.8|^9.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.3",
+                    "datestamp": "1586900806",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                },
+                "patches_applied": {
+                    "2914746 - Fatal error after installing the module": "https://www.drupal.org/files/issues/2020-01-10/menu_trail_by_path-fatal_error_on_menu_active_trail_service_override-2914746-18.patch"
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Berdir",
+                    "homepage": "https://www.drupal.org/user/214652"
+                },
+                {
+                    "name": "SeriousMatters",
+                    "homepage": "https://www.drupal.org/user/290439"
+                },
+                {
+                    "name": "davy-r",
+                    "homepage": "https://www.drupal.org/user/3278771"
+                },
+                {
+                    "name": "mbovan",
+                    "homepage": "https://www.drupal.org/user/3149657"
+                },
+                {
+                    "name": "redndahead",
+                    "homepage": "https://www.drupal.org/user/160320"
+                }
+            ],
+            "description": "Expand menus and set active-trail according to the current path.",
+            "homepage": "https://www.drupal.org/project/menu_trail_by_path",
+            "support": {
+                "source": "https://git.drupalcode.org/project/menu_trail_by_path"
+            }
+        },
+        {
             "name": "drupal/message",
             "version": "1.2.0",
             "source": {
@@ -8194,16 +8257,6 @@
             "homepage": "http://github.com/myclabs/php-enum",
             "keywords": [
                 "enum"
-            ],
-            "funding": [
-                {
-                    "url": "https://github.com/mnapoli",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/myclabs/php-enum",
-                    "type": "tidelift"
-                }
             ],
             "time": "2021-07-05T08:18:36+00:00"
         },
@@ -16585,7 +16638,6 @@
                     "type": "github"
                 }
             ],
-            "abandoned": true,
             "time": "2020-09-28T06:45:17+00:00"
         },
         {

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -33,6 +33,9 @@
     "drupal/group_flex": {
       "3207164 - fatal error when saving after adding an image to an image field in a flex group" : "patches/group_flex/3207164-fatal-error-when-saving-after-adding-an-image-to-an-image-field-in-a-flex-group-24.patch"
     },
+    "drupal/menu_trail_by_path": {
+      "2914746 - Fatal error after installing the module": "https://www.drupal.org/files/issues/2020-01-10/menu_trail_by_path-fatal_error_on_menu_active_trail_service_override-2914746-18.patch"
+    },
     "drupal/message_subscribe": {
       "3086125 - Prevent infinite loop when sending messages with queue": "https://www.drupal.org/files/issues/2021-10-01/3086125-skip-if-we-have-last-item-14.patch"
     },

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -52,6 +52,7 @@ module:
   eic_media_document: 0
   eic_media_statistics: 0
   eic_media_video: 0
+  eic_menus: 0
   eic_message_subscriptions: 0
   eic_messages: 0
   eic_migrate: 0
@@ -98,6 +99,7 @@ module:
   media_entity_download: 0
   media_library: 0
   menu_link_content: 0
+  menu_trail_by_path: 0
   menu_ui: 0
   message: 0
   message_notify: 0

--- a/config/sync/menu_trail_by_path.settings.yml
+++ b/config/sync/menu_trail_by_path.settings.yml
@@ -1,0 +1,4 @@
+max_path_parts: 0
+trail_source: core
+_core:
+  default_config_hash: ZgwJ8bM6k-25MIqJjDtxAs94eahFxWfBq2IuHf-qh_I

--- a/config/sync/system.menu.main.yml
+++ b/config/sync/system.menu.main.yml
@@ -1,7 +1,12 @@
 uuid: d31ee2ae-cc95-4f3f-b27a-b50218e2a9c1
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - menu_trail_by_path
+third_party_settings:
+  menu_trail_by_path:
+    trail_source: path
 _core:
   default_config_hash: Q2Ra3jfoIVk0f3SjxJX61byRQFVBAbpzYDQOiY-kno8
 id: main

--- a/lib/modules/eic_menus/eic_menus.info.yml
+++ b/lib/modules/eic_menus/eic_menus.info.yml
@@ -1,0 +1,9 @@
+name: EIC Menus
+type: module
+description: Provides custom logic for menus.
+package: European Innovation Council
+core: 8.x
+php: 7.3
+core_version_requirement: ^8 || ^9
+dependencies:
+  - menu_trail_by_path:menu_trail_by_path

--- a/lib/modules/eic_menus/eic_menus.services.yml
+++ b/lib/modules/eic_menus/eic_menus.services.yml
@@ -1,0 +1,16 @@
+services:
+  eic_menus.menu_trail_by_path.active_trail:
+    class: Drupal\eic_menus\EICMenuTrailByPathActiveTrail
+    decorates: menu_trail_by_path.active_trail
+    public: false
+    arguments:
+      - '@eic_menus.menu_trail_by_path.active_trail.inner'
+      - '@plugin.manager.menu.link'
+      - '@current_route_match'
+      - '@cache.menu'
+      - '@lock'
+      - '@menu_trail_by_path.path_helper'
+      - '@menu_trail_by_path.menu_helper'
+      - '@router.request_context'
+      - '@language_manager'
+      - '@config.factory'

--- a/lib/modules/eic_menus/src/EICMenuTrailByPathActiveTrail.php
+++ b/lib/modules/eic_menus/src/EICMenuTrailByPathActiveTrail.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\eic_menus;
+
+use Drupal\menu_trail_by_path\MenuTrailByPathActiveTrail;
+use Drupal\system\Entity\Menu;
+
+/**
+ * Decorates menu active trail by path to fix menu active trails.
+ */
+class EICMenuTrailByPathActiveTrail extends MenuTrailByPathActiveTrail {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function doGetActiveTrailIds($menu_name) {
+    // Parent ids; used both as key and value to ensure uniqueness.
+    // We always want all the top-level links with parent == ''.
+    $active_trail = ['' => ''];
+
+    $entity = Menu::load($menu_name);
+    if (!$entity) {
+      // If a link in the given menu indeed matches the route, then use it to
+      // complete the active trail.
+      if ($active_link = $this->getActiveLink($menu_name)) {
+        if ($parents = $this->menuLinkManager->getParentIds($active_link->getPluginId())) {
+          $active_trail = $parents + $active_trail;
+        }
+      }
+
+      return $active_trail;
+    }
+
+    return parent::doGetActiveTrailIds($menu_name);
+  }
+
+}


### PR DESCRIPTION
### Improvements

- Install contrib module menu_trail_by_path;
- Create new custom module eic_menus for custom logic around menus;
- Fix menu active trails when viewing group pages.

### Tests

- [x] Navigate through group pages (group content pages + group overviews) and make sure the link "Groups" in the main menu is active.