### PR TITLE
EICNET-1642: Modify user messages for the user contact form.

### DIFF
--- a/lib/modules/eic_private_message/src/Form/PrivateMessageForm.php
+++ b/lib/modules/eic_private_message/src/Form/PrivateMessageForm.php
@@ -101,7 +101,7 @@ class PrivateMessageForm extends FormBase {
 
       if (!$user->get(PrivateMessage::PRIVATE_MESSAGE_USER_ALLOW_CONTACT_ID)->value) {
         $this->messenger()->addError($this->t(
-          'This user does not allow contact notification.',
+          'The user you are trying to contact has disabled private messages from its profile. The operation you are requesting cannot be completed.',
           [],
           ['context' => 'eic_private_message']
         ));
@@ -210,7 +210,7 @@ class PrivateMessageForm extends FormBase {
 
     if ($mail['result']) {
       $this->messenger()->addMessage($this->t(
-        'Mail sent with success.',
+        'Your message was successfully sent!',
         [],
         ['context' => 'eic_private_message']
       ));


### PR DESCRIPTION
### Tests

- [x] Uncheck "Members are allowed to contact you through your personal contact form" checkbox for a user in the user settings form
- [x] Try to contact this user at `/user/<uid>/contact`
- [x] You shoudl see the udpated message: _The user you are trying to contact has disabled private messages from its profile. The operation you are requesting cannot be completed._
- [x] Check the option "Members are allowed to contact you through your personal contact form" back from the user settings
- [x] Submit the form
- [x] You should see the udpated message _Your message was successfully sent!_