### PR TITLE
EICNET-1771: Configure pathauto to not create new aliases automatically on title change.

### DIFF
--- a/config/sync/pathauto.pattern.books.yml
+++ b/config/sync/pathauto.pattern.books.yml
@@ -5,18 +5,18 @@ dependencies:
   module:
     - node
 id: books
-label: Books
+label: 'Node - Books'
 type: 'canonical_entities:node'
 pattern: '[node:title]'
 selection_criteria:
-  fdab11e7-299e-415c-aa79-a01432230c59:
+  8884be28-c3f4-45e4-b523-2133eb766027:
     id: node_type
     bundles:
       book: book
     negate: false
     context_mapping:
       node: node
-    uuid: fdab11e7-299e-415c-aa79-a01432230c59
+    uuid: 8884be28-c3f4-45e4-b523-2133eb766027
 selection_logic: and
 weight: -10
 relationships: {  }

--- a/config/sync/pathauto.pattern.discussions.yml
+++ b/config/sync/pathauto.pattern.discussions.yml
@@ -5,18 +5,18 @@ dependencies:
   module:
     - node
 id: discussions
-label: Discussions
+label: 'Node - Discussions'
 type: 'canonical_entities:node'
 pattern: '[node:node_group_url]/discussions/[node:title]'
 selection_criteria:
-  070972a0-f22e-46fc-bed4-3fa7b8beb222:
+  6820c0e7-8784-4945-9a11-4a6c8a1069a6:
     id: node_type
     bundles:
       discussion: discussion
     negate: false
     context_mapping:
       node: node
-    uuid: 070972a0-f22e-46fc-bed4-3fa7b8beb222
+    uuid: 6820c0e7-8784-4945-9a11-4a6c8a1069a6
 selection_logic: and
 weight: -9
 relationships: {  }

--- a/config/sync/pathauto.pattern.events.yml
+++ b/config/sync/pathauto.pattern.events.yml
@@ -1,22 +1,22 @@
-uuid: 30db2b25-edc5-47f1-8e7d-2c4aa2c836c8
+uuid: 0a33dd88-b8c0-4353-9b3d-244cc91f0f52
 langcode: en
 status: true
 dependencies:
   module:
     - node
-id: wiki_pages
-label: 'Node - Wiki pages'
+id: events
+label: 'Node - Events'
 type: 'canonical_entities:node'
-pattern: '[node:node_book_parent_url]/[node:title]'
+pattern: '[node:node_group_url]/events/[node:title]'
 selection_criteria:
-  b5306925-5f84-4c9f-9acf-caf877f214b1:
+  7b3d0e5a-ec30-4013-9d8b-0cd422633c6b:
     id: node_type
     bundles:
-      wiki_page: wiki_page
+      event: event
     negate: false
     context_mapping:
       node: node
-    uuid: b5306925-5f84-4c9f-9acf-caf877f214b1
+    uuid: 7b3d0e5a-ec30-4013-9d8b-0cd422633c6b
 selection_logic: and
 weight: -5
 relationships: {  }

--- a/config/sync/pathauto.pattern.library.yml
+++ b/config/sync/pathauto.pattern.library.yml
@@ -5,11 +5,11 @@ dependencies:
   module:
     - node
 id: library
-label: Library
+label: 'Node - Library'
 type: 'canonical_entities:node'
 pattern: '[node:node_group_url]/library/[node:title]'
 selection_criteria:
-  a9ca8400-c6bc-40de-b50d-141e57b05890:
+  ef0a2ae5-ad37-4354-a444-8e0f3d3b7ccf:
     id: node_type
     bundles:
       document: document
@@ -18,7 +18,7 @@ selection_criteria:
     negate: false
     context_mapping:
       node: node
-    uuid: a9ca8400-c6bc-40de-b50d-141e57b05890
+    uuid: ef0a2ae5-ad37-4354-a444-8e0f3d3b7ccf
 selection_logic: and
 weight: -8
 relationships: {  }

--- a/config/sync/pathauto.pattern.news.yml
+++ b/config/sync/pathauto.pattern.news.yml
@@ -5,18 +5,18 @@ dependencies:
   module:
     - node
 id: news
-label: News
+label: 'Node - News'
 type: 'canonical_entities:node'
 pattern: '[node:node_group_url]/news/[node:title]'
 selection_criteria:
-  fa81abf5-640d-4efc-a8d3-7bea7be61832:
+  23e4d324-834a-40b7-aaa8-4123cdda0e54:
     id: node_type
     bundles:
       news: news
     negate: false
     context_mapping:
       node: node
-    uuid: fa81abf5-640d-4efc-a8d3-7bea7be61832
+    uuid: 23e4d324-834a-40b7-aaa8-4123cdda0e54
 selection_logic: and
 weight: -7
 relationships: {  }

--- a/config/sync/pathauto.pattern.stories.yml
+++ b/config/sync/pathauto.pattern.stories.yml
@@ -5,18 +5,18 @@ dependencies:
   module:
     - node
 id: stories
-label: Stories
+label: 'Node - Stories'
 type: 'canonical_entities:node'
 pattern: '[node:node_group_url]/stories/[node:title]'
 selection_criteria:
-  9576bc1d-7c9e-426e-b9c0-23bac8084a58:
+  77e61113-8d04-4de0-be65-d20cfe221a02:
     id: node_type
     bundles:
       story: story
     negate: false
     context_mapping:
       node: node
-    uuid: 9576bc1d-7c9e-426e-b9c0-23bac8084a58
+    uuid: 77e61113-8d04-4de0-be65-d20cfe221a02
 selection_logic: and
 weight: -6
 relationships: {  }

--- a/config/sync/pathauto.settings.yml
+++ b/config/sync/pathauto.settings.yml
@@ -41,7 +41,7 @@ transliterate: true
 reduce_ascii: false
 case: true
 ignore_words: 'an, as, at, before, but, by, for, from, is, in, into, like, of, off, on, onto, per, since, than, the, this, that, to, up, via, with'
-update_action: 2
+update_action: 0
 safe_tokens:
   - alias
   - path


### PR DESCRIPTION
### Tests

- [x] Change the title of node, don't touch URL alias field
- [x] URL alias should remain the same
- [x] Change the URL alias of the node
- [x] Node alias should now be the new one and the old one should be redirected to the new one