### PR TITLE
EICNET-1839: Private images re-used in homepage banner are not shown for anonymous

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3144,6 +3144,9 @@
                     "services": {
                         "drush.services.yml": "^9"
                     }
+                },
+                "patches_applied": {
+                    "3168418 - Batch update error when there are no entities to load": "https://www.drupal.org/files/issues/2021-12-07/batch-update-error-3168418-16.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -6610,7 +6613,8 @@
                     }
                 },
                 "patches_applied": {
-                    "3130139 - Group Content Add/Create Paths do not work": "https://www.drupal.org/files/issues/2020-04-23/subpathauto-group-content-create-urls-3130139-2.patch"
+                    "3130139 - Group Content Add/Create Paths do not work": "https://www.drupal.org/files/issues/2020-04-23/subpathauto-group-content-create-urls-3130139-2.patch",
+                    "3188768 - Install from configuration fails due to missing dependencies": "./patches/subpathauto/3188768-subpathauto-add-dependencies.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -13,6 +13,9 @@
     "drupal/default_content": {
       "2698425 - Do not reimport existing entities": "https://www.drupal.org/files/issues/2021-01-20/default_content-integrity_constrait_violation-3162987-137-2.0.x.patch"
     },
+    "drupal/entity_usage": {
+      "3168418 - Batch update error when there are no entities to load": "https://www.drupal.org/files/issues/2021-12-07/batch-update-error-3168418-16.patch"
+    },
     "drupal/group": {
       "2881769 - group/{group}/node/create uses the permissions of group/{group}/node/add": "https://www.drupal.org/files/issues/2020-10-01/2881769-22.patch",
       "2746839 - Add Devel plugin for generating groups": "patches/group/2746839-add-devel-plugin-for-generating-groups-12.patch",

--- a/config/sync/entity_usage.settings.yml
+++ b/config/sync/entity_usage.settings.yml
@@ -6,6 +6,7 @@ _core:
 track_enabled_source_entity_types:
   - node
   - block_content
+  - group
   - paragraph
   - user
 track_enabled_target_entity_types:

--- a/config/sync/entity_usage.settings.yml
+++ b/config/sync/entity_usage.settings.yml
@@ -5,6 +5,7 @@ _core:
   default_config_hash: AXUBMTvVtpcNp0jKjDaWjSHqMy6HjuUf7j4yVbXgazI
 track_enabled_source_entity_types:
   - node
+  - block_content
   - paragraph
   - user
 track_enabled_target_entity_types:


### PR DESCRIPTION
### Improvements

- Add custom_block and group entities as entity usage source so that anonymous users can view private images that are attached to custom_blocks and groups.

### Fixes

- Create and apply contrib patch that fixes endless loop during batch operation to update all entity usages (see https://www.drupal.org/project/entity_usage/issues/3168418#comment-14331779).

### Tests

- [x] Go to `/admin/config/entity-usage/batch-update` and click on **Recreate all entity usage statistics**
- [x] Make sure the batch doesn't end up in an endless loop
- [x] Clear all cache
- [x] As anonymous user, navigate to the frontpage and make sure you can view the Banner image
- [x] As anonymous user, navigate to groups overview page `/groups` and make sure you can view the group banner images