### PR TITLE
EICNET-1780: Create News & Stories and Events overview pages in default content

### DIFF
--- a/config/sync/core.entity_view_display.overview_page.overview_page.default.yml
+++ b/config/sync/core.entity_view_display.overview_page.overview_page.default.yml
@@ -8,7 +8,6 @@ dependencies:
   module:
     - block_field
     - eic_overviews
-    - options
 id: overview_page.overview_page.default
 targetEntityType: overview_page
 bundle: overview_page
@@ -21,13 +20,6 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-  field_overview_id:
-    weight: 3
-    label: above
-    settings: {  }
-    third_party_settings: {  }
-    type: list_default
-    region: content
   overview_block:
     label: hidden
     type: entity_reference_entity_view
@@ -48,6 +40,7 @@ content:
 hidden:
   banner_image: true
   created: true
+  field_overview_id: true
   langcode: true
   search_api_excerpt: true
   status: true

--- a/lib/modules/eic_default_content/eic_default_content.services.yml
+++ b/lib/modules/eic_default_content/eic_default_content.services.yml
@@ -24,6 +24,10 @@ services:
     class: Drupal\eic_default_content\Generator\NewsGenerator
     tags:
       - { name: data_fixtures }
+  eic_default_content.menu_generator:
+    class: Drupal\eic_default_content\Generator\MenuGenerator
+    tags:
+      - { name: data_fixtures, priority: 2 }
   eic_default_content.block_content_generator:
     class: Drupal\eic_default_content\Generator\BlockContentGenerator
     tags:

--- a/lib/modules/eic_default_content/src/Generator/MenuGenerator.php
+++ b/lib/modules/eic_default_content/src/Generator/MenuGenerator.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Drupal\eic_default_content\Generator;
+
+use Drupal\menu_link_content\Entity\MenuLinkContent;
+
+/**
+ * Generates menu items.
+ *
+ * @package Drupal\eic_default_content\Generator
+ */
+class MenuGenerator extends CoreGenerator {
+
+  /**
+   * The menu links to generate.
+   *
+   * @var array
+   */
+  protected $menuLinks = [
+    'main' => [
+      [
+        'title' => 'Home',
+        'link' => ['uri' => 'internal:/'],
+        'weight' => 0,
+      ],
+      [
+        'title' => 'Stories',
+        'link' => ['uri' => 'internal:/articles'],
+        'weight' => 1,
+      ],
+      [
+        'title' => 'Topics',
+        'link' => ['uri' => 'internal:/topics'],
+        'weight' => 2,
+      ],
+      [
+        'title' => 'Groups',
+        'link' => ['uri' => 'internal:/groups'],
+        'weight' => 3,
+      ],
+      [
+        'title' => 'Events',
+        'link' => ['uri' => 'internal:/events'],
+        'weight' => 4,
+      ],
+      [
+        'title' => 'People',
+        'link' => ['uri' => 'internal:/people'],
+        'weight' => 5,
+      ],
+    ],
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function load() {
+    foreach ($this->menuLinks as $menu_name => $items) {
+      foreach ($items as $item) {
+        $menu_item = [
+          'title' => $item['title'],
+          'link' => $item['link'],
+          'menu_name' => $menu_name,
+          'expanded' => $item['expanded'] ?? FALSE,
+          'weight' => $item['weight'] ?? 0,
+        ];
+        $menu_link = MenuLinkContent::create($menu_item);
+        $menu_link->save();
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function unLoad() {
+    // Make sure we only delete the items created by this generator.
+    foreach ($this->menuLinks as $menu_name => $items) {
+      foreach ($items as $item) {
+        $conditions = [
+          'menu_name' => $menu_name,
+          'link' => $item['link'],
+        ];
+        $this->unloadEntities('menu_link_content', $conditions);
+      }
+    }
+  }
+
+}

--- a/lib/modules/eic_default_content/src/Generator/OverviewPageGenerator.php
+++ b/lib/modules/eic_default_content/src/Generator/OverviewPageGenerator.php
@@ -6,6 +6,7 @@ use Drupal\eic_events\Constants\Event;
 use Drupal\eic_overviews\Entity\OverviewPage;
 use Drupal\eic_overviews\GlobalOverviewPages;
 use Drupal\eic_search\Search\Sources\GlobalSourceType;
+use Drupal\eic_search\Search\Sources\GlobalEventSourceType;
 use Drupal\eic_search\Search\Sources\GroupSourceType;
 use Drupal\eic_search\Search\Sources\NewsStorySourceType;
 use Drupal\eic_search\Search\Sources\UserGallerySourceType;

--- a/lib/modules/eic_default_content/src/Generator/OverviewPageGenerator.php
+++ b/lib/modules/eic_default_content/src/Generator/OverviewPageGenerator.php
@@ -2,10 +2,12 @@
 
 namespace Drupal\eic_default_content\Generator;
 
+use Drupal\eic_events\Constants\Event;
 use Drupal\eic_overviews\Entity\OverviewPage;
 use Drupal\eic_overviews\GlobalOverviewPages;
 use Drupal\eic_search\Search\Sources\GlobalSourceType;
 use Drupal\eic_search\Search\Sources\GroupSourceType;
+use Drupal\eic_search\Search\Sources\NewsStorySourceType;
 use Drupal\eic_search\Search\Sources\UserGallerySourceType;
 
 /**
@@ -37,15 +39,40 @@ class OverviewPageGenerator extends CoreGenerator {
         'ss_group_topic_name',
       ],
       'source_type' => GroupSourceType::class,
-    ], 'Groups overview', '/groups',
+    ], 'Groups', '/groups',
       GlobalOverviewPages::GROUPS
     );
 
     $this->createOverview([
       'enable_search' => TRUE,
       'source_type' => UserGallerySourceType::class,
-    ], 'Members overview', '/people',
+    ], 'Members', '/people',
       GlobalOverviewPages::MEMBERS
+    );
+
+    $this->createOverview([
+      'enable_search' => TRUE,
+      'facets' => [
+        'ss_content_type',
+        'sm_content_field_vocab_topics_string',
+        'sm_content_field_vocab_geo_string',
+      ],
+      'source_type' => NewsStorySourceType::class,
+    ], 'News & Stories', '/articles',
+      GlobalOverviewPages::NEWS_STORIES
+    );
+
+    $this->createOverview([
+      'enable_search' => TRUE,
+      'facets' => [
+        'ss_group_topic_name',
+        'sm_group_field_location_type',
+        Event::SOLR_FIELD_ID_WEIGHT_STATE_LABEL,
+        'ss_group_event_country',
+      ],
+      'source_type' => GlobalEventSourceType::class,
+    ], 'Events', '/events',
+      GlobalOverviewPages::EVENTS
     );
   }
 

--- a/lib/modules/eic_overviews/eic_overviews.module
+++ b/lib/modules/eic_overviews/eic_overviews.module
@@ -52,7 +52,7 @@ function _eic_overviews_allowed_values_id() {
     GlobalOverviewPages::GLOBAL_SEARCH => t('Global overview', [], ['context' => 'eic_overviews']),
     GlobalOverviewPages::GROUPS => t('Groups', [], ['context' => 'eic_overviews']),
     GlobalOverviewPages::MEMBERS => t('Members', [], ['context' => 'eic_overviews']),
-    GlobalOverviewPages::STORIES => t('Stories', [], ['context' => 'eic_overviews']),
+    GlobalOverviewPages::NEWS_STORIES => t('News & Stories', [], ['context' => 'eic_overviews']),
     GlobalOverviewPages::EVENTS => t('Events', [], ['context' => 'eic_overviews']),
   ];
 }

--- a/lib/modules/eic_overviews/src/GlobalOverviewPages.php
+++ b/lib/modules/eic_overviews/src/GlobalOverviewPages.php
@@ -27,9 +27,9 @@ class GlobalOverviewPages {
   const MEMBERS = 3;
 
   /**
-   * ID of the Stories overview page.
+   * ID of the News & Stories overview page.
    */
-  const STORIES = 4;
+  const NEWS_STORIES = 4;
 
   /**
    * ID of the Events overview page.

--- a/lib/modules/eic_search/eic_search.services.yml
+++ b/lib/modules/eic_search/eic_search.services.yml
@@ -36,7 +36,7 @@ services:
     tags:
       - { name: eic_search.source }
   eic_search.source_story:
-    class: Drupal\eic_search\Search\Sources\StorySourceType
+    class: Drupal\eic_search\Search\Sources\NewsStorySourceType
     tags:
       - { name: eic_search.source }
   eic_search.source_global_event:

--- a/lib/modules/eic_search/src/Search/Sources/NewsStorySourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/NewsStorySourceType.php
@@ -7,11 +7,11 @@ use Drupal\eic_flags\FlagType;
 use Drupal\eic_search\Service\SolrDocumentProcessor;
 
 /**
- * Class StorySourceType
+ * Class NewsStorySourceType
  *
  * @package Drupal\eic_groups\Search\Sources
  */
-class StorySourceType extends SourceType {
+class NewsStorySourceType extends SourceType {
 
   use StringTranslationTrait;
 
@@ -26,7 +26,7 @@ class StorySourceType extends SourceType {
    * @inheritDoc
    */
   public function getLabel(): string {
-    return $this->t('Story', [], ['context' => 'eic_search']);
+    return $this->t('News & Stories', [], ['context' => 'eic_search']);
   }
 
   /**

--- a/lib/themes/eic_community/includes/preprocess/views.inc
+++ b/lib/themes/eic_community/includes/preprocess/views.inc
@@ -41,7 +41,7 @@ function eic_community_preprocess_views_view(&$variables) {
       'link' => [
         'label' => t('View all stories'),
         'path' => GlobalOverviewPages::getGlobalOverviewPageUrl(
-          GlobalOverviewPages::STORIES
+          GlobalOverviewPages::NEWS_STORIES
         ),
       ],
     ],


### PR DESCRIPTION
### Improvements

- There is a new MenuGenerator that will create the main menu links

### Tests

- [x] Run `drush fixtures:reload all`
- [ ] You should have now **News & Stories** and **Events** overview pages in _/admin/community/overview-pages_