### PR TITLE
EICNET-1510: Email notification for a group transitioned to unblocked

### DIFF
--- a/config/sync/core.entity_form_display.message.notify_content_status_changed.default.yml
+++ b/config/sync/core.entity_form_display.message.notify_content_status_changed.default.yml
@@ -1,0 +1,59 @@
+uuid: a460c917-18f1-4bf2-b265-128c38cd6a07
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.message.notify_content_status_changed.field_entity_prev_status_label
+    - field.field.message.notify_content_status_changed.field_entity_status_label
+    - field.field.message.notify_content_status_changed.field_entity_url
+    - field.field.message.notify_content_status_changed.field_message_subject
+    - field.field.message.notify_content_status_changed.field_referenced_entity_label
+    - message.template.notify_content_status_changed
+  module:
+    - link
+id: message.notify_content_status_changed.default
+targetEntityType: message
+bundle: notify_content_status_changed
+mode: default
+content:
+  field_entity_prev_status_label:
+    weight: 5
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_entity_status_label:
+    weight: 1
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_entity_url:
+    weight: 3
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+  field_message_subject:
+    weight: 2
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_referenced_entity_label:
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+hidden: {  }

--- a/config/sync/core.entity_view_display.message.notify_content_status_changed.default.yml
+++ b/config/sync/core.entity_view_display.message.notify_content_status_changed.default.yml
@@ -1,0 +1,48 @@
+uuid: 52ce19c3-cb87-4ba8-9b36-a22b74ecfc59
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.message.notify_content_status_changed.field_entity_prev_status_label
+    - field.field.message.notify_content_status_changed.field_entity_status_label
+    - field.field.message.notify_content_status_changed.field_entity_url
+    - field.field.message.notify_content_status_changed.field_message_subject
+    - field.field.message.notify_content_status_changed.field_referenced_entity_label
+    - message.template.notify_content_status_changed
+  module:
+    - link
+id: message.notify_content_status_changed.default
+targetEntityType: message
+bundle: notify_content_status_changed
+mode: default
+content:
+  field_entity_prev_status_label:
+    weight: 3
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_entity_url:
+    weight: 1
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+  partial_0:
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  field_entity_status_label: true
+  field_message_subject: true
+  field_referenced_entity_label: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.notify_content_status_changed.mail_body.yml
+++ b/config/sync/core.entity_view_display.message.notify_content_status_changed.mail_body.yml
@@ -1,0 +1,32 @@
+uuid: 47785e0e-adbe-41cb-84ec-d259ef3abf55
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.message.mail_body
+    - field.field.message.notify_content_status_changed.field_entity_prev_status_label
+    - field.field.message.notify_content_status_changed.field_entity_status_label
+    - field.field.message.notify_content_status_changed.field_entity_url
+    - field.field.message.notify_content_status_changed.field_message_subject
+    - field.field.message.notify_content_status_changed.field_referenced_entity_label
+    - message.template.notify_content_status_changed
+id: message.notify_content_status_changed.mail_body
+targetEntityType: message
+bundle: notify_content_status_changed
+mode: mail_body
+content:
+  partial_0:
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  partial_1:
+    weight: 0
+    region: content
+hidden:
+  field_entity_prev_status_label: true
+  field_entity_status_label: true
+  field_entity_url: true
+  field_message_subject: true
+  field_referenced_entity_label: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.notify_content_status_changed.mail_subject.yml
+++ b/config/sync/core.entity_view_display.message.notify_content_status_changed.mail_subject.yml
@@ -1,0 +1,33 @@
+uuid: e8301699-3c30-4da0-b554-556424da2442
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.message.mail_subject
+    - field.field.message.notify_content_status_changed.field_entity_prev_status_label
+    - field.field.message.notify_content_status_changed.field_entity_status_label
+    - field.field.message.notify_content_status_changed.field_entity_url
+    - field.field.message.notify_content_status_changed.field_message_subject
+    - field.field.message.notify_content_status_changed.field_referenced_entity_label
+    - message.template.notify_content_status_changed
+id: message.notify_content_status_changed.mail_subject
+targetEntityType: message
+bundle: notify_content_status_changed
+mode: mail_subject
+content:
+  field_message_subject:
+    type: string
+    weight: 0
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+hidden:
+  field_entity_prev_status_label: true
+  field_entity_status_label: true
+  field_entity_url: true
+  field_referenced_entity_label: true
+  partial_0: true
+  partial_1: true
+  search_api_excerpt: true

--- a/config/sync/field.field.message.notify_content_status_changed.field_entity_prev_status_label.yml
+++ b/config/sync/field.field.message.notify_content_status_changed.field_entity_prev_status_label.yml
@@ -1,0 +1,19 @@
+uuid: 0ebd5270-7d23-469b-b8e9-2d8599b97b63
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_entity_prev_status_label
+    - message.template.notify_content_status_changed
+id: message.notify_content_status_changed.field_entity_prev_status_label
+field_name: field_entity_prev_status_label
+entity_type: message
+bundle: notify_content_status_changed
+label: 'Entity previous status label'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.message.notify_content_status_changed.field_entity_status_label.yml
+++ b/config/sync/field.field.message.notify_content_status_changed.field_entity_status_label.yml
@@ -1,0 +1,19 @@
+uuid: c0543e64-bbb8-4baa-ae7e-b989f22695dc
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_entity_status_label
+    - message.template.notify_content_status_changed
+id: message.notify_content_status_changed.field_entity_status_label
+field_name: field_entity_status_label
+entity_type: message
+bundle: notify_content_status_changed
+label: 'Entity status label'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.message.notify_content_status_changed.field_entity_url.yml
+++ b/config/sync/field.field.message.notify_content_status_changed.field_entity_url.yml
@@ -1,0 +1,23 @@
+uuid: 1feef88a-7836-44ce-9093-3ad0eb813104
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_entity_url
+    - message.template.notify_content_status_changed
+  module:
+    - link
+id: message.notify_content_status_changed.field_entity_url
+field_name: field_entity_url
+entity_type: message
+bundle: notify_content_status_changed
+label: 'Entity URL'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 0
+field_type: link

--- a/config/sync/field.field.message.notify_content_status_changed.field_message_subject.yml
+++ b/config/sync/field.field.message.notify_content_status_changed.field_message_subject.yml
@@ -1,0 +1,19 @@
+uuid: 70281b0a-9c0b-42a9-82ea-d68f20661489
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_subject
+    - message.template.notify_content_status_changed
+id: message.notify_content_status_changed.field_message_subject
+field_name: field_message_subject
+entity_type: message
+bundle: notify_content_status_changed
+label: Subject
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.message.notify_content_status_changed.field_referenced_entity_label.yml
+++ b/config/sync/field.field.message.notify_content_status_changed.field_referenced_entity_label.yml
@@ -1,0 +1,19 @@
+uuid: fe3e8d03-3310-4b57-bc64-b46f979e1a6c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_referenced_entity_label
+    - message.template.notify_content_status_changed
+id: message.notify_content_status_changed.field_referenced_entity_label
+field_name: field_referenced_entity_label
+entity_type: message
+bundle: notify_content_status_changed
+label: 'Entity Label'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.message.field_entity_prev_status_label.yml
+++ b/config/sync/field.storage.message.field_entity_prev_status_label.yml
@@ -1,0 +1,21 @@
+uuid: 022aba25-66a2-4b6f-b754-fb3d7c30557c
+langcode: en
+status: true
+dependencies:
+  module:
+    - message
+id: message.field_entity_prev_status_label
+field_name: field_entity_prev_status_label
+entity_type: message
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.message.field_entity_status_label.yml
+++ b/config/sync/field.storage.message.field_entity_status_label.yml
@@ -1,0 +1,21 @@
+uuid: 812fd060-ebd8-4583-b94f-9d50038e970b
+langcode: en
+status: true
+dependencies:
+  module:
+    - message
+id: message.field_entity_status_label
+field_name: field_entity_status_label
+entity_type: message
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.message.field_entity_url.yml
+++ b/config/sync/field.storage.message.field_entity_url.yml
@@ -1,0 +1,19 @@
+uuid: b9ad0e4a-5caf-46a8-aa60-2fee9a98b54d
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - message
+id: message.field_entity_url
+field_name: field_entity_url
+entity_type: message
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/language/en/message.template.notify_content_status_changed.yml
+++ b/config/sync/language/en/message.template.notify_content_status_changed.yml
@@ -1,0 +1,4 @@
+text:
+  -
+    value: "<p>Dear [message:author:field_first_name:value]&nbsp;[message:author:field_last_name:value],</p>\r\n\r\n<p><a href=\"[message:field_entity_url:uri]\">[message:field_referenced_entity_label:value]</a>&nbsp;has changed status from [message:field_entity_prev_status_label:value] to [message:field_entity_status_label:value].</p>\r\n\r\n<p>The EIC Community team</p>\r\n"
+    format: full_html

--- a/config/sync/message.template.notify_content_status_changed.yml
+++ b/config/sync/message.template.notify_content_status_changed.yml
@@ -1,0 +1,24 @@
+uuid: 628495cf-bea4-4641-8835-9b7a09de1f5d
+langcode: en
+status: true
+dependencies:
+  config:
+    - filter.format.full_html
+  module:
+    - eic_messages
+third_party_settings:
+  eic_messages:
+    message_template_type: notification
+template: notify_content_status_changed
+label: 'NOTIFY :: MT :: Content status changed'
+description: 'Notifies an author that a content has changed its status.'
+text:
+  -
+    value: "<p>Dear [message:author:field_first_name:value]&nbsp;[message:author:field_last_name:value],</p>\r\n\r\n<p><a href=\"[message:field_entity_url:uri]\">[message:field_referenced_entity_label:value]</a>&nbsp;has changed status from [message:field_entity_prev_status_label:value] to [message:field_entity_status_label:value].</p>\r\n\r\n<p>The EIC Community team</p>\r\n"
+    format: full_html
+settings:
+  'token options':
+    clear: false
+    'token replace': true
+  purge_override: false
+  purge_methods: {  }

--- a/lib/modules/eic_messages/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_messages/src/Hooks/EntityOperations.php
@@ -10,7 +10,9 @@ use Drupal\eic_messages\Service\MessageBusInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Class EntityUpdate
+ * Class EntityUpdate.
+ *
+ * Implementations for entity hooks.
  *
  * @package Drupal\eic_messages\Hooks
  */
@@ -19,18 +21,51 @@ class EntityOperations implements ContainerInjectionInterface {
   use StringTranslationTrait;
 
   /**
+   * The content moderation archived state key.
+   *
+   * @var string
+   */
+  const MODERATION_STATE_ARCHIVED = 'archived';
+
+  /**
+   * The content moderation blocked state key.
+   *
+   * @var string
+   */
+  const MODERATION_STATE_BLOCKED = 'blocked';
+
+  /**
+   * The entity type labels to use in notification message.
+   *
+   * @var array
+   */
+  const ENTITY_TYPE_LABELS = [
+    'node' => 'content',
+    'group__group' => 'group',
+    'group__event' => 'event',
+  ];
+
+  /**
+   * The content moderation information service.
+   *
    * @var \Drupal\content_moderation\ModerationInformationInterface
    */
   private $moderationInformation;
 
   /**
+   * The message bus service.
+   *
    * @var \Drupal\eic_messages\Service\MessageBusInterface
    */
   private $messageBus;
 
   /**
+   * Constructs a new EntityOperations object.
+   *
    * @param \Drupal\content_moderation\ModerationInformationInterface $moderationInformation
+   *   The content moderation information service.
    * @param \Drupal\eic_messages\Service\MessageBusInterface $message_bus
+   *   The message bus service.
    */
   public function __construct(
     ModerationInformationInterface $moderationInformation,
@@ -55,26 +90,83 @@ class EntityOperations implements ContainerInjectionInterface {
    */
   public function entityUpdate(EntityInterface $entity) {
     // We do send notifications only for moderated contents.
-    if (!$this->moderationInformation->isModeratedEntity($entity)
-      || $entity->original->get('moderation_state')->value !== 'archived') {
+    if (!$this->moderationInformation->isModeratedEntity($entity)) {
+      return;
+    }
+
+    // Gets the previous content moderation state.
+    $previous_state = $entity->original->get('moderation_state')->value;
+    // Gets the current content moderation state.
+    $current_state = $entity->get('moderation_state')->value;
+    // If the content moderation state didn't change, we do nothing.
+    if ($previous_state === $current_state) {
+      return;
+    }
+
+    // Gets the entity type label to use in the message notification.
+    $entity_type_label = isset(self::ENTITY_TYPE_LABELS[$entity->getEntityTypeId()])
+      ? self::ENTITY_TYPE_LABELS[$entity->getEntityTypeId()]
+      : (isset(self::ENTITY_TYPE_LABELS["{$entity->getEntityTypeId()}__{$entity->bundle()}"])
+          ? self::ENTITY_TYPE_LABELS["{$entity->getEntityTypeId()}__{$entity->bundle()}"]
+          : $entity->getEntityTypeId());
+
+    // By default notification is not skipped.
+    $skip_notification = FALSE;
+    // Default message fields.
+    $message = [
+      'template' => 'notify_content_status_changed',
+      'uid' => $entity->getOwnerId(),
+      'field_message_subject' => NULL,
+      'field_referenced_entity_label' => $entity->label(),
+      'field_entity_prev_status_label' => $previous_state,
+      'field_entity_status_label' => $current_state,
+      'field_entity_url' => [
+        'uri' => $entity->toUrl()->toString(),
+        'title' => $entity->label(),
+      ],
+    ];
+
+    switch ($previous_state) {
+      case self::MODERATION_STATE_ARCHIVED:
+        $message['field_message_subject'] = $this->t(
+          'Your @entity_type "@entity_label" has been published again',
+          [
+            '@entity_type' => $entity_type_label,
+            '@entity_label' => $entity->label(),
+          ]
+        );
+        break;
+
+      case self::MODERATION_STATE_BLOCKED:
+        $message['field_message_subject'] = $this->t(
+          'Your @entity_type "@entity_label" has been unblocked',
+          [
+            '@entity_type' => $entity_type_label,
+            '@entity_label' => $entity->label(),
+          ]
+        );
+        break;
+
+      default:
+        $skip_notification = TRUE;
+        break;
+
+    }
+
+    if ($skip_notification) {
       return;
     }
 
     // Check if the new state is marked as "published".
     $workflow = $this->moderationInformation->getWorkflowForEntity($entity);
     $is_published_state = $workflow->getTypePlugin()
-      ->getState($entity->get('moderation_state')->value)
+      ->getState($current_state)
       ->isPublishedState();
     if (!$is_published_state) {
       return;
     }
 
-    $this->messageBus->dispatch([
-      'template' => 'notify_archived_republished',
-      'uid' => $entity->getOwnerId(),
-      'field_message_subject' => $this->t('Your content is published again'),
-      'field_referenced_entity_label' => $entity->label(),
-    ]);
+    $this->messageBus->dispatch($message);
   }
 
 }

--- a/lib/modules/eic_messages/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_messages/src/Hooks/EntityOperations.php
@@ -36,17 +36,6 @@ class EntityOperations implements ContainerInjectionInterface {
   const MODERATION_STATE_BLOCKED = 'blocked';
 
   /**
-   * The entity type labels to use in notification message.
-   *
-   * @var array
-   */
-  const ENTITY_TYPE_LABELS = [
-    'node' => 'content',
-    'group__group' => 'group',
-    'group__event' => 'event',
-  ];
-
-  /**
    * The content moderation information service.
    *
    * @var \Drupal\content_moderation\ModerationInformationInterface


### PR DESCRIPTION
### Features

- Create new generic message type to use when an entity has changed status;
- Send notification message to group owner when SA/SCM unblocks a group.

### Tests

- [x] As SA/SCM, block a group
- [x] After blocking the group, go to the group edit form and published the group
- [x] Run cron
- [x] Make sure an email notification has been sent to the group owner