### PR TITLE
[EICNET-1696]fix: Separate filename by comma

### DIFF
--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Library/DocumentLibraryResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Library/DocumentLibraryResultItem.js
@@ -56,9 +56,7 @@ class DocumentLibraryResultItem extends React.Component {
               })}
             </div>
             <div className="ecl-teaser__files">
-              {filenames && filenames.length > 0 && filenames.map((filename) => {
-                return `${filename} `;
-              })}
+              {filenames && filenames.length > 0 && filenames.join(', ')}
             </div>
             <div className="ecl-teaser__meta-content">
               <div className="ecl-teaser__meta-content-item">


### PR DESCRIPTION
How to test:

- [ ] Go to library of groups and check if in teaser the string of documents is separated by comma