### PR TITLE
[EICNET] Fix color for custom group's tags

### DIFF
--- a/lib/themes/eic_community/sass/components/_tag.scss
+++ b/lib/themes/eic_community/sass/components/_tag.scss
@@ -21,6 +21,11 @@
     color: map-get($ecl-colors, 'white');
   }
 
+  &--is-custom {
+    background: $ecl-color-orange;
+    color: map-get($ecl-colors, 'white');
+  }
+
   &--is-private {
     background-color: map-get($ecl-colors, 'red');
     color: map-get($ecl-colors, 'white');


### PR DESCRIPTION
### How to test

- create a restricted group and check if tag "custom" is orange

https://citnet.tech.ec.europa.eu/CITnet/jira/secure/RapidBoard.jspa?rapidView=6628&view=detail&selectedIssue=EICNET-1722&quickFilter=26822