### PR TITLE
EICNET-1546: Fix author name in blocked history list

### DIFF
--- a/config/sync/views.view.admin_blocked_entities.yml
+++ b/config/sync/views.view.admin_blocked_entities.yml
@@ -4,13 +4,10 @@ status: true
 dependencies:
   config:
     - field.storage.flagging.field_block_reason
-    - field.storage.user.field_first_name
-    - field.storage.user.field_last_name
     - flag.flag.block_group
   module:
     - flag
     - group
-    - user
 id: admin_blocked_entities
 label: 'Admin - Blocked entities'
 module: views
@@ -268,144 +265,18 @@ display:
           entity_type: flagging
           entity_field: created
           plugin_id: field
-        field_first_name:
-          id: field_first_name
-          table: user__field_first_name
-          field: field_first_name
-          relationship: user
-          group_type: group
-          admin_label: ''
-          label: ''
-          exclude: true
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: value
-          type: string
-          settings:
-            link_to_entity: false
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-          plugin_id: field
-        field_last_name:
-          id: field_last_name
-          table: user__field_last_name
-          field: field_last_name
-          relationship: user
-          group_type: group
-          admin_label: ''
-          label: ''
-          exclude: true
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: value
-          type: string
-          settings:
-            link_to_entity: false
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-          plugin_id: field
-        name:
-          id: name
-          table: users_field_data
-          field: name
-          relationship: user
+        uid:
+          id: uid
+          table: flagging
+          field: uid
+          relationship: none
           group_type: group
           admin_label: ''
           label: Author
           exclude: false
           alter:
-            alter_text: true
-            text: '{{ field_first_name }} {{ field_last_name }}'
+            alter_text: false
+            text: ''
             make_link: false
             path: ''
             absolute: false
@@ -438,15 +309,15 @@ display:
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
-          empty: 'No author''s name'
+          empty: ''
           hide_empty: false
           empty_zero: false
-          hide_alter_empty: false
-          click_sort_column: value
-          type: string
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
           settings:
-            link_to_entity: true
-          group_column: value
+            link: false
+          group_column: target_id
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -456,8 +327,8 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: user
-          entity_field: name
+          entity_type: flagging
+          entity_field: uid
           plugin_id: field
       filters:
         flag_id:
@@ -518,16 +389,6 @@ display:
           required: true
           entity_type: flagging
           plugin_id: standard
-        user:
-          id: user
-          table: flagging
-          field: user
-          relationship: none
-          group_type: group
-          admin_label: User
-          required: false
-          entity_type: flagging
-          plugin_id: standard
       arguments:
         id:
           id: id
@@ -582,8 +443,6 @@ display:
         - user.group_permissions
       tags:
         - 'config:field.storage.flagging.field_block_reason'
-        - 'config:field.storage.user.field_first_name'
-        - 'config:field.storage.user.field_last_name'
   page_admin_group_blocked_history:
     display_plugin: page
     id: page_admin_group_blocked_history
@@ -605,5 +464,3 @@ display:
         - user.group_permissions
       tags:
         - 'config:field.storage.flagging.field_block_reason'
-        - 'config:field.storage.user.field_first_name'
-        - 'config:field.storage.user.field_last_name'


### PR DESCRIPTION
### Fixes

- Fix author name in blocked history list of a group.

### Tests

- [ ] As SA/SCM, block a group and provide a reason
- [ ] Go to the blocked history page `groups/<group-name>/blocked-history` and make sure the author column displays the correct name