### PR TITLE
EICNET-1725: Error when adding a topic of interest in user profile

### DIFF
--- a/lib/modules/eic_flags/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_flags/src/Hooks/EntityOperations.php
@@ -402,6 +402,13 @@ class EntityOperations implements ContainerInjectionInterface {
 
     // Follow new topics.
     foreach ($topics as $topic) {
+      $topic_flag = $this->flagService->getFlagging($flag, $topic, $user);
+
+      // If topic is already flagged, we do nothing.
+      if ($topic_flag) {
+        continue;
+      }
+
       $this->flagService->flag($flag, $topic, $user);
     }
   }


### PR DESCRIPTION
### Fixes

- Do not flag topic of interest if the user is already following the topic.

### Tests

- [x] Go to `/topics/financial-development` and follow the topic
- [x] Edit the profile of the current user you are logged in with and add the **Financial development** topic in the topics of interest field
- [x] Make sure the page doesn't throw any error and check if there is no error in the logs such as: `Drupal\Core\Entity\EntityStorageException: The user has already flagged the entity with the flag. in Drupal\Core\Entity\Sql\SqlContentEntityStorage->save() (line 810 of /var/www/html/web/core/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorage.php).`