### PR TITLE
[EICNET] Fix topic details stats keys name

### DIFF
--- a/lib/themes/eic_community/patterns/compositions/topic/topic.stats.html.twig
+++ b/lib/themes/eic_community/patterns/compositions/topic/topic.stats.html.twig
@@ -10,7 +10,7 @@
         }
       } only %}
       <a href="{{ stat.url }}">
-        <span class="ecl-topic__stats__data">{{ stat.data }}</span>
+        <span class="ecl-topic__stats__data">{{ stat.value }}</span>
         <span>{{ stat.title }}</span>
       </a>
     </div>

--- a/lib/themes/eic_community/styleguide/bundles/topic.stories.js
+++ b/lib/themes/eic_community/styleguide/bundles/topic.stories.js
@@ -76,7 +76,7 @@ export const TopicDetails = () =>
         stats: mockItems(
           {
             title: "Members",
-            data: "123",
+            value: "123",
             icon: {
               name: 'like',
               type: 'custom',


### PR DESCRIPTION
I just change the name of the key to have the same everywhere