### PR TITLE
EICNET-1838: Display breadcrumbs below global overview banner

### DIFF
--- a/config/sync/context.context.global.yml
+++ b/config/sync/context.context.global.yml
@@ -1,7 +1,16 @@
 uuid: 44d144c1-950b-4ce1-b861-08c50e272eea
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  config:
+    - system.menu.footer---european-commision
+    - system.menu.footer---european-union
+    - system.menu.main
+  content:
+    - 'block_content:basic:34a810c9-d608-4979-ac40-00657bce344b'
+  module:
+    - block_content
+    - system
 name: global
 label: Global
 group: Global
@@ -80,20 +89,6 @@ reactions:
         unique: 0
         context_id: global
         uuid: 116105ac-257d-4a9f-9495-133d1ad12d7c
-      292ff26d-ebfd-4a3b-9b7e-394be1e2a1f8:
-        id: system_breadcrumb_block
-        label: Breadcrumbs
-        provider: system
-        label_display: '0'
-        region: breadcrumbs
-        weight: '0'
-        context_mapping: {  }
-        custom_id: system_breadcrumb_block
-        theme: eic_community
-        css_class: ''
-        unique: 0
-        context_id: global
-        uuid: 292ff26d-ebfd-4a3b-9b7e-394be1e2a1f8
       7462f059-07c4-4599-b4c9-2b59abf042a2:
         id: system_messages_block
         label: Messages

--- a/config/sync/context.context.global_breadcrumbs.yml
+++ b/config/sync/context.context.global_breadcrumbs.yml
@@ -1,0 +1,42 @@
+uuid: 3299d281-9585-4160-b100-5d07a273c9f1
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+name: global_breadcrumbs
+label: 'Global - Breadcrumbs'
+group: Global
+description: ''
+requireAllConditions: false
+disabled: false
+conditions:
+  request_path_exclusion:
+    id: request_path_exclusion
+    negate: true
+    pages: "/articles\r\n/events\r\n/groups\r\n/people\r\n/search"
+    uuid: 67b08cb2-557c-41fa-b404-4bfcb6aed9df
+    context_mapping: {  }
+reactions:
+  blocks:
+    blocks:
+      d7192b0b-2613-4801-873f-00445b5a69b4:
+        id: system_breadcrumb_block
+        label: Breadcrumbs
+        provider: system
+        label_display: '0'
+        region: breadcrumbs
+        weight: '0'
+        context_mapping: {  }
+        custom_id: system_breadcrumb_block
+        theme: eic_community
+        css_class: ''
+        unique: 0
+        context_id: global_breadcrumbs
+        third_party_settings: {  }
+        uuid: d7192b0b-2613-4801-873f-00445b5a69b4
+    id: blocks
+    saved: false
+    uuid: 7a3c6805-2f56-4f46-bd7c-61b858c8e0b6
+    include_default_blocks: 0
+weight: 0

--- a/lib/themes/eic_community/includes/preprocess/common.inc
+++ b/lib/themes/eic_community/includes/preprocess/common.inc
@@ -321,3 +321,30 @@ function _eic_community_process_term_parents_tree(TermInterface $term, array $te
 
   return $terms;
 }
+
+/**
+ * Loads breadcrumb block to use it in twig templates.
+ *
+ * @return array
+ *   The renderable array of the block.
+ */
+function _eic_community_load_breadcrumb_block() {
+  $block_manager = \Drupal::service('plugin.manager.block');
+  // You can hard code configuration or you load from settings.
+  $config = [];
+  $plugin_block = $block_manager->createInstance('system_breadcrumb_block', $config);
+  // Some blocks might implement access check.
+  $access_result = $plugin_block->access(\Drupal::currentUser());
+  // Return empty render array if user doesn't have access.
+  // $access_result can be boolean or an AccessResult class.
+  if (is_object($access_result) && $access_result->isForbidden() || is_bool($access_result) && !$access_result) {
+    // You might need to add some cache tags/contexts.
+    return [];
+  }
+  $render = $plugin_block->build();
+  // In some cases, you need to add the cache tags/context depending on
+  // the block implemention. As it's possible to add the cache tags and
+  // contexts in the render method and in ::getCacheTags and
+  // ::getCacheContexts methods.
+  return $render;
+}

--- a/lib/themes/eic_community/includes/preprocess/overview_pages/overview-page.inc
+++ b/lib/themes/eic_community/includes/preprocess/overview_pages/overview-page.inc
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @file
+ * Prepares variables for overview_page templates.
+ */
+
+/**
+ * Implements hook_preprocess_overview_page().
+ */
+function eic_community_preprocess_overview_page(array &$variables) {
+  // Adds breadcrumbs block to the theme variables.
+  $variables['eic_community_breadcrumbs'] = _eic_community_load_breadcrumb_block();
+}

--- a/lib/themes/eic_community/templates/overview_pages/overview-page.html.twig
+++ b/lib/themes/eic_community/templates/overview_pages/overview-page.html.twig
@@ -1,0 +1,28 @@
+{#
+/**
+ * @file
+ * Default theme implementation to present an overview page entity.
+ *
+ * This template is used when viewing a registered overview page,
+ *
+ * Available variables:
+ * - content: A list of content items. Use 'content' to print all content, or
+ *   print a subset such as 'content.title'.
+ * - attributes: HTML attributes for the container element.
+ *
+ * @see template_preprocess_overview_page()
+ */
+#}
+{% block page_header %}
+  {% include "@theme/patterns/compositions/overview-header.html.twig" with {
+    title_element: 'h1',
+    title: content.title,
+    image: {
+      src: banner_image_url
+    },
+  } only %}
+
+  {{ eic_community_breadcrumbs }}
+{% endblock %}
+
+{{ content }}


### PR DESCRIPTION
### Improvements

- Create common function to load breadcrumb block;
- Place breadcrumb block bellow the global overview banner.

### Tests

- [x] Check all overview pages (`/articles`, `/events`, `/groups`, `/people`, `/search`) and make sure the breadcrumb is shown bellow the banner.