### PR TITLE
EICNET-1373: Change "invite member" default settings in group creation form (Rework)

### DIFF
--- a/lib/modules/oec_group_flex/src/Entity/Form/GroupForm.php
+++ b/lib/modules/oec_group_flex/src/Entity/Form/GroupForm.php
@@ -273,14 +273,14 @@ class GroupForm extends GroupFormBase {
       }
     }
 
-    // If the group is new and the selected joining method is
-    // "tu_group_membership_request", we enable member invitations by default.
+    // If the group is new and the selected joining method is "tu_open_method",
+    // we enable member invitations by default.
     // This logic needs to be triggered during this process because the group
     // visibility and joining methods are saved previously after the group is
     // saved in the Database.
     if ($is_new &&
       $group->hasField('field_group_invite_members') &&
-      ($groupFlexSettings['settings']['visibility']['plugin_id'] === 'private' || $groupFlexSettings['settings']['joining_methods'] === 'tu_group_membership_request')
+      $groupFlexSettings['settings']['joining_methods'] === 'tu_open_method'
     ) {
       $group->set('field_group_invite_members', TRUE);
       $group->save();


### PR DESCRIPTION
### Improvements

- Set "invite members" enabled by default when creating a new group with joining method set to "tu_open_method" instead of "tu_group_membership_request"

### Tests

- [ ] Create a new group and select joining method "Open"
- [ ] Save the group
- [ ] Make sure the members invitations are enabled (you can check this in the group edit form)
- [ ] Create another group and select joining method "Request (for trusted users)". **Note**: do **not** check the box "Invite members"
- [ ] Save the group
- [ ] Make sure the members invitations are disabled (you can check this in the group edit form)