### PR TITLE
EICNET-1673: Fix issue with wrong visibility for stories/news.

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/layout/page.inc
+++ b/lib/themes/eic_community/includes/preprocess/layout/page.inc
@@ -165,7 +165,7 @@ function _preprocess_node_page(&$variables) {
         $variables['editorial_header'] = [
           // @todo Not the correct display, has to be created in storybook.
           'type' => [
-            'label' => $node->private->value === '0' ? t('Public') : t('Community members only'),
+            'label' => $node->private->value === '1' ? t('Community members only') : t('Public'),
           ],
           'meta' => [
             ['label' => $node->type->entity->label()],


### PR DESCRIPTION
Bugfix: when the value of private field is empty (NULL), it was showing Community members only while remaining available for anonymous users.

This mostly applies to contents not created throught the UI where the value would be set automaticlaly depending on the checkbox. (like content generation)