### PR TITLE
EICNET-286: As a site admin I want to be able to adapt the non logged in homepage welcome header content (Rework)

### DIFF
--- a/config/sync/user.role.content_administrator.yml
+++ b/config/sync/user.role.content_administrator.yml
@@ -70,6 +70,7 @@ permissions:
   - 'edit own news content'
   - 'edit own story content'
   - 'flag recommend_group'
+  - 'link to any page'
   - 'make archive request'
   - 'make delete request'
   - 'manage archival deletion requests'

--- a/config/sync/user.role.site_admin.yml
+++ b/config/sync/user.role.site_admin.yml
@@ -73,6 +73,7 @@ permissions:
   - 'edit own news content'
   - 'edit own story content'
   - 'flag recommend_group'
+  - 'link to any page'
   - 'make archive request'
   - 'make delete request'
   - 'manage archival deletion requests'


### PR DESCRIPTION
### Fixes

- Allow SA/SCM users to add links to any page when filling in a link field.

### Tests

- [x] As SA/SCM, try to edit the homepage welcome header via `/admin/content/block-content`
- [x] Make sure you can add the URLs `/user/register` and `/user/login` and save it
- [x] Go back to the edit form and make sure the URLs didn't disappear