### PR TITLE
EICNET-1627: As a user, I want to have a profile page so that I can see the personal informations of another user (Back-end)

### DIFF
--- a/config/sync/flag.flag.follow_user.yml
+++ b/config/sync/flag.flag.follow_user.yml
@@ -22,7 +22,7 @@ flood_control_active: false
 flood_control_limit: 0
 flood_control_window: 0
 flag_type: 'entity:user'
-link_type: eic_count_link
+link_type: eic_count_link_button
 flagTypeConfig:
   show_in_links: {  }
   show_as_field: true

--- a/config/sync/user.role.trusted_user.yml
+++ b/config/sync/user.role.trusted_user.yml
@@ -34,6 +34,7 @@ permissions:
   - 'post comments'
   - 'skip comment approval'
   - 'unflag recommend_group'
+  - 'update own member profile'
   - 'use group_wiki transition create_new_draft'
   - 'use group_wiki transition publish'
   - 'use group_wiki transition unpublish'

--- a/lib/modules/eic_flags/eic_flags.module
+++ b/lib/modules/eic_flags/eic_flags.module
@@ -36,6 +36,7 @@ function eic_flags_theme() {
         'action' => 'flag',
         'flag' => NULL,
         'flaggable' => NULL,
+        'showAsButton' => FALSE,
       ],
     ],
     'eic_flag_count_text' => [

--- a/lib/modules/eic_flags/src/Plugin/ActionLink/EICFlagCountLink.php
+++ b/lib/modules/eic_flags/src/Plugin/ActionLink/EICFlagCountLink.php
@@ -30,7 +30,7 @@ class EICFlagCountLink extends AJAXactionLink {
    *
    * @var \Drupal\flag\FlagCountManagerInterface
    */
-  protected $flagCountManager;
+  private $flagCountManager;
 
   /**
    * Build a new link type instance and sets the configuration.

--- a/lib/modules/eic_flags/src/Plugin/ActionLink/EICFlagCountLink.php
+++ b/lib/modules/eic_flags/src/Plugin/ActionLink/EICFlagCountLink.php
@@ -30,7 +30,7 @@ class EICFlagCountLink extends AJAXactionLink {
    *
    * @var \Drupal\flag\FlagCountManagerInterface
    */
-  private $flagCountManager;
+  protected $flagCountManager;
 
   /**
    * Build a new link type instance and sets the configuration.

--- a/lib/modules/eic_flags/src/Plugin/ActionLink/EICFlagCountLinkButton.php
+++ b/lib/modules/eic_flags/src/Plugin/ActionLink/EICFlagCountLinkButton.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\eic_flags\Plugin\ActionLink;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\flag\FlagInterface;
+
+/**
+ * Provides the Count link type as a button.
+ *
+ * This class is an extension of the Ajax link type, but modified to
+ * provide flag count.
+ *
+ * @ActionLinkType(
+ *   id = "eic_count_link_button",
+ *   label = @Translation("EIC Count link (show as button)"),
+ *   description = "An AJAX action link button which displays the count with the flag."
+ * )
+ */
+class EICFlagCountLinkButton extends EICFlagCountLink {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getAsFlagLink(FlagInterface $flag, EntityInterface $entity) {
+    $build = parent::getAsFlagLink($flag, $entity);
+    $build['#showAsButton'] = TRUE;
+    // Return the modified render array.
+    return $build;
+  }
+
+}

--- a/lib/modules/eic_user/src/Hooks/FieldWidgetOperations.php
+++ b/lib/modules/eic_user/src/Hooks/FieldWidgetOperations.php
@@ -51,7 +51,7 @@ class FieldWidgetOperations {
         $new_url = $form_state_values[$key]['link'];
 
         // Exception for LinkedIn since we need to prepend "in/" if missing.
-        if ($social_network_name === 'linkedin') {
+        if ($social_network_name === 'linkedin' && !empty($value['link'])) {
           // Remove backslash from the beginning if exists.
           if (substr($form_state_values[$key]['link'], 0, 1) === '/') {
             $new_url = substr($form_state_values[$key]['link'], 1);
@@ -59,6 +59,12 @@ class FieldWidgetOperations {
 
           if (substr($new_url, 0, 3) !== 'in/') {
             $form_state_values[$key]['link'] = 'in/' . $new_url;
+          }
+
+          // If the link value only contains the base LinkedIn path, we clean
+          // up the value.
+          if ($form_state_values[$key]['link'] === 'in/') {
+            $form_state_values[$key]['link'] = '';
           }
         }
         break;

--- a/lib/themes/eic_community/includes/preprocess/users/user.inc
+++ b/lib/themes/eic_community/includes/preprocess/users/user.inc
@@ -83,6 +83,17 @@ function eic_community_preprocess_user(array &$variables) {
         ],
       ];
 
+      // Gets user operation links.
+      if ($user_operation_links = _eic_community_get_user_operation_links($user)) {
+        $user_operation_links['icon'] = [
+          'name' => 'gear',
+          'type' => 'custom',
+        ];
+        $user_operation_links['icon_file_path'] = $variables['eic_icon_path'];
+        $user_operation_links['extra_classes'] = 'ecl-collapsible-options--blue';
+        $user_item['editorial_header']['actions'][] = $user_operation_links;
+      }
+
       // We show the contact link and follow flag if current user is not
       // viewing its own profile page.
       if ($current_user->id() !== $user->id()) {
@@ -554,5 +565,77 @@ function _eic_community_get_user_type(UserInterface $account, ProfileInterface $
       'name' => 'star_circle',
       'type' => 'custom',
     ],
+  ];
+}
+
+/**
+ * Returns the 'render' array to use in templates for the operation links.
+ *
+ * @param \Drupal\user\UserInterface $account
+ *   The user account for which we want to get the user operation links.
+ *
+ * @return array
+ *   The render array for templates.
+ */
+function _eic_community_get_user_operation_links(UserInterface $account, ProfileInterface $member_profile = NULL) {
+  // Get user operation links.
+  $user_operation_links = \Drupal::entityTypeManager()->getListBuilder($account->getEntityTypeId())
+    ->getOperations($account);
+
+  $processed_user_operation_links = [];
+  foreach ($user_operation_links as $key => $user_operation_link) {
+    switch ($key) {
+      // Override operation link titles.
+      case 'edit':
+        $user_operation_link['title'] = t('Edit account information');
+        break;
+
+      case 'delete':
+        $user_operation_link['title'] = t('Delete account');
+        break;
+
+    }
+    $processed_user_operation_links[] = [
+      'link' => [
+        'label' => $user_operation_link['title'],
+        'path' => $user_operation_link['url']->toString(),
+      ],
+    ];
+  }
+
+  // Loads user member profile.
+  $member_profile = $member_profile ?? \Drupal::service('eic_user.helper')->getUserMemberProfile($account);
+  // Get user member profile operation links.
+  if ($member_profile) {
+    $member_profile_operation_links = \Drupal::entityTypeManager()->getListBuilder($member_profile->getEntityTypeId())
+      ->getOperations($member_profile);
+    foreach ($member_profile_operation_links as $key => $member_profile_operation_link) {
+      // Override operation link titles.
+      switch ($key) {
+        case 'edit':
+          $member_profile_operation_link['title'] = t('Edit profile details');
+          break;
+
+        case 'delete':
+          $member_profile_operation_link['title'] = t('Delete profile');
+          break;
+
+      }
+      $processed_user_operation_links[] = [
+        'link' => [
+          'label' => $member_profile_operation_link['title'],
+          'path' => $member_profile_operation_link['url']->toString(),
+        ],
+      ];
+    }
+  }
+
+  if (empty($processed_user_operation_links)) {
+    return [];
+  }
+
+  return [
+    'label' => 'Manage profile',
+    'items' => $processed_user_operation_links,
   ];
 }

--- a/lib/themes/eic_community/includes/preprocess/users/user.inc
+++ b/lib/themes/eic_community/includes/preprocess/users/user.inc
@@ -557,8 +557,9 @@ function _eic_community_get_user_type(UserInterface $account, ProfileInterface $
     return [];
   }
 
-  /** @var \Drupal\taxonomy\Entity\Term $user_type */
-  $user_type = reset($member_profile->get('field_vocab_user_type')->referencedEntities());
+  /** @var \Drupal\taxonomy\Entity\TermInterface[] $user_type */
+  $user_types = $member_profile->get('field_vocab_user_type')->referencedEntities();
+  $user_type = reset($user_types);
   return [
     'label' => $user_type->getName(),
     'icon' => [

--- a/lib/themes/eic_community/includes/preprocess/users/user.inc
+++ b/lib/themes/eic_community/includes/preprocess/users/user.inc
@@ -51,6 +51,7 @@ function eic_community_preprocess_user(array &$variables) {
       break;
 
     case 'full':
+      $current_user = \Drupal::currentUser();
       $member_profile = \Drupal::service('eic_user.helper')->getUserMemberProfile($user);
       $user_item = [
         'editorial_header' => [
@@ -66,6 +67,7 @@ function eic_community_preprocess_user(array &$variables) {
         'icon_file_path' => $variables['eic_icon_path'],
         'title' => \Drupal::service('eic_user.helper')->getFullName($user),
         'description' => _eic_community_get_user_profile_body($user, $member_profile),
+        'type' => _eic_community_get_user_type($user, $member_profile),
         'job_titles' => _eic_community_get_user_job_titles($user, $member_profile),
         'image' => _get_profile_image_array($user),
         'meta' => [
@@ -81,22 +83,26 @@ function eic_community_preprocess_user(array &$variables) {
         ],
       ];
 
-      // Gets user contact link.
-      if (
-        ($user_contact_link = _eic_community_get_user_contact_link($user)) &&
-        $user->get(PrivateMessage::PRIVATE_MESSAGE_USER_ALLOW_CONTACT_ID)->value
-      ) {
-        $user_contact_link['icon']['name'] = 'send';
-        $user_contact_link['link'] = [
-          'label' => t('Direct message'),
-          'path' => $user_contact_link['path'],
-        ];
-        $user_item['editorial_header']['actions'][] = $user_contact_link;
-      }
+      // We show the contact link and follow flag if current user is not
+      // viewing its own profile page.
+      if ($current_user->id() !== $user->id()) {
+        // Gets user contact link.
+        if (
+          ($user_contact_link = _eic_community_get_user_contact_link($user)) &&
+          $user->get(PrivateMessage::PRIVATE_MESSAGE_USER_ALLOW_CONTACT_ID)->value
+        ) {
+          $user_contact_link['icon']['name'] = 'send';
+          $user_contact_link['link'] = [
+            'label' => t('Direct message'),
+            'path' => $user_contact_link['path'],
+          ];
+          $user_item['editorial_header']['actions'][] = $user_contact_link;
+        }
 
-      // Gets the follow user flag.
-      if (isset($variables['elements']['flag_' . FlagType::FOLLOW_USER])) {
-        $user_item['editorial_header']['actions'][] = ['content' => $variables['elements']['flag_' . FlagType::FOLLOW_USER]];
+        // Gets the follow user flag.
+        if (isset($variables['elements']['flag_' . FlagType::FOLLOW_USER])) {
+          $user_item['editorial_header']['actions'][] = ['content' => $variables['elements']['flag_' . FlagType::FOLLOW_USER]];
+        }
       }
 
       // Gets user social links.
@@ -514,4 +520,39 @@ function _eic_community_get_user_topics(UserInterface $account, $taxonomy_term_f
   }
 
   return $topics;
+}
+
+/**
+ * Returns the 'render' array to use in templates for the user type.
+ *
+ * @param \Drupal\user\UserInterface $account
+ *   The user account for which we want to get the user type.
+ * @param \Drupal\profile\Entity\ProfileInterface $member_profile
+ *   (optional) The user profile entity associated with user account.
+ *
+ * @return array
+ *   The render array for templates.
+ */
+function _eic_community_get_user_type(UserInterface $account, ProfileInterface $member_profile = NULL) {
+  $member_profile = $member_profile ?? \Drupal::service('eic_user.helper')->getUserMemberProfile($account);
+
+  // If we don't have a member profile for this user, skip.
+  if (empty($member_profile)) {
+    return [];
+  }
+
+  // If the member profile doesn't have job titles, skip.
+  if ($member_profile->get('field_vocab_user_type')->isEmpty()) {
+    return [];
+  }
+
+  /** @var \Drupal\taxonomy\Entity\Term $user_type */
+  $user_type = reset($member_profile->get('field_vocab_user_type')->referencedEntities());
+  return [
+    'label' => $user_type->getName(),
+    'icon' => [
+      'name' => 'star_circle',
+      'type' => 'custom',
+    ],
+  ];
 }

--- a/lib/themes/eic_community/sass/components/_link.scss
+++ b/lib/themes/eic_community/sass/components/_link.scss
@@ -46,6 +46,17 @@
     }
   }
 
+  body &--button-secondary {
+    @extend .ecl-button--secondary;
+
+    &:hover,
+    &:focus {
+      border: 2px solid $ecl-color-blue;
+      background-color: map-get($ecl-colors, 'blue');
+      color: map-get($ecl-colors, 'white');
+    }
+  }
+
   body &--button-call {
     @extend .ecl-button--call;
   }

--- a/lib/themes/eic_community/templates/flag/eic-flag-count.html.twig
+++ b/lib/themes/eic_community/templates/flag/eic-flag-count.html.twig
@@ -17,9 +17,9 @@
 
 {# Depending on the flag action, set the appropriate action class. #}
 {% if action == 'unflag' %}
-    {% set action_class = 'action-unflag' %}
+  {% set action_class = 'action-unflag' %}
 {% else %}
-    {% set action_class = 'action-flag' %}
+  {% set action_class = 'action-flag' %}
 {% endif %}
 
 {# Set the remaining Flag CSS classes. #}
@@ -39,19 +39,25 @@
 {% set attributes = attributes.setAttribute('rel', 'nofollow') %}
 
 {% if flag.id in ['follow_group' , 'follow_content'] %}
-    {% set icon_name = 'views' %}
+  {% set icon_name = 'views' %}
 {% elseif flag.id == 'recommend' %}
-    {% set icon_name = 'follow' %}
+  {% set icon_name = 'follow' %}
 {% elseif flag.id == 'bookmark_content' %}
-    {% set icon_name = 'tag' %}
+  {% set icon_name = 'tag' %}
 {% elseif flag.id == 'highlight_content' %}
-    {% set icon_name = 'highlight' %}
+  {% set icon_name = 'highlight' %}
 {% else %}
-    {% set icon_name = 'like' %}
+  {% set icon_name = 'like' %}
+{% endif %}
+
+{% if showAsButton %}
+  {% set default_classes = 'ecl-button ecl-button--secondary ecl-link--button ecl-link--button-secondary' %}
+{% else %}
+  {% set default_classes = 'ecl-link ecl-link--default ecl-link--icon ecl-link--icon-before ecl-link--standalone ecl-link--flag' %}
 {% endif %}
 
 <span class="{{classes|join(' ')}}">
-  <a {{ attributes|without('class') }} class="ecl-link ecl-link--default ecl-link--icon ecl-link--icon-before ecl-link--standalone ecl-link--flag {{ attributes.class }}">
+  <a {{ attributes|without('class') }} class="{{ default_classes }} {{ attributes.class }}">
     {% if eic_icon_path %}
       {% include "@ecl-twig/ec-component-icon/ecl-icon.html.twig" with {
         icon: {


### PR DESCRIPTION
### Features

- Show user type label in profile detail page.
- Adds user operation links dropdown when viewing profile detail page.

### Improvements

- Show contact link and follow flag if current user is not viewing its own profile page.
- Do not show LinkedIn profile link if empty.
- Allow trusted users to be able to edit their own member profile.

### Tests

As Trusted user:

- [x] Go to your profile detail page `/user`
- [x] Check if the user type label is shown before the First and Last name
- [x] Make sure that you have a dropdown menu containin the operation links: **Edit account information** and **Edit profile details**
- [x] Make sure the link to the contact form is not shown
- [x] Make sure the follow flag is not shown
- [x] Edit your profile and remove the LinkedIn social link.
- [x] Go back to the profile detail page and make sure there is no LinkedIn link shown in the sidebar information