### PR TITLE
EICNET-1808: User profile My Interests

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/common.inc
+++ b/lib/themes/eic_community/includes/preprocess/common.inc
@@ -15,6 +15,7 @@ use Drupal\eic_flags\FlagType;
 use Drupal\eic_groups\Constants\GroupVisibilityType;
 use Drupal\group\Entity\GroupInterface;
 use Drupal\node\NodeInterface;
+use Drupal\taxonomy\TermInterface;
 
 /**
  * Returns the build of the social share block.
@@ -268,4 +269,55 @@ function _eic_community_get_entity_last_comment(EntityInterface $entity, $first_
   }
 
   return NULL;
+}
+
+/**
+ * Loads taxonomy term parents from a term.
+ *
+ * @param \Drupal\taxonomy\TermInterface $term
+ *   The taxonomy term from which we want to load the parents.
+ * @param array $loaded_parents
+ *   The array of loaded parents.
+ *
+ * @return array
+ *   Array of all loaded parents of the term.
+ */
+function _eic_community_get_term_parents(TermInterface $term, array $loaded_parents) {
+  if ($term->parent->entity) {
+    $loaded_parents[$term->parent->entity->id()] = $term->parent->entity;
+    $loaded_parents = _eic_community_get_term_parents($term->parent->entity, $loaded_parents);
+  }
+  return $loaded_parents;
+}
+
+/**
+ * Processes all term parents hierarchically.
+ *
+ * @param \Drupal\taxonomy\TermInterface $term
+ *   The taxonomy term from which we want load the hierarchy.
+ * @param array $terms
+ *   The hierarchical tree of terms.
+ * @param array $loaded_parents
+ *   The array of loaded parents.
+ *
+ * @return array
+ *   Nested array of all loaded parents of the term.
+ */
+function _eic_community_process_term_parents_tree(TermInterface $term, array $terms, array $loaded_parents) {
+  $parent = array_shift($loaded_parents);
+  if (!isset($terms[$parent->id()])) {
+    $terms[$parent->id()]['term'] = $parent;
+    $terms[$parent->id()]['title'] = $parent->getName();
+    $terms[$parent->id()]['items'] = [];
+  }
+
+  if (!empty($loaded_parents)) {
+    $terms[$parent->id()]['items'] = _eic_community_process_term_parents_tree($term, $terms[$parent->id()]['items'], $loaded_parents);
+  }
+  else {
+    $terms[$parent->id()]['items'][$term->id()]['term'] = $term;
+    $terms[$parent->id()]['items'][$term->id()]['title'] = $term->getName();
+  }
+
+  return $terms;
 }

--- a/lib/themes/eic_community/includes/preprocess/users/user.inc
+++ b/lib/themes/eic_community/includes/preprocess/users/user.inc
@@ -153,16 +153,22 @@ function eic_community_preprocess_user(array &$variables) {
         ],
       ];
 
+      $user_item['flagged_interests'] = [
+        'title' => t('My Interests'),
+        'items' => [],
+      ];
       // Gets user topics of interest.
-      if ($topics_of_interest = _eic_community_get_user_topics_of_interest($user, $member_profile)) {
-        $user_item['flagged_interests'] = [
-          'title' => t('My Interests'),
-          'items' => [
-            [
-              'title' => t('Topics of interests'),
-              'items' => $topics_of_interest,
-            ],
-          ],
+      if ($topics_of_interest = _eic_community_get_user_topics($user, 'field_vocab_topic_interest', $member_profile)) {
+        $user_item['flagged_interests']['items'][] = [
+          'title' => t('Topics of interests'),
+          'items' => $topics_of_interest,
+        ];
+      }
+      // Gets user topics of expertise.
+      if ($topics_of_expertise = _eic_community_get_user_topics($user, 'field_vocab_topic_expertise', $member_profile)) {
+        $user_item['flagged_interests']['items'][] = [
+          'title' => t('Topics of expertise'),
+          'items' => $topics_of_expertise,
         ];
       }
 
@@ -463,17 +469,19 @@ function _eic_community_get_user_joining_date(UserInterface $account, $format = 
 }
 
 /**
- * Returns the array of topics of interest to use in templates.
+ * Returns the array of topics terms to use in templates.
  *
  * @param \Drupal\user\UserInterface $account
- *   The user account for which we want to get the topics of interest.
+ *   The user account for which we want to get the topics.
+ * @param string $taxonomy_term_field_name
+ *   The taxonomy term field name.
  * @param \Drupal\profile\Entity\ProfileInterface $member_profile
  *   (optional) The user profile entity associated with user account.
  *
  * @return array
- *   The array of topics of interest.
+ *   The array of topic terms.
  */
-function _eic_community_get_user_topics_of_interest(UserInterface $account, ProfileInterface $member_profile = NULL) {
+function _eic_community_get_user_topics(UserInterface $account, $taxonomy_term_field_name, ProfileInterface $member_profile = NULL) {
   $member_profile = $member_profile ?? \Drupal::service('eic_user.helper')->getUserMemberProfile($account);
 
   // If we don't have a member profile for this user, skip.
@@ -481,13 +489,18 @@ function _eic_community_get_user_topics_of_interest(UserInterface $account, Prof
     return [];
   }
 
-  // If the member profile doesn't have social links, skip.
-  if ($member_profile->get('field_vocab_topic_interest')->isEmpty()) {
+  // If the member profile doesn't have the field, skip.
+  if (!$member_profile->hasField($taxonomy_term_field_name)) {
+    return [];
+  }
+
+  // If the member profile doesn't have any selected topics, skip.
+  if ($member_profile->get($taxonomy_term_field_name)->isEmpty()) {
     return [];
   }
 
   /** @var \Drupal\taxonomy\TermInterface[] $terms */
-  $terms = $member_profile->get('field_vocab_topic_interest')->referencedEntities();
+  $terms = $member_profile->get($taxonomy_term_field_name)->referencedEntities();
 
   $topics = [];
   foreach ($terms as $term) {

--- a/lib/themes/eic_community/includes/preprocess/users/user.inc
+++ b/lib/themes/eic_community/includes/preprocess/users/user.inc
@@ -153,6 +153,19 @@ function eic_community_preprocess_user(array &$variables) {
         ],
       ];
 
+      // Gets user topics of interest.
+      if ($topics_of_interest = _eic_community_get_user_topics_of_interest($user, $member_profile)) {
+        $user_item['flagged_interests'] = [
+          'title' => t('My Interests'),
+          'items' => [
+            [
+              'title' => t('Topics of interests'),
+              'items' => $topics_of_interest,
+            ],
+          ],
+        ];
+      }
+
       $variables['user_item'] = $user_item;
       break;
 
@@ -447,4 +460,43 @@ function _eic_community_get_user_job_titles(UserInterface $account, ProfileInter
 function _eic_community_get_user_joining_date(UserInterface $account, $format = DateTimeHelper::DATE_FORMAT_MONTH_FULL_YEAR) {
   $date_formatter = \Drupal::service('date.formatter');
   return $date_formatter->format($account->getCreatedTime(), $format);
+}
+
+/**
+ * Returns the array of topics of interest to use in templates.
+ *
+ * @param \Drupal\user\UserInterface $account
+ *   The user account for which we want to get the topics of interest.
+ * @param \Drupal\profile\Entity\ProfileInterface $member_profile
+ *   (optional) The user profile entity associated with user account.
+ *
+ * @return array
+ *   The array of topics of interest.
+ */
+function _eic_community_get_user_topics_of_interest(UserInterface $account, ProfileInterface $member_profile = NULL) {
+  $member_profile = $member_profile ?? \Drupal::service('eic_user.helper')->getUserMemberProfile($account);
+
+  // If we don't have a member profile for this user, skip.
+  if (empty($member_profile)) {
+    return [];
+  }
+
+  // If the member profile doesn't have social links, skip.
+  if ($member_profile->get('field_vocab_topic_interest')->isEmpty()) {
+    return [];
+  }
+
+  /** @var \Drupal\taxonomy\TermInterface[] $terms */
+  $terms = $member_profile->get('field_vocab_topic_interest')->referencedEntities();
+
+  $topics = [];
+  foreach ($terms as $term) {
+    $loaded_parents = [];
+    /** @var \Drupal\taxonomy\TermInterface[] $loaded_parents */
+    $loaded_parents = _eic_community_get_term_parents($term, $loaded_parents);
+    $loaded_parents = array_reverse($loaded_parents, TRUE);
+    $topics = _eic_community_process_term_parents_tree($term, $topics, $loaded_parents);
+  }
+
+  return $topics;
 }

--- a/lib/themes/eic_community/templates/user/user--full.html.twig
+++ b/lib/themes/eic_community/templates/user/user--full.html.twig
@@ -1,3 +1,11 @@
+{% set user_interests %}
+  {% include "@theme/patterns/compositions/extended-list/extended-list.html.twig" with user_item.flagged_interests %}
+{% endset %}
+
 {% include "@theme/patterns/compositions/member/member.full.html.twig" with user_item|default({})|merge({
-  sidebar_title: 'Contact information'|t
+  sidebar_title: 'Contact information'|t,
+  flagged_interests: {
+    title: 'Interests'|t,
+    content: user_interests,
+  },
 }) %}


### PR DESCRIPTION
### Features

- Show topics of interest and topics of expertise when viewing user profile.
- Create helper functions in the theme to grab vocabulary terms in hierarchical tree.

### Tests

- [ ] Edit a user profile `/user/<uid>/member` and add some topics of interest and expertise
- [ ] Go to the user detail page and make sure there is a new tab "Interests" that shows the topics of interest and expertise selected by the user. Also make sure those are shown as a hierarchical tree.

### Notes

- [ ] This PR should be merged after #950 