### PR TITLE
[EICNET-1692] fix: Remove the url alias field from the join form

### DIFF
--- a/config/sync/core.entity_form_display.group_content.group-group_membership.default.yml
+++ b/config/sync/core.entity_form_display.group_content.group-group_membership.default.yml
@@ -5,8 +5,6 @@ dependencies:
   config:
     - field.field.group_content.group-group_membership.group_roles
     - group.content_type.group-group_membership
-  module:
-    - path
 id: group_content.group-group_membership.default
 targetEntityType: group_content
 bundle: group-group_membership
@@ -14,7 +12,7 @@ mode: default
 content:
   entity_id:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 1
     settings:
       match_operator: CONTAINS
       size: 60
@@ -24,22 +22,17 @@ content:
     third_party_settings: {  }
   group_roles:
     type: options_buttons
-    weight: 31
+    weight: 2
     settings: {  }
     third_party_settings: {  }
     region: content
   langcode:
     type: language_select
-    weight: 2
+    weight: 0
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
-  path:
-    type: path
-    weight: 30
-    region: content
-    settings: {  }
-    third_party_settings: {  }
 hidden:
+  path: true
   uid: true


### PR DESCRIPTION
## To Test

- [ ] Go to the join group page
- [ ] You shouldn't see the URL alias field anymore