### PR TITLE
EICNET-286: Allow SA/SCM users to edit custom blocks

### DIFF
--- a/config/sync/user.role.content_administrator.yml
+++ b/config/sync/user.role.content_administrator.yml
@@ -8,6 +8,7 @@ weight: -7
 is_admin: null
 permissions:
   - 'access administration pages'
+  - 'access block content overview'
   - 'access comments'
   - 'access contact group users page'
   - 'access contact user page'
@@ -77,7 +78,14 @@ permissions:
   - 'publish archived content'
   - 'schedule publishing of nodes'
   - 'unflag recommend_group'
+  - 'update any basic block content'
+  - 'update any cta_tiles block content'
+  - 'update any facts_figures block content'
+  - 'update any latest_news_stories block content'
   - 'update any member profile'
+  - 'update any page_banner block content'
+  - 'update any social_media block content'
+  - 'update any tiles_reference block content'
   - 'update own member profile'
   - 'use group_wiki transition create_new_draft'
   - 'use group_wiki transition publish'

--- a/config/sync/user.role.site_admin.yml
+++ b/config/sync/user.role.site_admin.yml
@@ -8,6 +8,7 @@ weight: -5
 is_admin: null
 permissions:
   - 'access administration pages'
+  - 'access block content overview'
   - 'access comments'
   - 'access contact group users page'
   - 'access contact user page'
@@ -81,7 +82,14 @@ permissions:
   - 'publish archived content'
   - 'schedule publishing of nodes'
   - 'unflag recommend_group'
+  - 'update any basic block content'
+  - 'update any cta_tiles block content'
+  - 'update any facts_figures block content'
+  - 'update any latest_news_stories block content'
   - 'update any member profile'
+  - 'update any page_banner block content'
+  - 'update any social_media block content'
+  - 'update any tiles_reference block content'
   - 'update own member profile'
   - 'use admin toolbar search'
   - 'use group_wiki transition create_new_draft'


### PR DESCRIPTION
### Improvements

- Add permissions to edit custom blocks and access custom blocks overview page (for SA and SCM users).

### Tests

- [x] As SA/SCM, make sure you can access the list of custom blocks `/admin/content/block-content`
- [x] Make sure you can edit all blocks shown in the list