### PR TITLE
[EICNET] fix: Do not type-hint in FlagEventSubscriber

### DIFF
--- a/lib/modules/eic_user/src/EventSubscriber/FlagEventSubscriber.php
+++ b/lib/modules/eic_user/src/EventSubscriber/FlagEventSubscriber.php
@@ -5,7 +5,6 @@ namespace Drupal\eic_user\EventSubscriber;
 use Drupal\Core\Cache\Cache;
 use Drupal\eic_flags\FlagType;
 use Drupal\flag\Event\FlagEvents;
-use Drupal\flag\Event\FlaggingEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -26,10 +25,10 @@ class FlagEventSubscriber implements EventSubscriberInterface {
   /**
    * React to flagging event.
    *
-   * @param \Drupal\flag\Event\FlaggingEvent $event
+   * @param \Drupal\flag\Event\FlaggingEvent|\Drupal\flag\Event\UnflaggingEvent $event
    *   The flagging event.
    */
-  public function invalidateFlaggedEntityCache(FlaggingEvent $event) {
+  public function invalidateFlaggedEntityCache($event) {
     /** @var \Drupal\flag\FlaggingInterface $flagging */
     $flagging = $event->getFlagging();
 


### PR DESCRIPTION
It seems like this event subscriber is for flagging and unflagging events. However the type-hint of the `invalidateFlaggedEntityCache` is wrong as an UnflaggingEvent can be passed

We make the choice to remove the type-hint for the moment as the Event interface these 2 events are implementing is deprecated and should be replaced whenever possible