### PR TITLE
[EICNET] Feat: Topics overview in storybook

### DIFF
--- a/lib/themes/eic_community/patterns/compositions/topic/topic.details.html.twig
+++ b/lib/themes/eic_community/patterns/compositions/topic/topic.details.html.twig
@@ -1,0 +1,112 @@
+
+ {% extends "@theme/patterns/layout/base.html.twig" %}
+
+{% block page_header %}
+  {% include "@theme/patterns/compositions/overview-header.html.twig" with {
+    title_element: 'h1',
+    title: title,
+    image: image,
+  } only %}
+
+  {% include "@theme/patterns/compositions/breadcrumb.html.twig" with breadcrumb|default({}) only %}
+
+  {% include "@theme/patterns/compositions/editorial-header.html.twig" with editorial_header|default({})|merge({
+    extra_classes: 'ecl-editorial-header--is-compact',
+  }) only %}
+
+{% endblock %}
+
+
+
+{% block content %}
+  {% embed "@theme/patterns/compositions/editorial-overview.html.twig" with editorial_article|default({}) %}
+    {% block content %}
+
+      <h2>{{ title }}</h2>
+      <p>{{ body }}</p>
+
+      {% if stats %}
+        {% include '@theme/patterns/compositions/topic/topic.stats.html.twig' with stats|default({})|merge({
+          icon_file_path: icon_file_path
+        }) %}
+      {% endif %}
+
+      {% if activityStream %}
+        {% include '@theme/patterns/compositions/activity-stream.html.twig' with activityStream|default({})|merge({
+          title_element: "h2"
+        }) %}
+      {% endif %}
+
+      {% if related_groups %}
+        {% include "@theme/patterns/compositions/featured-content-collection.html.twig" with related_groups|default({})|merge({
+          extra_classes: "ecl-section-wrapper ecl-section-wrapper--is-white ecl-featured-content-collection--has-overview-layout",
+          icon_file_path: common.icon_file_path,
+          no_container: true,
+          items_extra_classes: "ecl-featured-content-collection__item--big"
+        }) only %}
+      {% endif %}
+
+      {% if related_companies %}
+        {% include "@theme/patterns/compositions/featured-content-collection.html.twig" with related_companies|default({})|merge({
+          icon_file_path: common.icon_file_path,
+          extra_classes: "ecl-section-wrapper ecl-section-wrapper--is-white ecl-featured-content-collection--has-overview-layout",
+          no_container: true
+        }) only %}
+      {% endif %}
+
+
+      {% if related_stories %}
+        {% include "@theme/patterns/compositions/featured-content-collection.html.twig" with related_stories|default({})|merge({
+          icon_file_path: common.icon_file_path,
+          extra_classes: "ecl-section-wrapper ecl-section-wrapper--is-white ecl-featured-content-collection--has-list-layout",
+          no_container: true,
+
+        }) only %}
+      {% endif %}
+
+      {% if discussions %}
+        {% include "@theme/patterns/compositions/featured-content-collection.html.twig" with discussions|default({})|merge({
+          icon_file_path: common.icon_file_path,
+          extra_classes: "ecl-section-wrapper ecl-section-wrapper--is-white ecl-featured-content-collection--has-list-layout",
+          no_container: true,
+          items_extra_classes: "ecl-featured-content-collection__item--big"
+        }) only %}
+      {% endif %}
+
+      {% if related_documents %}
+        {% include "@theme/patterns/compositions/featured-content-collection.html.twig" with related_documents|default({})|merge({
+          icon_file_path: common.icon_file_path,
+          extra_classes: "ecl-section-wrapper ecl-section-wrapper--is-white ecl-featured-content-collection--has-list-layout",
+          no_container: true,
+          items_extra_classes: "ecl-featured-content-collection__item--big"
+        }) only %}
+      {% endif %}
+
+      {% if events %}
+        {% include "@theme/patterns/compositions/featured-content-collection.html.twig" with events|default({})|merge({
+          icon_file_path: common.icon_file_path,
+          extra_classes: "ecl-section-wrapper ecl-section-wrapper--is-white ecl-featured-content-collection--has-list-layout",
+          no_container: true,
+          items_extra_classes: "ecl-featured-content-collection__item--big"
+        }) only %}
+      {% endif %}
+
+      {{ content }}
+
+    {% endblock %}
+
+    {% block sidebar %}
+
+      {% if topics %}
+        {% include "@theme/patterns/compositions/featured-topics.html.twig" with topics|default({}) %}
+      {% endif %}
+
+      {% if contributors %}
+        {% include "@theme/patterns/compositions/featured-contributors.html.twig" with contributors|default({}) %}
+      {% endif %}
+
+    {% endblock %}
+  {% endembed %}
+
+
+{% endblock %}

--- a/lib/themes/eic_community/patterns/compositions/topic/topic.overview.html.twig
+++ b/lib/themes/eic_community/patterns/compositions/topic/topic.overview.html.twig
@@ -19,94 +19,19 @@
 
 
 {% block content %}
-  {% embed "@theme/patterns/compositions/editorial-overview.html.twig" with editorial_article|default({}) %}
-    {% block content %}
 
-      <h2>{{ title }}</h2>
-      <p>{{ body }}</p>
+  <div class="ecl-container ecl-topic__overview">
+    <h2>{{ title }}</h2>
+    <p>{{ body }}</p>
 
-      {% if stats %}
-        {% include '@theme/patterns/compositions/topic/topic.stats.html.twig' with stats|default({})|merge({
+    <div class="ecl-topic__overview__items">
+      {% for topic in topics %}
+        {% include "@theme/patterns/compositions/topic/topic.overview.item.html.twig" with topic|merge({
           icon_file_path: icon_file_path
         }) %}
-      {% endif %}
-
-      {% if activityStream %}
-        {% include '@theme/patterns/compositions/activity-stream.html.twig' with activityStream|default({})|merge({
-          title_element: "h2"
-        }) %}
-      {% endif %}
-
-      {% if related_groups %}
-        {% include "@theme/patterns/compositions/featured-content-collection.html.twig" with related_groups|default({})|merge({
-          extra_classes: "ecl-section-wrapper ecl-section-wrapper--is-white ecl-featured-content-collection--has-overview-layout",
-          icon_file_path: common.icon_file_path,
-          no_container: true,
-          items_extra_classes: "ecl-featured-content-collection__item--big"
-        }) only %}
-      {% endif %}
-
-      {% if related_companies %}
-        {% include "@theme/patterns/compositions/featured-content-collection.html.twig" with related_companies|default({})|merge({
-          icon_file_path: common.icon_file_path,
-          extra_classes: "ecl-section-wrapper ecl-section-wrapper--is-white ecl-featured-content-collection--has-overview-layout",
-          no_container: true
-        }) only %}
-      {% endif %}
-
-
-      {% if related_stories %}
-        {% include "@theme/patterns/compositions/featured-content-collection.html.twig" with related_stories|default({})|merge({
-          icon_file_path: common.icon_file_path,
-          extra_classes: "ecl-section-wrapper ecl-section-wrapper--is-white ecl-featured-content-collection--has-list-layout",
-          no_container: true,
-
-        }) only %}
-      {% endif %}
-
-      {% if discussions %}
-        {% include "@theme/patterns/compositions/featured-content-collection.html.twig" with discussions|default({})|merge({
-          icon_file_path: common.icon_file_path,
-          extra_classes: "ecl-section-wrapper ecl-section-wrapper--is-white ecl-featured-content-collection--has-list-layout",
-          no_container: true,
-          items_extra_classes: "ecl-featured-content-collection__item--big"
-        }) only %}
-      {% endif %}
-
-      {% if related_documents %}
-        {% include "@theme/patterns/compositions/featured-content-collection.html.twig" with related_documents|default({})|merge({
-          icon_file_path: common.icon_file_path,
-          extra_classes: "ecl-section-wrapper ecl-section-wrapper--is-white ecl-featured-content-collection--has-list-layout",
-          no_container: true,
-          items_extra_classes: "ecl-featured-content-collection__item--big"
-        }) only %}
-      {% endif %}
-
-      {% if events %}
-        {% include "@theme/patterns/compositions/featured-content-collection.html.twig" with events|default({})|merge({
-          icon_file_path: common.icon_file_path,
-          extra_classes: "ecl-section-wrapper ecl-section-wrapper--is-white ecl-featured-content-collection--has-list-layout",
-          no_container: true,
-          items_extra_classes: "ecl-featured-content-collection__item--big"
-        }) only %}
-      {% endif %}
-
-      {{ content }}
-
-    {% endblock %}
-
-    {% block sidebar %}
-
-      {% if topics %}
-        {% include "@theme/patterns/compositions/featured-topics.html.twig" with topics|default({}) %}
-      {% endif %}
-
-      {% if contributors %}
-        {% include "@theme/patterns/compositions/featured-contributors.html.twig" with contributors|default({}) %}
-      {% endif %}
-
-    {% endblock %}
-  {% endembed %}
-
+      {% endfor %}
+    </div>
+    {{ content }}
+  </div>
 
 {% endblock %}

--- a/lib/themes/eic_community/patterns/compositions/topic/topic.overview.html.twig
+++ b/lib/themes/eic_community/patterns/compositions/topic/topic.overview.html.twig
@@ -24,13 +24,12 @@
     <h2>{{ title }}</h2>
     <p>{{ body }}</p>
 
-    <div class="ecl-topic__overview__items">
-      {% for topic in topics %}
-        {% include "@theme/patterns/compositions/topic/topic.overview.item.html.twig" with topic|merge({
-          icon_file_path: icon_file_path
-        }) %}
-      {% endfor %}
-    </div>
+    {% if topics %}
+      {% include "@theme/patterns/compositions/topic/topic.overview.list.html.twig" with topics|merge({
+        icon_file_path: icon_file_path,
+      }) %}
+    {% endif %}
+
     {{ content }}
   </div>
 

--- a/lib/themes/eic_community/patterns/compositions/topic/topic.overview.item.html.twig
+++ b/lib/themes/eic_community/patterns/compositions/topic/topic.overview.item.html.twig
@@ -1,0 +1,10 @@
+<div class="ecl-topic__overview__item">
+  <h3>{{ title }}</h3>
+  <div class="ecl-topic__overview__subitems">
+    {% for item in items %}
+      {% include "@theme/patterns/compositions/topic/topic.overview.subitem.html.twig" with item|merge({
+        icon_file_path: icon_file_path
+      }) %}
+    {% endfor %}
+  </div>
+</div>

--- a/lib/themes/eic_community/patterns/compositions/topic/topic.overview.list.html.twig
+++ b/lib/themes/eic_community/patterns/compositions/topic/topic.overview.list.html.twig
@@ -1,0 +1,7 @@
+<div class="ecl-topic__overview__items">
+  {% for topic in topics %}
+    {% include "@theme/patterns/compositions/topic/topic.overview.item.html.twig" with topic|merge({
+      icon_file_path: icon_file_path
+    }) %}
+  {% endfor %}
+</div>

--- a/lib/themes/eic_community/patterns/compositions/topic/topic.overview.subitem.html.twig
+++ b/lib/themes/eic_community/patterns/compositions/topic/topic.overview.subitem.html.twig
@@ -3,21 +3,23 @@
     <img src="{{ image.src }}" alt="">
     <div class="ecl-topic__overview__subitem__content">
       <h3>{{ title }}</h3>
-      <div class="ecl-topic__overview__subitem__stats">
-        {% for stat in stats %}
-          <div class="ecl-topic__overview__subitem__stat">
-            {% include '@ecl-twig/ec-component-icon/ecl-icon.html.twig' with {
-              icon: {
-                size: 'm',
-                path: icon_file_path,
-                type: stat.icon.type,
-                name: stat.icon.name
-              }
-            } only %}
-            <span>&nbsp;{{ stat.stat }}</span>
-          </div>
-        {% endfor %}
-      </div>
+      {% if stats is not empty %}
+        <div class="ecl-topic__overview__subitem__stats">
+          {% for stat in stats %}
+            <div class="ecl-topic__overview__subitem__stat">
+              {% include '@ecl-twig/ec-component-icon/ecl-icon.html.twig' with {
+                icon: {
+                  size: 'm',
+                  path: icon_file_path,
+                  type: stat.icon.type,
+                  name: stat.icon.name
+                }
+              } only %}
+              <span>&nbsp;{{ stat.stat }}</span>
+            </div>
+          {% endfor %}
+        </div>
+      {% endif %}
     </div>
   </a>
 </div>

--- a/lib/themes/eic_community/patterns/compositions/topic/topic.overview.subitem.html.twig
+++ b/lib/themes/eic_community/patterns/compositions/topic/topic.overview.subitem.html.twig
@@ -1,0 +1,23 @@
+<div class="ecl-topic__overview__subitem">
+  <a href="{{ url }}">
+    <img src="{{ image.src }}" alt="">
+    <div class="ecl-topic__overview__subitem__content">
+      <h3>{{ title }}</h3>
+      <div class="ecl-topic__overview__subitem__stats">
+        {% for stat in stats %}
+          <div class="ecl-topic__overview__subitem__stat">
+            {% include '@ecl-twig/ec-component-icon/ecl-icon.html.twig' with {
+              icon: {
+                size: 'm',
+                path: icon_file_path,
+                type: stat.icon.type,
+                name: stat.icon.name
+              }
+            } only %}
+            <span>&nbsp;{{ stat.stat }}</span>
+          </div>
+        {% endfor %}
+      </div>
+    </div>
+  </a>
+</div>

--- a/lib/themes/eic_community/sass/compositions/_topic.scss
+++ b/lib/themes/eic_community/sass/compositions/_topic.scss
@@ -1,3 +1,76 @@
+.ecl-topic__overview {
+
+  & > p {
+    max-width: 66%;
+    @include ecl-media-breakpoint-down('md') {
+      max-width: 100%;
+    }
+  }
+
+  &__subitems {
+    display: flex;
+    flex-wrap: wrap;
+    gap: $ecl-spacing-s;
+    margin-bottom: $ecl-spacing-m;
+  }
+
+  &__subitem {
+    background-color: $ecl-color-grey-15;
+    width: calc(33% - #{$ecl-spacing-s / 2});
+    @include ecl-media-breakpoint-down('lg') {
+      width: calc(50% - #{$ecl-spacing-s});
+    }
+    @include ecl-media-breakpoint-down('sm') {
+      width: 100%;
+    }
+    & a {
+      display: flex;
+      &:hover {
+        text-decoration: none;
+        h3 {
+          text-decoration: underline;
+        }
+      }
+    }
+    & a > img {
+      width: 160px;
+      height: 160px;
+      object-fit: cover;
+      @include ecl-media-breakpoint-down('sm') {
+        width: 100px;
+        height: 100px;
+      }
+    }
+    &__content {
+      width: 100%;
+      padding: $ecl-spacing-s;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+
+      & h3 {
+        color: $ecl-color-blue;
+        font-weight: bold;
+        margin-top: 0;
+        @include ecl-media-breakpoint-down('sm') {
+          font-size: .85em;
+        }
+      }
+    }
+    &__stats, &__stats > div {
+      display: flex;
+      align-items: center;
+      color: $ecl-color-grey-50;
+      font-size: .85em;
+    }
+
+    &__stats {
+      gap: $ecl-spacing-s;
+      align-self: flex-end;
+    }
+  }
+}
+
 .ecl-topic__stats {
   display: flex;
   align-items: center;

--- a/lib/themes/eic_community/snippets/index.js
+++ b/lib/themes/eic_community/snippets/index.js
@@ -126,3 +126,27 @@ export const slice = (data, length = 3) => {
 
   return data;
 };
+
+function shuffle(array) {
+  let currentIndex = array.length,  randomIndex;
+
+  while (currentIndex != 0) {
+
+    randomIndex = Math.floor(Math.random() * currentIndex);
+    currentIndex--;
+
+    [array[currentIndex], array[randomIndex]] = [
+      array[randomIndex], array[currentIndex]];
+  }
+
+  return array;
+}
+
+export const randomString = (o) => {
+  const options = {
+    string: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+    length: Math.ceil(Math.random() * 7),
+    ...o
+  }
+  return shuffle(options.string.split(" ")).slice(0, options.length).join(" ")
+}

--- a/lib/themes/eic_community/styleguide/bundles/topic.stories.js
+++ b/lib/themes/eic_community/styleguide/bundles/topic.stories.js
@@ -2,24 +2,32 @@ export default {
   title: 'Bundles / Topic',
 };
 
-import activityStream from '@theme/data/activity-stream.data.js';
+import AttachmentTemplate from '@theme/patterns/components/attachment.html.twig';
+import attachment from '@theme/data/attachment.data';
+
+import FilelistTeaserTemplate from '@theme/patterns/compositions/filelist/filelist.teaser.html.twig';
+
+import FrontDetailsTemplate from '@theme/patterns/compositions/topic/topic.details.html.twig';
+import FrontOverviewTemplate from '@theme/patterns/compositions/topic/topic.overview.html.twig';
 import breadcrumb from '@theme/data/breadcrumb.data';
 import common from '@theme/data/common.data';
-import contributors from '@theme/data/contributors.data.js';
-import featuredContentCollection from '@theme/data/featured-content-collection';
+import mainmenu from '@theme/data/mainmenu.data';
 import pagination from '@theme/data/pagination.data';
 import searchform from '@theme/data/searchform.data';
 import siteFooter from '@theme/data/site-footer.data';
-import siteHeader from '@theme/data/site-header.data';
-import teaser from '@theme/data/teaser';
-import topics from '@theme/data/topics.data';
 import topMenu from '@theme/data/top-menu.data';
-
-import FilelistTeaserTemplate from '@theme/patterns/compositions/filelist/filelist.teaser.html.twig';
-import FrontDetailsTemplate from '@theme/patterns/compositions/topic/topic.details.html.twig';
-import FrontOverviewTemplate from '@theme/patterns/compositions/topic/topic.overview.html.twig';
+import topics from '@theme/data/topics.data';
+import contributors from '@theme/data/contributors.data.js';
+import featuredContentCollection from '@theme/data/featured-content-collection';
 import TeaserTemplate from '@theme/patterns/compositions/group/group.teaser.html.twig';
-import { mockItems, randomString } from '@theme/snippets';
+
+import teaser from '@theme/data/teaser';
+
+import activityStream from '@theme/data/activity-stream.data.js';
+
+import siteHeader from '@theme/data/site-header.data';
+
+import { editableField, mockItems, withoutn, randomString } from '@theme/snippets';
 
 const overview = {
   breadcrumb: breadcrumb,
@@ -35,7 +43,7 @@ const overviewItem = {
   "title": randomString(),
   "url": "#",
   "image": {
-    src: 'https://picsum.photos/1600/400',
+    src: 'https://picsum.photos/200/200',
   },
   stats: {
     groups: {

--- a/lib/themes/eic_community/styleguide/bundles/topic.stories.js
+++ b/lib/themes/eic_community/styleguide/bundles/topic.stories.js
@@ -1,34 +1,25 @@
-import {event_infos_items} from "../../data/event.data";
-
 export default {
   title: 'Bundles / Topic',
 };
 
-import AttachmentTemplate from '@theme/patterns/components/attachment.html.twig';
-import attachment from '@theme/data/attachment.data';
-
-import FilelistTeaserTemplate from '@theme/patterns/compositions/filelist/filelist.teaser.html.twig';
-
-import FrontpageTemplate from '@theme/patterns/compositions/topic/topic.overview.html.twig';
+import activityStream from '@theme/data/activity-stream.data.js';
 import breadcrumb from '@theme/data/breadcrumb.data';
 import common from '@theme/data/common.data';
-import mainmenu from '@theme/data/mainmenu.data';
+import contributors from '@theme/data/contributors.data.js';
+import featuredContentCollection from '@theme/data/featured-content-collection';
 import pagination from '@theme/data/pagination.data';
 import searchform from '@theme/data/searchform.data';
 import siteFooter from '@theme/data/site-footer.data';
-import topMenu from '@theme/data/top-menu.data';
-import topics from '@theme/data/topics.data';
-import contributors from '@theme/data/contributors.data.js';
-import featuredContentCollection from '@theme/data/featured-content-collection';
-import TeaserTemplate from '@theme/patterns/compositions/group/group.teaser.html.twig';
-
-import teaser from '@theme/data/teaser';
-
-import activityStream from '@theme/data/activity-stream.data.js';
-
 import siteHeader from '@theme/data/site-header.data';
+import teaser from '@theme/data/teaser';
+import topics from '@theme/data/topics.data';
+import topMenu from '@theme/data/top-menu.data';
 
-import { editableField, mockItems, without } from '@theme/snippets';
+import FilelistTeaserTemplate from '@theme/patterns/compositions/filelist/filelist.teaser.html.twig';
+import FrontDetailsTemplate from '@theme/patterns/compositions/topic/topic.details.html.twig';
+import FrontOverviewTemplate from '@theme/patterns/compositions/topic/topic.overview.html.twig';
+import TeaserTemplate from '@theme/patterns/compositions/group/group.teaser.html.twig';
+import { mockItems, randomString } from '@theme/snippets';
 
 const overview = {
   breadcrumb: breadcrumb,
@@ -40,105 +31,32 @@ const overview = {
   top_menu: topMenu,
   pagination: pagination,
 };
-
-const header = {
-  icon_file_path: common.icon_file_path,
-  description: editableField(),
-  title: 'The big debate about the Climate',
-  image: {
-    src: 'http://picsum.photos/320/160',
+const overviewItem = {
+  "title": randomString(),
+  "url": "#",
+  "image": {
+    src: 'https://picsum.photos/1600/400',
   },
-  flags: [
-    {
+  stats: {
+    groups: {
+      stat: 10,
       icon: {
-        name: 'like',
-        type: 'custom',
-      },
-      link: {
-        label: 'Like (5)',
-      },
+        type: "custom",
+        name: "group"
+      }
     },
-    {
+    experts: {
+      stat: 3,
       icon: {
-        name: 'follow',
-        type: 'custom',
-      },
-      link: {
-        label: 'Follow (24)',
-      },
-    },
-  ],
-  tags: [
-    {
-      tag: {
-        label: 'Public',
-      },
-      extra_classes: 'ecl-tag--is-public',
-    },
-  ],
-  actions: [
-    {
-      link: {
-        label: 'Login to join group',
-        path: '#path=request',
-      },
-    },
-  ],
-  stats: [
-    {
-      label: 'Members',
-      path: '#foo',
-      value: 294,
-      icon: {
-        name: 'group',
-        type: 'custom',
-      },
-      updates: {
-        label: 'Latest members from the past 14 days.',
-        value: 14,
-      },
-    },
-    {
-      label: 'Comments',
-      path: '#foo',
-      value: 33,
-      icon: {
-        name: 'comment',
-        type: 'custom',
-      },
-    },
-    {
-      label: 'Attachments',
-      value: 4,
-      icon: {
-        name: 'documents',
-        type: 'custom',
-      },
-    },
-    {
-      label: 'events',
-      value: 2,
-      icon: {
-        name: 'calendar',
-        type: 'custom',
-      },
-    },
-  ],
-  parent: {
-    link: {
-      label: 'All Groups',
-      path: '?path=groups',
-    },
-  },
-};
-
-const topicDetails = {
-  title: 'Subtopic name',
-  body: '<p>Lorem ipsum dolor sit amet, facilisi vulputate ne sea, quod tamquam eam ex. Ut inani nostrud torquatos eam. Et hinc graeco facete his. Ea nibh eleifend sea, quo praesent expetenda conceptam cu. Regione tritani vim in, eam eu mundi adolescens. At est decore persius accusata.</p><p>Denique hendrerit delicatissimi no quo, eu quo suas facer putent, ex fastidii placerat senserit qui. At qui diam phaedrum, ex usu lucilius petentium neglegentur. Nam no elitr consulatu adversarium, his graeco euismod alienum an. Putent dignissim sea id, usu ei zril prompta recteque. Malis delectus ut sea. Pro id epicuri probatus convenire.</p>',
+        type: "custom",
+        name: "user_circle"
+      }
+    }
+  }
 }
 
-export const TopicOverview = () =>
-  FrontpageTemplate(
+export const TopicDetails = () =>
+  FrontDetailsTemplate(
     Object.assign(
       {
         title: 'Subtopic name',
@@ -237,6 +155,40 @@ export const TopicOverview = () =>
           ),
         },
         events: {...featuredContentCollection.event, title: "Related events"},
+      },
+      overview
+    )
+  );
+
+export const TopicOverview = () =>
+  FrontOverviewTemplate(
+    Object.assign(
+      {
+        editorial_header: {
+          icon_file_path: common.icon_file_path,
+          parent: {
+            link: {
+              label: 'Previous page',
+              path: '#',
+            },
+          },
+        },
+        title: 'Topic overview',
+        image: {
+          src: 'https://picsum.photos/1600/400',
+        },
+        body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+        icon_file_path: common.icon_file_path,
+        topics: [
+          {
+            title: "Horizontal",
+            items: mockItems(overviewItem, 10)
+          },
+          {
+            title: "Topic",
+            items:  mockItems(overviewItem, 8)
+          }
+        ],
       },
       overview
     )

--- a/lib/themes/eic_community/styleguide/compositions/topics.docs.mdx
+++ b/lib/themes/eic_community/styleguide/compositions/topics.docs.mdx
@@ -1,0 +1,66 @@
+# Topics list
+
+Displays a section with all topics
+
+## Example:
+
+```
+{% include "@theme/patterns/compositions/topic/topic.overview.list.html.twig" with topics %}
+```
+
+## List parameters:
+
+| Key            | Type   | Description                                              | Mandatory |
+| -------------- | ------ | -------------------------------------------------------- | --------- |
+| Topics         | array | List of a topics                                         | yes       |
+
+## Data structure:
+```
+{
+  icon_file_path: common.icon_file_path,
+  topics: [
+    {
+      title: "Horizontal",
+      items: [array of teaser]
+    }
+  ]
+}
+```
+
+
+# Topics teaser
+
+Displays a list item
+
+## Example:
+```
+{% include "@theme/patterns/compositions/topic/topic.overview.subitem.html.twig" with topics %}
+```
+
+## Data structure:
+```
+ {
+  "title": randomString(),
+  "url": "#",
+  "image": {
+    src: 'https://picsum.photos/1600/400',
+  },
+  "stats": {
+    groups: {
+      stat: 10,
+      icon: {
+        type: "custom",
+        name: "group"
+      }
+    },
+    experts: {
+      stat: 3,
+      icon: {
+        type: "custom",
+        name: "user_circle"
+      }
+    }
+  }
+}
+```
+

--- a/lib/themes/eic_community/styleguide/compositions/topics.stories.js
+++ b/lib/themes/eic_community/styleguide/compositions/topics.stories.js
@@ -1,0 +1,50 @@
+import docs from './topics.docs.mdx';
+import topicListTemplate from '@theme/patterns/compositions/topic/topic.overview.list.html.twig';
+import topicTeaserTemplate from '@theme/patterns/compositions/topic/topic.overview.subitem.html.twig';
+import common from '@theme/data/common.data';
+import {mockItems, randomString} from "../../snippets";
+
+const teaserItem = {
+  "title": randomString(),
+  "url": "#",
+  "image": {
+    src: 'https://picsum.photos/200/200',
+  },
+  "stats": {
+    groups: {
+      stat: 10,
+      icon: {
+        type: "custom",
+        name: "group"
+      }
+    },
+    experts: {
+      stat: 3,
+      icon: {
+        type: "custom",
+        name: "user_circle"
+      }
+    }
+  }
+}
+const topicListItem = {
+  icon_file_path: common.icon_file_path,
+  topics: [
+    {
+      title: "Horizontal",
+      items: mockItems(teaserItem, 10)
+    }
+  ]
+}
+
+export const TopicsList = () => topicListTemplate(topicListItem)
+export const TopicTeaserItem = () => topicTeaserTemplate({...teaserItem, icon_file_path: common.icon_file_path,})
+
+export default {
+  title: 'Compositions / Topics list',
+  parameters: {
+    docs: {
+      page: docs,
+    },
+  },
+};


### PR DESCRIPTION
### What I did

- Add topic overview in storybook
- Rename old topic overview to topic details

### How to test

- https://www.figma.com/file/WZH3qhNynnmm0H6FKmD3hi/EASME_v1?node-id=9649%3A48224
- http://localhost:9000/?path=/story/bundles-topic--topic-overview

New: need to add stats (client request) so I remove the arrow 