### PR TITLE
[EICNET-1702] Fix: height of the teaser groups when title take 2 lines

### DIFF
--- a/lib/themes/eic_community/sass/compositions/_teaser.scss
+++ b/lib/themes/eic_community/sass/compositions/_teaser.scss
@@ -6,6 +6,8 @@
   @include ecl-media-breakpoint-up('sm') {
     display: flex;
     align-items: stretch;
+    height: 100%;
+    box-sizing: border-box;
   }
 
   @include ecl-media-breakpoint-up('sm') {


### PR DESCRIPTION
add height 100% on teaser groups elements