### PR TITLE
[EICNET]feat: Add state label of the event in group overview

### DIFF
--- a/config/sync/context.context.group_events_overviews.yml
+++ b/config/sync/context.context.group_events_overviews.yml
@@ -21,7 +21,7 @@ conditions:
 reactions:
   blocks:
     blocks:
-      5192d3d3-7de9-4cad-baa2-4195a79584f0:
+      5b2d7e48-2503-4cfc-bf97-ea9585c5cc86:
         id: eic_search_overview
         label: ''
         provider: eic_search
@@ -29,16 +29,46 @@ reactions:
         source_type: Drupal\eic_search\Search\Sources\GroupEventSourceType
         facets:
           ss_content_event_type_string: ss_content_event_type_string
-          sm_content_field_vocab_topics_string: sm_content_field_vocab_topics_string
           sm_content_field_location_type: sm_content_field_location_type
+          ss_event_weight_state_label: ss_event_weight_state_label
+          sm_content_field_vocab_topics_string: sm_content_field_vocab_topics_string
           ss_content_country_code: ss_content_country_code
         sort_options:
+          its_event_weight_state: its_event_weight_state
           ss_drupal_timestamp: ss_drupal_timestamp
           ss_content_title: ss_content_title
           its_content_field_date_range_start_value: its_content_field_date_range_start_value
           dm_aggregated_changed: dm_aggregated_changed
           its_last_flagged_bookmark_content: its_last_flagged_bookmark_content
-          its_flag_highlight_content: 0
+          its_last_comment_timestamp: 0
+          its_last_flagged_like_content: 0
+          its_last_flagged_highlight_content: 0
+        enable_search: 1
+        page_options: normal
+        prefilter_group: 1
+        enable_date_filter: 1
+        add_facet_interests: 0
+        add_facet_my_groups: 0
+        context_mapping: {  }
+      d17b6d27-762b-41da-88ba-5675ea385fc5:
+        id: eic_search_overview
+        label: ''
+        provider: eic_search
+        label_display: visible
+        source_type: Drupal\eic_search\Search\Sources\GroupEventSourceType
+        facets:
+          ss_content_event_type_string: ss_content_event_type_string
+          sm_content_field_location_type: sm_content_field_location_type
+          ss_event_weight_state_label: ss_event_weight_state_label
+          sm_content_field_vocab_topics_string: sm_content_field_vocab_topics_string
+          ss_content_country_code: ss_content_country_code
+        sort_options:
+          its_event_weight_state: its_event_weight_state
+          ss_drupal_timestamp: ss_drupal_timestamp
+          ss_content_title: ss_content_title
+          its_content_field_date_range_start_value: its_content_field_date_range_start_value
+          dm_aggregated_changed: dm_aggregated_changed
+          its_last_flagged_bookmark_content: its_last_flagged_bookmark_content
           its_last_comment_timestamp: 0
           its_last_flagged_like_content: 0
           its_last_flagged_highlight_content: 0
@@ -56,7 +86,7 @@ reactions:
         unique: 0
         context_id: group_events_overviews
         third_party_settings: {  }
-        uuid: 5192d3d3-7de9-4cad-baa2-4195a79584f0
+        uuid: d17b6d27-762b-41da-88ba-5675ea385fc5
     id: blocks
     saved: false
     uuid: 9c311d0e-a590-452a-ad85-a32b685d7729

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -43,6 +43,7 @@ module:
   eic_content_story: 0
   eic_content_wiki_page: 0
   eic_deploy: 0
+  eic_events: 0
   eic_flags: 0
   eic_fragment_fact_figure: 0
   eic_group_statistics: 0
@@ -60,11 +61,15 @@ module:
   eic_overviews: 0
   eic_paragraph_contributor: 0
   eic_paragraph_cta_tile: 0
+  eic_paragraph_full_media_content: 0
+  eic_paragraph_quote: 0
+  eic_paragraphs: 0
   eic_private_content: 0
   eic_private_message: 0
   eic_search: 0
   eic_seo: 0
   eic_share_content: 0
+  eic_statistics: 0
   eic_theme_helper: 0
   eic_topics: 0
   eic_user: 0
@@ -175,11 +180,7 @@ module:
   pathauto: 1
   views: 10
   paragraphs: 11
-  eic_paragraphs: 12
-  eic_paragraph_full_media_content: 13
-  eic_paragraph_quote: 13
   publication_date: 99
-  eic_statistics: 1000
   minimal: 1000
 theme:
   stable: 0

--- a/config/sync/field.field.node.event.field_vocab_geo.yml
+++ b/config/sync/field.field.node.event.field_vocab_geo.yml
@@ -12,7 +12,7 @@ entity_type: node
 bundle: event
 label: 'Regions & Countries'
 description: ''
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/lib/modules/eic_events/eic_events.info.yml
+++ b/lib/modules/eic_events/eic_events.info.yml
@@ -1,0 +1,7 @@
+name: EIC Events
+type: module
+description: Provides funcitonnality around events.
+package: European Innovation Council
+core: 8.x
+core_version_requirement: ^8 || ^9
+php: 7.3

--- a/lib/modules/eic_events/eic_events.module
+++ b/lib/modules/eic_events/eic_events.module
@@ -1,0 +1,22 @@
+<?php
+
+use Drupal\eic_events\Constants\Event;
+
+/**
+ * Implements hook_cron().
+ */
+function eic_events_cron() {
+  // Value returned is timestamp.
+  $last_request_time = \Drupal::state()
+    ->get(Event::CRON_STATE_ID_LAST_REQUEST_TIME);
+
+  $now = time();
+
+  // Re-sync each 2 hours.
+  if (0 >= ($last_request_time + 43200) - $now) {
+    \Drupal::service('eic_events.update_solr_events')
+      ->updateSolrEvents();
+
+    \Drupal::state()->set(Event::CRON_STATE_ID_LAST_REQUEST_TIME, $now);
+  }
+}

--- a/lib/modules/eic_events/eic_events.services.yml
+++ b/lib/modules/eic_events/eic_events.services.yml
@@ -1,0 +1,4 @@
+services:
+  eic_events.update_solr_events:
+    class: Drupal\eic_events\Commands\UpdateSolrEvents
+    arguments: ['@entity_type.manager', '@eic_search.solr_document_processor']

--- a/lib/modules/eic_events/src/Commands/UpdateSolrEventsCommands.php
+++ b/lib/modules/eic_events/src/Commands/UpdateSolrEventsCommands.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Drupal\eic_events\Commands;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\eic_search\Service\SolrDocumentProcessor;
+use Drupal\group\Entity\Group;
+use Drupal\node\Entity\Node;
+
+/**
+ * Class UpdateSolrEvents
+ *
+ * @package Drupal\eic_events\Commands
+ */
+class UpdateSolrEvents {
+
+  /**
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * @var SolrDocumentProcessor
+   */
+  protected $solrDocumentProcessor;
+
+  /**
+   * UpdateSolrEvents constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   * @param \Drupal\eic_search\Service\SolrDocumentProcessor $solr_document_processor
+   */
+  public function __construct(
+    EntityTypeManagerInterface $entity_type_manager,
+    SolrDocumentProcessor $solr_document_processor
+  ) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->solrDocumentProcessor = $solr_document_processor;
+  }
+
+  /**
+   * Update all events (group, event) that are ongoing or in the future.
+   * So state of the event in solr are updated (PAST, ON_GOING, FUTURE).
+   */
+  public function updateSolrEvents() {
+    $events_node_id = $this->entityTypeManager->getStorage('node')
+      ->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('type', 'event')
+      ->condition('field_date_range.end_value', time(), '>=')
+      ->execute();
+
+    $events_groups_id = $this->entityTypeManager->getStorage('group')
+      ->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('type', 'event')
+      ->condition('field_date_range.end_value', time(), '>=')
+      ->execute();
+
+    $event_nodes = Node::loadMultiple($events_node_id);
+    $event_groups = Group::loadMultiple($events_groups_id);
+
+    $this->solrDocumentProcessor->reIndexEntities(array_merge($event_nodes, $event_groups));
+  }
+
+}

--- a/lib/modules/eic_events/src/Constants/Event.php
+++ b/lib/modules/eic_events/src/Constants/Event.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\eic_events\Constants;
+
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
+/**
+ * Class Event
+ *
+ * @package Drupal\eic_events\Constants
+ */
+final class Event {
+
+  const WEIGHT_STATE_ONGOING = 1;
+
+  const WEIGHT_STATE_FUTURE = 2;
+
+  const WEIGHT_STATE_PAST = 3;
+
+  const SOLR_FIELD_ID_WEIGHT_STATE = 'its_event_weight_state';
+
+  const SOLR_FIELD_ID_WEIGHT_STATE_LABEL = 'ss_event_weight_state_label';
+
+  const CRON_STATE_ID_LAST_REQUEST_TIME = 'eic_events_last_update_events';
+
+  /**
+   * @return array
+   */
+  public static function getStateLabelsMapping(): array {
+    return [
+      self::WEIGHT_STATE_ONGOING => t('Ongoing', [], ['context' => 'eic_events']),
+      self::WEIGHT_STATE_FUTURE => t('Future', [], ['context' => 'eic_events']),
+      self::WEIGHT_STATE_PAST => t('Past', [], ['context' => 'eic_events']),
+    ];
+  }
+
+}

--- a/lib/modules/eic_search/src/Search/Sources/GlobalEventSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/GlobalEventSourceType.php
@@ -3,6 +3,7 @@
 namespace Drupal\eic_search\Search\Sources;
 
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\eic_events\Constants\Event;
 use Drupal\eic_flags\FlagType;
 use Drupal\eic_search\Service\SolrDocumentProcessor;
 
@@ -43,6 +44,7 @@ class GlobalEventSourceType extends SourceType {
     return [
       'ss_group_topic_name' => $this->t('Topic', [], ['context' => 'eic_search']),
       'sm_group_field_location_type' => $this->t('Location', [], ['context' => 'eic_search']),
+      Event::SOLR_FIELD_ID_WEIGHT_STATE_LABEL => $this->t('Time', [], ['context' => 'eic_search']),
       'ss_group_event_country' => $this->t('Country', [], ['context' => 'eic_search']),
     ];
   }
@@ -52,6 +54,10 @@ class GlobalEventSourceType extends SourceType {
    */
   public function getAvailableSortOptions(): array {
     return [
+      Event::SOLR_FIELD_ID_WEIGHT_STATE => [
+        'label' => $this->t('State (1. ongoing, 2. future, 3. past)', [], ['context' => 'eic_search']),
+        'ASC' => $this->t('Default', [], ['context' => 'eic_search'])
+      ],
       'timestamp' => [
         'label' => $this->t('Timestamp', [], ['context' => 'eic_search']),
         'ASC' => $this->t('Old', [], ['context' => 'eic_search']),
@@ -122,7 +128,7 @@ class GlobalEventSourceType extends SourceType {
    * @inheritDoc
    */
   public function getDefaultSort(): array {
-    return [GroupEventSourceType::START_DATE_SOLR_FIELD_ID, 'ASC'];
+    return [Event::SOLR_FIELD_ID_WEIGHT_STATE, 'ASC'];
   }
 
 }

--- a/lib/modules/eic_search/src/Search/Sources/GlobalEventSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/GlobalEventSourceType.php
@@ -56,7 +56,7 @@ class GlobalEventSourceType extends SourceType {
     return [
       Event::SOLR_FIELD_ID_WEIGHT_STATE => [
         'label' => $this->t('State (1. ongoing, 2. future, 3. past)', [], ['context' => 'eic_search']),
-        'ASC' => $this->t('Default', [], ['context' => 'eic_search'])
+        'ASC' => $this->t('Ongoing/upcoming', [], ['context' => 'eic_search'])
       ],
       'timestamp' => [
         'label' => $this->t('Timestamp', [], ['context' => 'eic_search']),

--- a/lib/modules/eic_search/src/Search/Sources/GroupEventSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/GroupEventSourceType.php
@@ -60,7 +60,7 @@ class GroupEventSourceType extends SourceType {
     return [
       Event::SOLR_FIELD_ID_WEIGHT_STATE => [
         'label' => $this->t('State (1. ongoing, 2. future, 3. past)', [], ['context' => 'eic_search']),
-        'ASC' => $this->t('Default', [], ['context' => 'eic_search'])
+        'ASC' => $this->t('Ongoing/upcoming', [], ['context' => 'eic_search'])
       ],
       'ss_drupal_timestamp' => [
         'label' => $this->t('Timestamp', [], ['context' => 'eic_search']),

--- a/lib/modules/eic_search/src/Search/Sources/GroupEventSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/GroupEventSourceType.php
@@ -3,6 +3,7 @@
 namespace Drupal\eic_search\Search\Sources;
 
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\eic_events\Constants\Event;
 use Drupal\eic_flags\FlagType;
 use Drupal\eic_search\Service\SolrDocumentProcessor;
 
@@ -45,8 +46,9 @@ class GroupEventSourceType extends SourceType {
   public function getAvailableFacets(): array {
     return [
       'ss_content_event_type_string' => $this->t('Type', [], ['context' => 'eic_search']),
-      'sm_content_field_vocab_topics_string' => $this->t('Topic', [], ['context' => 'eic_search']),
       'sm_content_field_location_type' => $this->t('Location', [], ['context' => 'eic_search']),
+      Event::SOLR_FIELD_ID_WEIGHT_STATE_LABEL => $this->t('Time', [], ['context' => 'eic_search']),
+      'sm_content_field_vocab_topics_string' => $this->t('Topic', [], ['context' => 'eic_search']),
       'ss_content_country_code' => $this->t('Country', [], ['context' => 'eic_search']),
     ];
   }
@@ -56,10 +58,9 @@ class GroupEventSourceType extends SourceType {
    */
   public function getAvailableSortOptions(): array {
     return [
-      'its_flag_highlight_content' => [
-        'label' => $this->t('Highlight', [], ['context' => 'eic_search']),
-        'DESC' => $this->t('Highlighted first', [], ['context' => 'eic_search']),
-        'ASC' => $this->t('Highlighted last', [], ['context' => 'eic_search']),
+      Event::SOLR_FIELD_ID_WEIGHT_STATE => [
+        'label' => $this->t('State (1. ongoing, 2. future, 3. past)', [], ['context' => 'eic_search']),
+        'ASC' => $this->t('Default', [], ['context' => 'eic_search'])
       ],
       'ss_drupal_timestamp' => [
         'label' => $this->t('Timestamp', [], ['context' => 'eic_search']),
@@ -160,7 +161,7 @@ class GroupEventSourceType extends SourceType {
    * @inheritDoc
    */
   public function getDefaultSort(): array {
-    return [GroupEventSourceType::START_DATE_SOLR_FIELD_ID, 'ASC'];
+    return [Event::SOLR_FIELD_ID_WEIGHT_STATE, 'ASC'];
   }
 
 }


### PR DESCRIPTION
Send the state of the event (ongoing, future, past) to solr. Also add a Drupal cron that will update event each 12hours

How to test:

- [x] Re-index elements in search api
- [x] Clear your cache
- [x] Go to group events overview
- [x] Be sure it's ordered 1. Ongoing 2. Future 3. Past
- [x] You can also filter by this state