### PR TITLE
EICNET-1733: Define different set of group features depending on the group type.

### DIFF
--- a/config/sync/oec_group_features.group_type_features.event.yml
+++ b/config/sync/oec_group_features.group_type_features.event.yml
@@ -1,0 +1,6 @@
+features:
+  - eic_groups_members
+  - eic_groups_wiki
+  - eic_groups_files
+  - eic_groups_latest_activity_stream
+  - eic_groups_discussions

--- a/config/sync/oec_group_features.group_type_features.group.yml
+++ b/config/sync/oec_group_features.group_type_features.group.yml
@@ -1,0 +1,7 @@
+features:
+  - eic_groups_members
+  - eic_groups_group_events
+  - eic_groups_wiki
+  - eic_groups_files
+  - eic_groups_latest_activity_stream
+  - eic_groups_discussions

--- a/lib/modules/oec_group_features/config/schema/oec_group_features.group_type_features.schema.yml
+++ b/lib/modules/oec_group_features/config/schema/oec_group_features.group_type_features.schema.yml
@@ -1,0 +1,8 @@
+oec_group_features.group_type_features.*:
+  type: config_object
+  mapping:
+    features:
+      type: sequence
+      label: 'Features'
+      sequence:
+        type: string

--- a/lib/modules/oec_group_features/oec_group_features.module
+++ b/lib/modules/oec_group_features/oec_group_features.module
@@ -5,9 +5,12 @@
  * Primary module hooks for OEC Group Features module.
  */
 
+use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\group\Entity\GroupInterface;
+use Drupal\oec_group_features\GroupFeatureHelper;
 use Drupal\oec_group_features\Hooks\EntityOperations;
 
 /**
@@ -18,17 +21,11 @@ use Drupal\oec_group_features\Hooks\EntityOperations;
 function oec_group_features_entity_base_field_info(EntityTypeInterface $entity_type) {
   $fields = [];
   if ($entity_type->id() == 'group') {
-    // Get available features.
-    $available_features = [];
-    $plugin_manager = \Drupal::service('plugin.manager.group_feature');
-    foreach ($plugin_manager->getDefinitions() as $definition) {
-      $available_features[$definition['id']] = $definition['label'];
-    }
 
     // Add our extra field to the Group entity type.
     // @todo Switch the 'list_string' a 'map' field type to avoid having an
     // extra table for this.
-    $fields['features'] = BaseFieldDefinition::create('list_string')
+    $fields[GroupFeatureHelper::FEATURES_FIELD_NAME] = BaseFieldDefinition::create('list_string')
       ->setLabel(t('Features'))
       ->setDescription(t('Select the features you would like to enable.'))
       ->setDisplayOptions('form', [
@@ -39,7 +36,7 @@ function oec_group_features_entity_base_field_info(EntityTypeInterface $entity_t
         'weight' => -10,
       ])
       ->setSettings([
-        'allowed_values' => $available_features,
+        'allowed_values_function' => 'oec_group_features_get_options',
       ])
       ->setReadOnly(FALSE)
       ->setRevisionable(FALSE)
@@ -49,6 +46,29 @@ function oec_group_features_entity_base_field_info(EntityTypeInterface $entity_t
       ->setDisplayConfigurable('form', TRUE);
   }
   return $fields;
+}
+
+/**
+ * Set dynamic allowed values for the group features field.
+ *
+ * @param \Drupal\Core\Field\BaseFieldDefinition $definition
+ *   The base field definition.
+ * @param \Drupal\Core\Entity\ContentEntityInterface|null $entity
+ *   The entity.
+ * @param bool $cacheable
+ *   Boolean indicating if the results are cacheable.
+ *
+ * @return array
+ *   An array of possible key and value options.
+ *
+ * @see options_allowed_values()
+ */
+function oec_group_features_get_options(BaseFieldDefinition $definition, ContentEntityInterface $entity = NULL, $cacheable) {
+  if (!$entity instanceof GroupInterface) {
+    return [];
+  }
+
+  return \Drupal::service('oec_group_features.helper')->getGroupTypeAvailableFeatures($entity->bundle());
 }
 
 /**

--- a/lib/modules/oec_group_features/oec_group_features.services.yml
+++ b/lib/modules/oec_group_features/oec_group_features.services.yml
@@ -2,3 +2,6 @@ services:
   plugin.manager.group_feature:
     class: Drupal\oec_group_features\GroupFeaturePluginManager
     parent: default_plugin_manager
+  oec_group_features.helper:
+    class: Drupal\oec_group_features\GroupFeatureHelper
+    arguments: ['@config.factory', '@plugin.manager.group_feature']

--- a/lib/modules/oec_group_features/src/GroupFeatureHelper.php
+++ b/lib/modules/oec_group_features/src/GroupFeatureHelper.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Drupal\oec_group_features;
+
+use Drupal\Core\Config\ConfigFactory;
+
+/**
+ * GroupFeatureHelper service that provides helper functions for Group features.
+ */
+class GroupFeatureHelper {
+
+  /**
+   * Name of the Features field.
+   *
+   * @var string
+   */
+  const FEATURES_FIELD_NAME = 'features';
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactory
+   */
+  protected $configFactory;
+
+  /**
+   * The Group feature plugin manager.
+   *
+   * @var \Drupal\oec_group_features\GroupFeaturePluginManager
+   */
+  protected $groupFeaturePluginManager;
+
+  /**
+   * Constructs a new GroupFeatureHelper.
+   *
+   * @param \Drupal\Core\Config\ConfigFactory $config_factory
+   *   The configuration factory service.
+   * @param \Drupal\oec_group_features\GroupFeaturePluginManager $group_feature_plugin_manager
+   *   The configuration factory service.
+   */
+  public function __construct(
+    ConfigFactory $config_factory,
+    GroupFeaturePluginManager $group_feature_plugin_manager
+  ) {
+    $this->configFactory = $config_factory;
+    $this->groupFeaturePluginManager = $group_feature_plugin_manager;
+  }
+
+  /**
+   * Returns all the defined group features.
+   *
+   * @return array
+   *   An array of plugin_id / label.
+   */
+  public function getAllAvailableFeatures() {
+    $available_features = [];
+    foreach ($this->groupFeaturePluginManager->getDefinitions() as $definition) {
+      $available_features[$definition['id']] = $definition['label'];
+    }
+    return $available_features;
+  }
+
+  /**
+   * Returns the available features for a specific group type.
+   *
+   * @param string $group_type
+   *   The group type.
+   *
+   * @return array
+   *   An array of plugin_id / label.
+   */
+  public function getGroupTypeAvailableFeatures(string $group_type) {
+    $available_features = $this->getAllAvailableFeatures();
+
+    if ($config = $this->configFactory->get('oec_group_features.group_type_features.' . $group_type)) {
+      $group_type_features = $config->get('features');
+
+      // If the config has specific features enabled, we loop through all
+      // features and remove the other ones.
+      if (!empty($group_type_features)) {
+        foreach ($available_features as $plugin_id => $label) {
+          if (!in_array($plugin_id, $group_type_features)) {
+            unset($available_features[$plugin_id]);
+          }
+        }
+      }
+    }
+
+    return $available_features;
+  }
+
+}

--- a/lib/modules/oec_group_features/src/Hooks/EntityOperations.php
+++ b/lib/modules/oec_group_features/src/Hooks/EntityOperations.php
@@ -7,6 +7,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\group\Entity\Group;
+use Drupal\oec_group_features\GroupFeatureHelper;
 use Drupal\oec_group_features\GroupFeaturePluginManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -96,7 +97,7 @@ class EntityOperations implements ContainerInjectionInterface {
   protected function manageFeatures(Group $group) {
     // Check if feature values have been changed to avoid performing unnecessary
     // actions.
-    if (!empty($group->original) && $group->get('features')->getValue() == $group->original->get('features')->getValue()) {
+    if (!empty($group->original) && $group->get(GroupFeatureHelper::FEATURES_FIELD_NAME)->getValue() == $group->original->get(GroupFeatureHelper::FEATURES_FIELD_NAME)->getValue()) {
       return;
     }
 
@@ -108,7 +109,7 @@ class EntityOperations implements ContainerInjectionInterface {
 
     // Get group enabled features.
     $enabled_features = [];
-    foreach ($group->get('features')->getValue() as $feature) {
+    foreach ($group->get(GroupFeatureHelper::FEATURES_FIELD_NAME)->getValue() as $feature) {
       $enabled_features[$feature['value']] = $feature['value'];
     }
 


### PR DESCRIPTION
### Tests

- [ ] Edit a Group group and check that you have following features available: Discussions, Members, Latest activity, Wiki, Events, Files 
- [ ] Edit ane Event group  and check that you have following features available: Discussions, Members, Latest activity, Wiki, Files 

### Remarks

- Although it would be a nice addition, currently there's no interface to manage the enabled features per group type (not in the scope)