### PR TITLE
EICNET-1506: As a TU, I want to see a message on blocked groups (Part 3)

### DIFF
--- a/lib/modules/eic_groups/src/EICGroupsHelper.php
+++ b/lib/modules/eic_groups/src/EICGroupsHelper.php
@@ -167,7 +167,7 @@ class EICGroupsHelper implements EICGroupsHelperInterface {
    *   The group entity.
    * @param \Drupal\Core\Session\AccountInterface $account
    *   The user account object.
-   * @param \Drupal\group\GroupMembership|NULL $membership
+   * @param \Drupal\group\GroupMembership|null $membership
    *   The group membership (optional).
    *
    * @return bool
@@ -551,6 +551,11 @@ class EICGroupsHelper implements EICGroupsHelperInterface {
     $is_group_page = FALSE;
     $current_path = $this->currentPath->getPath();
     $current_url = Url::fromUri("internal:" . $current_path);
+
+    if (!$current_url->isRouted()) {
+      return $is_group_page;
+    }
+
     $route_name = $current_url->getRouteName();
     $route_parameters = $current_url->getRouteParameters();
 


### PR DESCRIPTION
### Bug fixes

- Fix issue checking if a page is a group page when page has not been found.

### Tests

- [ ] Go to a group page
- [ ] Try to append `/something` in the URL and check if you get a page not found instead of `The website encountered an unexpected error. Please try again later.`
- [ ] Check the logs `(admin/reports/dblog)` and make sure there are no errors such as: `UnexpectedValueException: External URLs do not have an internal route name. in Drupal\Core\Url->getRouteName() (line 565 of /opt/approot/current/web/core/lib/Drupal/Core/Url.php).`