### PR TITLE
EICNET-1645: TU (as GM or GO) only sees Overview, About & wiki page of the group (Bugfix)

### DIFF
--- a/lib/modules/eic_overviews/src/Controller/GroupOverviewsController.php
+++ b/lib/modules/eic_overviews/src/Controller/GroupOverviewsController.php
@@ -75,7 +75,7 @@ class GroupOverviewsController extends ControllerBase {
 
     $access = $group->access($overview_perm, $account, TRUE);
 
-    if (!$access->isAllowed()) {
+    if ($access->isForbidden()) {
       return $access;
     }
 


### PR DESCRIPTION
### Bug fixes

- Allow TU and GM to view group overview pages when features are enabled in the group.

### Tests

- [ ] As SA/SCM, enable group features for a public group
- [ ] As TU (non-member), make sure you can access the overview page of every enabled feature
- [ ] As GM/GO, make sure you can access the overview page of every enabled feature