### PR TITLE
EICNET-1546: Fix group block/publish operation links

### DIFF
--- a/lib/modules/eic_flags/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_flags/src/Hooks/EntityOperations.php
@@ -165,6 +165,16 @@ class EntityOperations implements ContainerInjectionInterface {
       ];
     }
 
+    if ($entity->hasLinkTemplate('block-entity')) {
+      if ($entity->toUrl('block-entity')->access()) {
+        $operations['block'] = [
+          'title' => $this->t('Block'),
+          'url' => $entity->toUrl('block-entity')
+            ->setRouteParameter('destination', $this->currentRequest->getRequestUri()),
+        ];
+      }
+    }
+
     return $operations;
   }
 
@@ -182,6 +192,17 @@ class EntityOperations implements ContainerInjectionInterface {
       $handler = $this->collector->getHandlerByType($request_type);
 
       return $handler->getActions($entity);
+    }
+
+    $operations = [];
+    if ($entity->hasLinkTemplate('block-entity')) {
+      if ($entity->toUrl('block-entity')->access()) {
+        $operations['block'] = [
+          'title' => $this->t('Block'),
+          'url' => $entity->toUrl('block-entity')
+            ->setRouteParameter('destination', $this->currentRequest->getRequestUri()),
+        ];
+      }
     }
 
     $route_name = $this->routeMatch->getRouteName();
@@ -204,13 +225,13 @@ class EntityOperations implements ContainerInjectionInterface {
       && (int) $flag_id === FlaggedEntitiesListBuilder::VIEW_ARCHIVE_FLAG_ID
       && $url->access($this->account)
     ) {
-      return [
-        'publish' => [
-          'title' => $this->t('Publish'),
-          'url' => $url,
-        ],
+      $operations['publish'] = [
+        'title' => $this->t('Publish'),
+        'url' => $url,
       ];
     }
+
+    return $operations;
   }
 
   /**

--- a/lib/modules/eic_flags/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_flags/src/Hooks/EntityOperations.php
@@ -165,14 +165,14 @@ class EntityOperations implements ContainerInjectionInterface {
       ];
     }
 
-    if ($entity->hasLinkTemplate('block-entity')) {
-      if ($entity->toUrl('block-entity')->access()) {
-        $operations['block'] = [
-          'title' => $this->t('Block'),
-          'url' => $entity->toUrl('block-entity')
-            ->setRouteParameter('destination', $this->currentRequest->getRequestUri()),
-        ];
-      }
+    if ($entity->hasLinkTemplate('block-entity')
+      && $entity->toUrl('block-entity')->access()
+    ) {
+      $operations['block'] = [
+        'title' => $this->t('Block'),
+        'url' => $entity->toUrl('block-entity')
+          ->setRouteParameter('destination', $this->currentRequest->getRequestUri()),
+      ];
     }
 
     return $operations;
@@ -195,14 +195,14 @@ class EntityOperations implements ContainerInjectionInterface {
     }
 
     $operations = [];
-    if ($entity->hasLinkTemplate('block-entity')) {
-      if ($entity->toUrl('block-entity')->access()) {
-        $operations['block'] = [
-          'title' => $this->t('Block'),
-          'url' => $entity->toUrl('block-entity')
-            ->setRouteParameter('destination', $this->currentRequest->getRequestUri()),
-        ];
-      }
+    if ($entity->hasLinkTemplate('block-entity')
+      && $entity->toUrl('block-entity')->access()
+    ) {
+      $operations['block'] = [
+        'title' => $this->t('Block'),
+        'url' => $entity->toUrl('block-entity')
+          ->setRouteParameter('destination', $this->currentRequest->getRequestUri()),
+      ];
     }
 
     $route_name = $this->routeMatch->getRouteName();

--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -451,38 +451,19 @@ function eic_groups_entity_operation_alter(array &$operations, EntityInterface $
     return;
   }
 
-  // Gets current path alias.
-  $current_path = \Drupal::service('path.current')->getPath();
-  $current_path_alias = \Drupal::service('path_alias.manager')
-    ->getAliasByPath($current_path);
-
-  // Add publish group operation.
-  $publish_url_options = [
+  $url_options = [
     'query' => [
-      'destination' => $current_path_alias,
+      'destination' => \Drupal::requestStack()->getCurrentRequest()->getRequestUri(),
     ],
   ];
-  $publish_url = Url::fromRoute('eic_groups.group.publish.confirm_form', ['group' => $entity->id()], $publish_url_options);
+
+  // Add block group operation.
+  $publish_url = Url::fromRoute('eic_groups.group.publish.confirm_form', ['group' => $entity->id()], $url_options);
   if ($publish_url->access()) {
     $operations['publish'] = [
       'title' => t('Publish'),
       'weight' => -50,
       'url' => $publish_url,
-    ];
-  }
-
-  // Add block group operation.
-  $block_group_url_options = [
-    'query' => [
-      'destination' => $current_path_alias,
-    ],
-  ];
-  $block_group_url = Url::fromRoute('entity.group.block_entity', ['group' => $entity->id()], $block_group_url_options);
-  if ($block_group_url->access()) {
-    $operations['block'] = [
-      'title' => t('Block'),
-      'weight' => -50,
-      'url' => $block_group_url,
     ];
   }
 }

--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -457,7 +457,7 @@ function eic_groups_entity_operation_alter(array &$operations, EntityInterface $
     ],
   ];
 
-  // Add block group operation.
+  // Add publish group operation.
   $publish_url = Url::fromRoute('eic_groups.group.publish.confirm_form', ['group' => $entity->id()], $url_options);
   if ($publish_url->access()) {
     $operations['publish'] = [


### PR DESCRIPTION
### Fixes

- Fix block/publish operation links so that the destination URL takes into account the base path.

### Tests

- [ ] Go to a published group page
- [ ] Click on block
- [ ] Add a reason a press block
- [ ] You should be redirected back to the group page and you shouldn't get any error like: `Redirects to external URLs are not allowed by default, use \Drupal\Core\Routing\TrustedRedirectResponse`