### PR TITLE
EICNET-1679: Fix Admin Events page title

### DIFF
--- a/config/sync/views.view.admin_groups.yml
+++ b/config/sync/views.view.admin_groups.yml
@@ -1293,10 +1293,12 @@ display:
       defaults:
         filters: false
         filter_groups: false
+        title: false
       filter_groups:
         operator: AND
         groups:
           1: AND
+      title: 'Admin - Events'
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
### Tests

- [ ] Go to `/admin/community/events` and check if the page title is "Admin - Events"