### PR TITLE
EICNET-1506: Show group under review message (cache issues)

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/layout/page.inc
+++ b/lib/themes/eic_community/includes/preprocess/layout/page.inc
@@ -252,7 +252,7 @@ function _preprocess_front_page(&$variables) {
 }
 
 /**
- * Preprocess front page.
+ * Preprocess group page.
  */
 function _preprocess_group_page(&$variables) {
   // We need to add missing cache tags related to the group otherwise
@@ -265,5 +265,8 @@ function _preprocess_group_page(&$variables) {
     else {
       $variables['#cache']['tags'] = Cache::mergeTags($variables['#cache'], $group->getCacheTags());
     }
+    // Adds url.path as cache context otherwise anonymous users will always see
+    // the same message depending on which group the user visited first.
+    $variables['#cache']['contexts'][] = 'url.path';
   }
 }


### PR DESCRIPTION
### Fixes

- Fixed caching issues that prevented anonymous users to see the correct access denied message depending on the group.

### Tests

- [x] As anonymous user, try to access a private group that has been blocked and make sure you see the regular access denied message "You are not authorized to access this page."
- [x] Try to access a public group that has been blocked and make sure you see the "Group is under review" message.

Notes: Make sure you **DO NOT** clear the cache between those 2 steps.