### PR TITLE
[EICNET-1676] chore: Add the manage archival/deletion requests permission to SCM

### DIFF
--- a/config/sync/user.role.content_administrator.yml
+++ b/config/sync/user.role.content_administrator.yml
@@ -69,6 +69,7 @@ permissions:
   - 'flag recommend_group'
   - 'make archive request'
   - 'make delete request'
+  - 'manage archival deletion requests'
   - 'manage blocked entities'
   - 'mark private content'
   - 'overview messages'


### PR DESCRIPTION
## To Test

- [x] Login as SCM
- [x] You should be able to access /admin/community/request/delete