### PR TITLE
Feature/eicnet 1783 organisation visibility

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -58,6 +58,7 @@ module:
   eic_message_subscriptions: 0
   eic_messages: 0
   eic_migrate: 0
+  eic_organisations: 0
   eic_overviews: 0
   eic_paragraph_contributor: 0
   eic_paragraph_cta_tile: 0

--- a/lib/modules/eic_groups/modules/eic_organisations/eic_organisations.info.yml
+++ b/lib/modules/eic_groups/modules/eic_organisations/eic_organisations.info.yml
@@ -1,0 +1,9 @@
+name: EIC Groups - Organisations
+type: module
+description: Provides funcitonnality around group organisations.
+package: European Innovation Council
+core: 8.x
+core_version_requirement: ^8 || ^9
+php: 7.3
+dependencies:
+  - eic_groups:eic_groups

--- a/lib/modules/eic_groups/modules/eic_organisations/src/Plugin/CustomRestrictedVisibility/RestrictedOrganisations.php
+++ b/lib/modules/eic_groups/modules/eic_organisations/src/Plugin/CustomRestrictedVisibility/RestrictedOrganisations.php
@@ -29,6 +29,9 @@ class RestrictedOrganisations extends CustomRestrictedVisibilityBase {
    */
   public function getPluginForm():array {
     $form = parent::getPluginForm();
+
+    // @todo Make use of the entity_tree widget once available for
+    // organisations.
     $form[$this->getPluginId()][$this->getPluginId() . '_conf'] = [
       '#title' => $this->t('Organisations'),
       '#description' => $this->t('Add multiple organisations separating them with a comma'),

--- a/lib/modules/eic_groups/modules/eic_organisations/src/Plugin/CustomRestrictedVisibility/RestrictedOrganisations.php
+++ b/lib/modules/eic_groups/modules/eic_organisations/src/Plugin/CustomRestrictedVisibility/RestrictedOrganisations.php
@@ -31,7 +31,7 @@ class RestrictedOrganisations extends CustomRestrictedVisibilityBase {
     $form = parent::getPluginForm();
     $form[$this->getPluginId()][$this->getPluginId() . '_conf'] = [
       '#title' => $this->t('Organisations'),
-      '#description' => $this->t('Add multiple email organisations separating them with a comma'),
+      '#description' => $this->t('Add multiple organisations separating them with a comma'),
       '#type' => 'entity_autocomplete',
       '#target_type' => 'group',
       '#tags' => TRUE,

--- a/lib/modules/eic_groups/modules/eic_organisations/src/Plugin/CustomRestrictedVisibility/RestrictedOrganisations.php
+++ b/lib/modules/eic_groups/modules/eic_organisations/src/Plugin/CustomRestrictedVisibility/RestrictedOrganisations.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Drupal\eic_organisations\Plugin\CustomRestrictedVisibility;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\group\Access\GroupAccessResult;
+use Drupal\group\Entity\GroupInterface;
+use Drupal\group\Entity\Group;
+use Drupal\oec_group_flex\GroupVisibilityRecordInterface;
+use Drupal\oec_group_flex\Plugin\CustomRestrictedVisibilityBase;
+
+/**
+ * Provides a 'restricted_organisations' custom restricted visibility.
+ *
+ * @CustomRestrictedVisibility(
+ *  id = "restricted_organisations",
+ *  label = @Translation("Specific organisations"),
+ *  weight = 10
+ * )
+ */
+class RestrictedOrganisations extends CustomRestrictedVisibilityBase {
+
+  use StringTranslationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPluginForm():array {
+    $form = parent::getPluginForm();
+    $form[$this->getPluginId()][$this->getPluginId() . '_conf'] = [
+      '#title' => $this->t('Organisations'),
+      '#description' => $this->t('Add multiple email organisations separating them with a comma'),
+      '#type' => 'entity_autocomplete',
+      '#target_type' => 'group',
+      '#tags' => TRUE,
+      '#selection_settings' => [
+        'target_bundles' => ['organisation'],
+        'sort' => [
+          'field' => 'label',
+          'direction' => 'ASC',
+        ],
+      ],
+      '#states' => [
+        'visible' => [
+          ':input[name="' . $this->getPluginId() . '_status"]' => [
+            'checked' => TRUE,
+          ],
+        ],
+      ],
+      '#weight' => $this->getWeight() + 1,
+    ];
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setDefaultFormValues(array &$pluginForm, GroupVisibilityRecordInterface $group_visibility_record = NULL): array {
+    if (is_null($group_visibility_record)) {
+      return $pluginForm;
+    }
+
+    $options = $this->getOptionsForPlugin($group_visibility_record);
+    if (array_key_exists($this->getStatusKey(), $options) && $options[$this->getStatusKey()] === 1) {
+      $pluginForm[$this->getStatusKey()]['#default_value'] = 1;
+      $conf_key = $this->getPluginId() . '_conf';
+
+      $restricted_organisations = $options[$conf_key];
+      if ($restricted_organisations) {
+        foreach ($restricted_organisations as $organisation) {
+          $pluginForm[$conf_key]['#default_value'][] = Group::load($organisation['target_id']);
+        }
+      }
+    }
+    return $pluginForm;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function hasViewAccess(GroupInterface $entity, AccountInterface $account, GroupVisibilityRecordInterface $group_visibility_record) {
+    $conf_key = $this->getPluginId() . '_conf';
+    $options = $this->getOptionsForPlugin($group_visibility_record);
+    $restricted_organisations = array_key_exists($conf_key, $options) ? $options[$conf_key] : '';
+    $restricted_organisations = array_column($restricted_organisations, 'target_id');
+
+    // Allow access if user belongs to referenced organisations.
+    foreach ($restricted_organisations as $organisation_id) {
+      // Load the organisation.
+      /** @var \Drupal\group\Entity\GroupInterface $organisation */
+      $organisation = $this->entityTypeManager->getStorage('group')->load($organisation_id);
+      if (!$organisation) {
+        continue;
+      }
+
+      // If user is member of this group.
+      if ($organisation->getMember($account)) {
+        return GroupAccessResult::allowed()
+          ->addCacheableDependency($account)
+          ->addCacheableDependency($entity);
+      }
+    }
+    // Fallback to neutral access.
+    return parent::hasViewAccess($entity, $account, $group_visibility_record);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validatePluginForm(array &$element, FormStateInterface $form_state) {
+    // If plugin status is disabled, we do nothing.
+    if (parent::validatePluginForm($element, $form_state)) {
+      return;
+    }
+    $conf_key = $this->getPluginId() . '_conf';
+    if ($form_state->getValue($conf_key)) {
+      return;
+    }
+    return $form_state->setError($element[$this->getPluginId() . '_conf'], $this->t('Please select at least 1 organisation.'));
+  }
+
+}

--- a/lib/modules/eic_groups/src/Constants/GroupVisibilityType.php
+++ b/lib/modules/eic_groups/src/Constants/GroupVisibilityType.php
@@ -19,6 +19,8 @@ final class GroupVisibilityType {
 
   const GROUP_VISIBILITY_OPTION_EMAIL_DOMAIN = 'restricted_email_domains';
 
+  const GROUP_VISIBILITY_OPTION_ORGANISATIONS = 'restricted_organisations';
+
   const GROUP_VISIBILITY_OPTION_TRUSTED_USERS = 'restricted_users';
 
 }

--- a/lib/modules/eic_search/src/Plugin/search_api/processor/GroupAccessContent.php
+++ b/lib/modules/eic_search/src/Plugin/search_api/processor/GroupAccessContent.php
@@ -139,6 +139,7 @@ class GroupAccessContent extends ProcessorPluginBase {
     ss_group_visibility:' . GroupVisibilityType::GROUP_VISIBILITY_PUBLIC . '
     OR (ss_group_visibility:' . GroupVisibilityType::GROUP_VISIBILITY_PRIVATE . ' AND its_group_id_integer:(' . $group_ids_formatted . '))
     OR (ss_group_visibility:' . GroupVisibilityType::GROUP_VISIBILITY_OPTION_EMAIL_DOMAIN . ' AND ss_' . GroupVisibilityType::GROUP_VISIBILITY_OPTION_EMAIL_DOMAIN . ':*' . $domain . '*)
+    OR (ss_group_visibility:' . GroupVisibilityType::GROUP_VISIBILITY_OPTION_ORGANISATIONS . ' AND itm_' . GroupVisibilityType::GROUP_VISIBILITY_OPTION_ORGANISATIONS . ':(' . $group_ids_formatted . '))
     ';
 
     // Restricted community group, only trusted_user role can view.

--- a/lib/modules/eic_search/src/Service/SolrDocumentProcessor.php
+++ b/lib/modules/eic_search/src/Service/SolrDocumentProcessor.php
@@ -595,16 +595,35 @@ class SolrDocumentProcessor {
                 return -1;
               }
 
+              // @todo Make use of user ID only.
               return $user->id() . '|' . $user->getAccountName();
             }, $user_ids);
 
             $document->addField('ss_' . GroupVisibilityType::GROUP_VISIBILITY_OPTION_TRUSTED_USERS, implode(',', $users));
           }
+
+          if (GroupVisibilityType::GROUP_VISIBILITY_OPTION_ORGANISATIONS === $key && $option[GroupVisibilityType::GROUP_VISIBILITY_OPTION_ORGANISATIONS . '_status']) {
+            $group_visibility = GroupVisibilityType::GROUP_VISIBILITY_OPTION_ORGANISATIONS;
+
+            $organisation_ids = $option[GroupVisibilityType::GROUP_VISIBILITY_OPTION_ORGANISATIONS . '_conf'];
+            $organisations = array_map(function ($organisation_id) {
+              $organisation = Group::load(reset($organisation_id));
+              if (!$organisation) {
+                return -1;
+              }
+
+              return $organisation->id();
+            }, $organisation_ids);
+
+            $document->addField('itm_' . GroupVisibilityType::GROUP_VISIBILITY_OPTION_ORGANISATIONS, $organisations);
+          }
         }
         break;
+
       default:
         $group_visibility = GroupVisibilityType::GROUP_VISIBILITY_PUBLIC;
         break;
+
     }
 
     $document->addField('ss_group_visibility', $group_visibility);

--- a/lib/modules/oec_group_flex/src/Plugin/CustomRestrictedVisibility/RestrictedUsers.php
+++ b/lib/modules/oec_group_flex/src/Plugin/CustomRestrictedVisibility/RestrictedUsers.php
@@ -31,6 +31,8 @@ class RestrictedUsers extends CustomRestrictedVisibilityBase {
     $form = parent::getPluginForm();
 
     // Specific trusted users text box.
+    // @todo Make use of the entity_tree widget once available for
+    //   organisations.
     $form[$this->getPluginId()][$this->getPluginId() . '_conf'] = [
       '#title' => $this->t('Select trusted users'),
       '#type' => 'entity_autocomplete',

--- a/lib/modules/oec_group_flex/src/Plugin/CustomRestrictedVisibility/RestrictedUsers.php
+++ b/lib/modules/oec_group_flex/src/Plugin/CustomRestrictedVisibility/RestrictedUsers.php
@@ -31,8 +31,6 @@ class RestrictedUsers extends CustomRestrictedVisibilityBase {
     $form = parent::getPluginForm();
 
     // Specific trusted users text box.
-    // @todo Make use of the entity_tree widget once available for
-    //   organisations.
     $form[$this->getPluginId()][$this->getPluginId() . '_conf'] = [
       '#title' => $this->t('Select trusted users'),
       '#type' => 'entity_autocomplete',

--- a/lib/modules/oec_group_flex/src/Plugin/CustomRestrictedVisibilityBase.php
+++ b/lib/modules/oec_group_flex/src/Plugin/CustomRestrictedVisibilityBase.php
@@ -4,15 +4,54 @@ namespace Drupal\oec_group_flex\Plugin;
 
 use Drupal\Component\Plugin\PluginBase;
 use Drupal\Core\Access\AccessResultNeutral;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\group\Entity\GroupInterface;
 use Drupal\oec_group_flex\GroupVisibilityRecordInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Base class for Custom restricted visibility plugins.
  */
-abstract class CustomRestrictedVisibilityBase extends PluginBase implements CustomRestrictedVisibilityInterface {
+abstract class CustomRestrictedVisibilityBase extends PluginBase implements CustomRestrictedVisibilityInterface, ContainerFactoryPluginInterface {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a \Drupal\Component\Plugin\PluginBase object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager')
+    );
+  }
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
### Tests

- [x] Create 2 organisations: Organisation A and Organisation B
- [x] Change the visibility of Group 1 to Custom restriction => Specific organisations => Organisation A
- [x] Change the visibility of Group 2 to Custom restriction => Specific organisations => Organisation B
- [x] Add User 1 (TU) to Organisation A
- [x] Add User 2 (TU) to Organisation B
- [x] Login as User 1
- [x] Check that you can access Goup 1 detail page and not Group 2
- [x] Check that you see all content from Group 1 in all Solr views and no content from Group 2
- [x] Login as User 2
- [x] Check that you can access Goup 2 detail page and not Group 1
- [x] Check that you see all content from Group 2 in all Solr views and no content from Group 1

### Remarks

- The React entity_tree widget is not ready yet, it should be a sub-ticket