### PR TITLE
[EICNET] Convert non-standard reverse proxy headers to standard ones

### DIFF
--- a/docker/nginx/servers/default.conf
+++ b/docker/nginx/servers/default.conf
@@ -22,11 +22,9 @@ server {
 
         proxy_set_header Upgrade           $http_upgrade;
         proxy_set_header Connection        "upgrade";
-        proxy_set_header Host              $host;
-        proxy_set_header X-Real-IP         $remote_addr;
-        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Host  $host;
-        proxy_set_header X-Forwarded-Port  8085;
+        proxy_set_header X-Request-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Request-Proto $scheme;
+        proxy_set_header X-Request-Host  $host;
+        proxy_set_header X-Request-Port  8085;
     }
 }

--- a/lib/modules/eic_helper/eic_helper.services.yml
+++ b/lib/modules/eic_helper/eic_helper.services.yml
@@ -1,4 +1,9 @@
 services:
   eic_helper.datetime:
     class: Drupal\eic_helper\DateTimeHelper
-    arguments: ['@datetime.time']
+    arguments: [ '@datetime.time' ]
+  eic_helper.reverse_proxy_header_mapper:
+    class: Drupal\eic_helper\StackMiddleware\HeaderMapper
+    arguments: [ '@settings' ]
+    tags:
+      - { name: http_middleware, priority: 301 }

--- a/lib/modules/eic_helper/src/StackMiddleware/HeaderMapper.php
+++ b/lib/modules/eic_helper/src/StackMiddleware/HeaderMapper.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Drupal\eic_helper\StackMiddleware;
+
+use Drupal\Core\Site\Settings;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/**
+ * Class HeaderMapper
+ * This class is intended to map non-standard reverse proxy headers
+ * to X-Forwarded-* headers.
+ * We then let the job to the ReverseProxyMiddleware from core.
+ *
+ * @package Drupal\eic_helper\StackMiddleware
+ */
+class HeaderMapper implements HttpKernelInterface {
+
+  /**
+   * Name of the settings where the mapping is stored.
+   */
+  const HEADER_MAPPING_SETTING = 'reverse_proxy_header_mapping';
+
+  /**
+   * List of supported headers this class maps values towards.
+   */
+  private const TRUSTED_HEADERS = [
+    Request::HEADER_X_FORWARDED_FOR => 'X_FORWARDED_FOR',
+    Request::HEADER_X_FORWARDED_HOST => 'X_FORWARDED_HOST',
+    Request::HEADER_X_FORWARDED_PROTO => 'X_FORWARDED_PROTO',
+    Request::HEADER_X_FORWARDED_PORT => 'X_FORWARDED_PORT',
+  ];
+
+  /**
+   * @var \Symfony\Component\HttpKernel\HttpKernelInterface
+   */
+  protected $httpKernel;
+
+  /**
+   * @var \Drupal\Core\Site\Settings
+   */
+  protected $settings;
+
+  /**
+   * @param \Symfony\Component\HttpKernel\HttpKernelInterface $http_kernel
+   * @param \Drupal\Core\Site\Settings $settings
+   */
+  public function __construct(
+    HttpKernelInterface $http_kernel,
+    Settings $settings
+  ) {
+    $this->settings = $settings;
+    $this->httpKernel = $http_kernel;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function handle(
+    Request $request,
+    $type = self::MASTER_REQUEST,
+    $catch = TRUE
+  ) {
+    if (
+      $this->settings->get('reverse_proxy') !== FALSE
+      && !empty($this->settings->get(self::HEADER_MAPPING_SETTING))
+    ) {
+      $this->mapHeaders($request);
+    }
+
+    return $this->httpKernel->handle($request, $type, $catch);
+  }
+
+  /**
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   */
+  protected function mapHeaders(Request $request) {
+    $supported_headers = Settings::get(self::HEADER_MAPPING_SETTING);
+    foreach ($supported_headers as $to => $from) {
+      if (!self::TRUSTED_HEADERS[$to] || !$request->headers->has($from)) {
+        continue;
+      }
+
+      $request->headers->set(
+        self::TRUSTED_HEADERS[$to],
+        $request->headers->get($from)
+      );
+    }
+  }
+
+}

--- a/web/sites/default/default.settings.local.php
+++ b/web/sites/default/default.settings.local.php
@@ -23,6 +23,9 @@
  *
  * @see https://wiki.php.net/rfc/expectations
  */
+
+use Symfony\Component\HttpFoundation\Request;
+
 assert_options(ASSERT_ACTIVE, TRUE);
 \Drupal\Component\Assertion\Handle::register();
 
@@ -204,3 +207,11 @@ $settings['smed_api_taxonomy_endpoint'] = getenv('SMED_API_ENDPOINT');
 $settings['reverse_proxy'] = TRUE;
 $settings['reverse_proxy_addresses'] = [gethostbyname('nginx')];
 $settings['reverse_proxy_trusted_headers'] = \Symfony\Component\HttpFoundation\Request::HEADER_X_FORWARDED_FOR | \Symfony\Component\HttpFoundation\Request::HEADER_X_FORWARDED_HOST | \Symfony\Component\HttpFoundation\Request::HEADER_X_FORWARDED_PORT | \Symfony\Component\HttpFoundation\Request::HEADER_X_FORWARDED_PROTO | \Symfony\Component\HttpFoundation\Request::HEADER_FORWARDED;
+// Only for local & dev environments as we do not support X-Forwarded-* headers for them.
+// Production/acceptance can use them instead.
+$settings['reverse_proxy_header_mapping'] = [
+  Request::HEADER_X_FORWARDED_HOST => 'X-Request-Host',
+  Request::HEADER_X_FORWARDED_FOR => 'X-Request-For',
+  Request::HEADER_X_FORWARDED_PORT => 'X-Request-Port',
+  Request::HEADER_X_FORWARDED_PROTO => 'X-Request-Proto',
+];


### PR DESCRIPTION
## Description
Unfortunately our dev environments aren't supporting standard X-Forwarded-* headers. This PR introduces an HTTP middleware which maps custom headers into standard X-Forwarded-* headers and let's the symfony/http-foundation component do its job.

## To Test

- [ ] Re-setup your local env or be sure to have the correct mapping in settings.php (check for the `reverse_proxy_header_mapping' setting) 
- [ ] Go to `localhost:[REVERSE_PROXY_PORT]/community` and navigate (e.g: you should stay on that hostname when signing in)