### PR TITLE
EICNET-1656: Empty states for enabled empty blocks

### DIFF
--- a/config/sync/context.context.group_event_homepage.yml
+++ b/config/sync/context.context.group_event_homepage.yml
@@ -10,7 +10,7 @@ name: group_event_homepage
 label: 'Group - Event homepage'
 group: Groups
 description: 'Group group type homepage'
-requireAllConditions: false
+requireAllConditions: true
 disabled: false
 conditions:
   route:

--- a/config/sync/context.context.homepage.yml
+++ b/config/sync/context.context.homepage.yml
@@ -143,6 +143,7 @@ reactions:
         description:
           value: ''
           format: basic_text
+        show_user_activity_feed_link: true
         region: content
         weight: '-2'
         context_mapping: {  }

--- a/config/sync/views.view.group_discussions.yml
+++ b/config/sync/views.view.group_discussions.yml
@@ -10,7 +10,6 @@ dependencies:
     - flag
     - group
     - node
-    - user
 _core:
   default_config_hash: eKWN3z9j-zM3Sn_r3-u4y7-TtiRshBKXOJLqXRtFfwc
 id: group_discussions
@@ -28,9 +27,9 @@ display:
     position: 0
     display_options:
       access:
-        type: perm
+        type: group_permission
         options:
-          perm: 'access content'
+          group_permission: 'access discussions overview'
       cache:
         type: tag
         options: {  }
@@ -199,7 +198,18 @@ display:
             format: plain_text
           plugin_id: text
       footer: {  }
-      empty: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content: 'We haven’t found any discussions in the group.'
+          plugin_id: text_custom
       relationships:
         flag_relationship:
           id: flag_relationship
@@ -279,9 +289,10 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - route
+        - route.group
         - url
+        - user.group_permissions
         - 'user.node_grants:view'
-        - user.permissions
       tags: {  }
   block_1:
     display_plugin: block
@@ -296,7 +307,8 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - route
+        - route.group
         - url
+        - user.group_permissions
         - 'user.node_grants:view'
-        - user.permissions
       tags: {  }

--- a/config/sync/views.view.group_documents.yml
+++ b/config/sync/views.view.group_documents.yml
@@ -10,7 +10,6 @@ dependencies:
     - flag
     - group
     - node
-    - user
 _core:
   default_config_hash: eKWN3z9j-zM3Sn_r3-u4y7-TtiRshBKXOJLqXRtFfwc
 id: group_documents
@@ -28,9 +27,9 @@ display:
     position: 0
     display_options:
       access:
-        type: perm
+        type: group_permission
         options:
-          perm: 'access content'
+          group_permission: 'access files overview'
       cache:
         type: tag
         options: {  }
@@ -229,7 +228,18 @@ display:
             format: plain_text
           plugin_id: text
       footer: {  }
-      empty: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content: 'We haven’t found any documents in the group.'
+          plugin_id: text_custom
       relationships:
         flag_relationship:
           id: flag_relationship
@@ -309,9 +319,10 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - route
+        - route.group
         - url
+        - user.group_permissions
         - 'user.node_grants:view'
-        - user.permissions
       tags: {  }
   block_1:
     display_plugin: block
@@ -326,7 +337,8 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - route
+        - route.group
         - url
+        - user.group_permissions
         - 'user.node_grants:view'
-        - user.permissions
       tags: {  }

--- a/config/sync/views.view.group_related_groups.yml
+++ b/config/sync/views.view.group_related_groups.yml
@@ -143,7 +143,18 @@ display:
       sorts: {  }
       header: {  }
       footer: {  }
-      empty: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content: 'We haven’t found any related groups.'
+          plugin_id: text_custom
       relationships: {  }
       arguments: {  }
       display_extenders: {  }
@@ -313,5 +324,7 @@ display:
         - route
         - url
       tags:
+        - 'config:core.entity_view_display.group.event.default'
+        - 'config:core.entity_view_display.group.group.about_page'
         - 'config:core.entity_view_display.group.group.default'
         - 'config:core.entity_view_display.group.group.teaser'

--- a/config/sync/views.view.group_related_news_stories.yml
+++ b/config/sync/views.view.group_related_news_stories.yml
@@ -300,6 +300,20 @@ display:
     position: 1
     display_options:
       display_extenders: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content: 'We haven’t found any stories related to this group.'
+          plugin_id: text_custom
+      defaults:
+        empty: false
     cache_metadata:
       max-age: -1
       contexts:

--- a/lib/themes/eic_community/templates/views/views-view--featured-content-collection.html.twig
+++ b/lib/themes/eic_community/templates/views/views-view--featured-content-collection.html.twig
@@ -53,4 +53,11 @@
     items: _items,
     extra_classes: 'ecl-featured-content-collection--has-overview-layout ecl-featured-content-collection--is-ready',
   } only %}
+{% else %}
+  {% include "@theme/patterns/compositions/featured-content-collection.html.twig" with {
+    title: view.title|default(''),
+    description: empty,
+    items: [],
+    extra_classes: 'ecl-featured-content-collection--has-overview-layout ecl-featured-content-collection--is-ready',
+  } only %}
 {% endif %}


### PR DESCRIPTION
### Improvements

- Add empty text to group overview page lists;
- Hide group overview lists if features are disabled.

### Tests

- [ ] Create a new group, enable all group features
- [ ] Go to group overview page and make sure all the blocks from group features are shown with an empty text message
- [ ] Try to disable all features and make sure the blocks are now hidden in the group overview page