### PR TITLE
Feature/eicnet 1860 data export [Part 1]

### DIFF
--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -96,9 +96,16 @@ function eic_groups_views_data() {
   ];
   $data['groups_field_data']['group_visibility_custom_restricted_organisations'] = [
     'title' => t('Visibility Custom: Restricted organisations'),
-    'help' => t('The chosen email domains for group Custom - Restricted email organisations.'),
+    'help' => t('The chosen organisations for group Custom - Restricted email organisations.'),
     'field' => [
       'id' => 'group_visibility_custom_restricted_organisations',
+    ],
+  ];
+  $data['groups_field_data']['group_visibility_custom_restricted_organisation_types'] = [
+    'title' => t('Visibility Custom: Restricted organisations types'),
+    'help' => t('The chosen organisation types for group Custom - Restricted email organisations types.'),
+    'field' => [
+      'id' => 'group_visibility_custom_restricted_organisation_types',
     ],
   ];
 

--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -94,6 +94,13 @@ function eic_groups_views_data() {
       'id' => 'resend_invitation',
     ],
   ];
+  $data['groups_field_data']['group_visibility_custom_restricted_organisations'] = [
+    'title' => t('Visibility Custom: Restricted organisations'),
+    'help' => t('The chosen email domains for group Custom - Restricted email organisations.'),
+    'field' => [
+      'id' => 'group_visibility_custom_restricted_organisations',
+    ],
+  ];
 
   return $data;
 }

--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -108,6 +108,13 @@ function eic_groups_views_data() {
       'id' => 'group_visibility_custom_restricted_organisation_types',
     ],
   ];
+  $data['groups_field_data']['group_members_by_role'] = [
+    'title' => t('Group members'),
+    'help' => t('Displays the group members, optionally filtered by role.'),
+    'field' => [
+      'id' => 'group_members_by_role',
+    ],
+  ];
 
   return $data;
 }

--- a/lib/modules/eic_groups/src/EICGroupsHelper.php
+++ b/lib/modules/eic_groups/src/EICGroupsHelper.php
@@ -259,6 +259,41 @@ class EICGroupsHelper implements EICGroupsHelperInterface {
   }
 
   /**
+   * Provides the list of roles for the given group types.
+   *
+   * @param string[]|null $group_types
+   *   An array of group types to filter on. Default to all.
+   * @param bool $include_internal_roles
+   *   Whether to include group internal roles. Default to FALSE.
+   *
+   * @return array
+   *   An array keyed as follows:
+   *   - group_type: the group type machine name
+   *     - label: the group type's label.
+   *     - roles: array of roles.
+   *       - role_id: the role machine name.
+   *         => label of the role.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  public function getGroupRoles($group_types = NULL, $include_internal_roles = FALSE) {
+    $roles = [];
+
+    /** @var \Drupal\group\Entity\GroupTypeInterface[] $group_types */
+    $group_types = $this->entityTypeManager->getStorage('group_type')->loadMultiple($group_types);
+    foreach ($group_types as $group_type) {
+      $roles[$group_type->id()]['label'] = $group_type->label();
+      $group_roles = $group_type->getRoles($include_internal_roles);
+      foreach ($group_roles as $group_role) {
+        $roles[$group_type->id()]['roles'][$group_role->id()] = $group_role->label();
+      }
+    }
+
+    return $roles;
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function getGroupFromRoute() {

--- a/lib/modules/eic_groups/src/Plugin/views/field/GroupMembersByRole.php
+++ b/lib/modules/eic_groups/src/Plugin/views/field/GroupMembersByRole.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Drupal\eic_groups\Plugin\views\field;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\group\Entity\GroupInterface;
+use Drupal\views\Plugin\views\field\FieldPluginBase;
+use Drupal\views\ResultRow;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * A handler to provide a field to display group members by role.
+ *
+ * This plugin may not be suitable with large data if you need performance.
+ *
+ * @ingroup views_field_handlers
+ *
+ * @ViewsField("group_members_by_role")
+ */
+class GroupMembersByRole extends FieldPluginBase {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a PluginBase object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function defineOptions() {
+    $options = parent::defineOptions();
+    $options['roles'] = ['default' => []];
+    return $options;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildOptionsForm(&$form, FormStateInterface $form_state) {
+    $options = $this->getGroupRoleOptions();
+    $form['roles'] = [
+      '#title' => $this->t('Select the role(s) to filter on'),
+      '#description' => $this->t('If none selected, all roles will be returned.'),
+      '#type' => 'checkboxes',
+      '#options' => $options,
+      '#default_value' => $this->options['roles'],
+    ];
+
+    parent::buildOptionsForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    // Do nothing -- to override the parent query.
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render(ResultRow $values) {
+    /** @var \Drupal\group\Entity\GroupInterface $group */
+    $group = $values->_entity;
+    if (!$group instanceof GroupInterface) {
+      return '';
+    }
+
+    $usernames = [];
+    $memberships = $group->getMembers($this->getSelectedRoles());
+    foreach ($memberships as $membership) {
+      $usernames[] = $membership->getUser()->getDisplayName();
+    }
+
+    // @todo Create formatting options for the field.
+    return implode(', ', $usernames);
+  }
+
+  /**
+   * Returns the list of user defined roles for all group types.
+   *
+   * @return array
+   *   An array of role_id => label.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  protected function getGroupRoleOptions() {
+    $roles = [];
+    $group_types = $this->entityTypeManager->getStorage('group_type')->loadMultiple();
+    foreach ($group_types as $group_type) {
+      $group_roles = $group_type->getRoles(FALSE);
+      foreach ($group_roles as $group_role) {
+        $roles[$group_role->id()] = $group_type->label() . ' - ' . $group_role->label();
+      }
+    }
+
+    return $roles;
+  }
+
+  /**
+   * Returns the selected roles for this instance.
+   *
+   * @return array
+   *   An array of role machine names.
+   */
+  protected function getSelectedRoles() {
+    $selected_roles = [];
+    foreach ($this->options['roles'] as $role_id => $value) {
+      if ($role_id === $value) {
+        $selected_roles[] = $role_id;
+      }
+    }
+    return $selected_roles;
+  }
+
+}

--- a/lib/modules/eic_groups/src/Plugin/views/field/GroupMembersByRole.php
+++ b/lib/modules/eic_groups/src/Plugin/views/field/GroupMembersByRole.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\eic_groups\Plugin\views\field;
 
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\eic_groups\EICGroupsHelper;
 use Drupal\group\Entity\GroupInterface;
 use Drupal\views\Plugin\views\field\FieldPluginBase;
 use Drupal\views\ResultRow;
@@ -21,14 +21,14 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class GroupMembersByRole extends FieldPluginBase {
 
   /**
-   * The entity type manager.
+   * The EIC groups helper service.
    *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   * @var \Drupal\eic_groups\EICGroupsHelper
    */
-  protected $entityTypeManager;
+  protected $groupsHelper;
 
   /**
-   * Constructs a PluginBase object.
+   * Constructs a GroupMembersByRole object.
    *
    * @param array $configuration
    *   A configuration array containing information about the plugin instance.
@@ -36,12 +36,12 @@ class GroupMembersByRole extends FieldPluginBase {
    *   The plugin_id for the plugin instance.
    * @param mixed $plugin_definition
    *   The plugin implementation definition.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   * @param \Drupal\eic_groups\EICGroupsHelper $eic_groups_helper
    *   The entity type manager.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EICGroupsHelper $eic_groups_helper) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->entityTypeManager = $entity_type_manager;
+    $this->groupsHelper = $eic_groups_helper;
   }
 
   /**
@@ -52,7 +52,7 @@ class GroupMembersByRole extends FieldPluginBase {
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('entity_type.manager')
+      $container->get('eic_groups.helper')
     );
   }
 
@@ -118,12 +118,12 @@ class GroupMembersByRole extends FieldPluginBase {
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
   protected function getGroupRoleOptions() {
+    // @todo Cache the results to avoid running this code on each row.
     $roles = [];
-    $group_types = $this->entityTypeManager->getStorage('group_type')->loadMultiple();
-    foreach ($group_types as $group_type) {
-      $group_roles = $group_type->getRoles(FALSE);
-      foreach ($group_roles as $group_role) {
-        $roles[$group_role->id()] = $group_type->label() . ' - ' . $group_role->label();
+
+    foreach ($this->groupsHelper->getGroupRoles() as $info) {
+      foreach ($info['roles'] as $role_id => $role_label) {
+        $roles[$role_id] = $info['label'] . ' - ' . $role_label;
       }
     }
 

--- a/lib/modules/eic_groups/src/Plugin/views/field/RestrictedOrganisationTypes.php
+++ b/lib/modules/eic_groups/src/Plugin/views/field/RestrictedOrganisationTypes.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Drupal\eic_groups\Plugin\views\field;
+
+use Drupal\group\Entity\GroupInterface;
+use Drupal\oec_group_flex\Plugin\views\field\GroupFlexFieldPluginBase;
+use Drupal\taxonomy\Entity\Term;
+use Drupal\views\ResultRow;
+
+/**
+ * A handler to provide a field for custom restricted organisation types.
+ *
+ * @ingroup views_field_handlers
+ *
+ * @ViewsField("group_visibility_custom_restricted_organisation_types")
+ */
+class RestrictedOrganisationTypes extends GroupFlexFieldPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    // Do nothing -- to override the parent query.
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render(ResultRow $values) {
+    $group = $values->_entity;
+    if (!$group instanceof GroupInterface) {
+      return '';
+    }
+    $visibility_settings = $this->oecGroupFlexHelper->getGroupVisibilitySettings($group);
+    if ($visibility_settings['plugin_id'] != 'custom_restricted') {
+      return '';
+    }
+
+    $visibility_record_settings = $this->oecGroupFlexHelper->getGroupVisibilityRecordSettings($visibility_settings['settings']);
+    if (empty($visibility_record_settings['restricted_organisation_types'])) {
+      return '';
+    }
+
+    if (empty($visibility_record_settings['restricted_organisation_types']['options'])) {
+      return '';
+    }
+
+    // @todo Create formatting options for the field.
+    $terms = [];
+    foreach ($visibility_record_settings['restricted_organisation_types']['options'] as $term_id => $status) {
+      if ($status) {
+        $terms[] = Term::load($term_id)->label();
+      }
+    }
+    return implode(', ', $terms);
+  }
+
+}

--- a/lib/modules/eic_groups/src/Plugin/views/field/RestrictedOrganisations.php
+++ b/lib/modules/eic_groups/src/Plugin/views/field/RestrictedOrganisations.php
@@ -1,19 +1,20 @@
 <?php
 
-namespace Drupal\oec_group_flex\Plugin\views\field;
+namespace Drupal\eic_groups\Plugin\views\field;
 
 use Drupal\group\Entity\GroupInterface;
-use Drupal\user\Entity\User;
+use Drupal\group\Entity\Group;
+use Drupal\oec_group_flex\Plugin\views\field\GroupFlexFieldPluginBase;
 use Drupal\views\ResultRow;
 
 /**
- * A handler to provide a field for custom restricted users.
+ * A handler to provide a field for custom restricted organisations.
  *
  * @ingroup views_field_handlers
  *
- * @ViewsField("group_visibility_custom_restricted_users")
+ * @ViewsField("group_visibility_custom_restricted_organisations")
  */
-class RestrictedUsers extends GroupFlexFieldPluginBase {
+class RestrictedOrganisations extends GroupFlexFieldPluginBase {
 
   /**
    * {@inheritdoc}
@@ -37,20 +38,21 @@ class RestrictedUsers extends GroupFlexFieldPluginBase {
     }
 
     $visibility_record_settings = $this->oecGroupFlexHelper->getGroupVisibilityRecordSettings($visibility_settings['settings']);
-    if (empty($visibility_record_settings['restricted_users'])) {
+    if (empty($visibility_record_settings['restricted_organisations'])) {
       return '';
     }
 
-    if (empty($visibility_record_settings['restricted_users']['options'])) {
+    if (empty($visibility_record_settings['restricted_organisations']['options'])) {
       return '';
     }
 
     // @todo Create formatting options for the field.
-    $users = [];
-    foreach (array_column($visibility_record_settings['restricted_users']['options'], 'target_id') as $user_id) {
-      $users[] = User::load($user_id)->label();
+    $groups = [];
+    foreach (array_column($visibility_record_settings['restricted_organisations']['options'], 'target_id') as $group_id) {
+      $groups[] = Group::load($group_id)->label();
     }
-    return implode(', ', $users);
+    return implode(', ', $groups);
+
   }
 
 }

--- a/lib/modules/oec_group_flex/oec_group_flex.module
+++ b/lib/modules/oec_group_flex/oec_group_flex.module
@@ -155,7 +155,7 @@ function oec_group_flex_views_data() {
   ];
   $data['groups_field_data']['group_visibility_custom_restricted_users'] = [
     'title' => t('Visibility Custom: Restricted users'),
-    'help' => t('The chosen email domains for group Custom - Restricted users visibility.'),
+    'help' => t('The chosen users for group Custom - Restricted users visibility.'),
     'field' => [
       'id' => 'group_visibility_custom_restricted_users',
     ],

--- a/lib/modules/oec_group_flex/oec_group_flex.module
+++ b/lib/modules/oec_group_flex/oec_group_flex.module
@@ -153,5 +153,12 @@ function oec_group_flex_views_data() {
       'id' => 'group_visibility_custom_restricted_email_domains',
     ],
   ];
+  $data['groups_field_data']['group_visibility_custom_restricted_users'] = [
+    'title' => t('Visibility Custom: Restricted users'),
+    'help' => t('The chosen email domains for group Custom - Restricted users visibility.'),
+    'field' => [
+      'id' => 'group_visibility_custom_restricted_users',
+    ],
+  ];
   return $data;
 }

--- a/lib/modules/oec_group_flex/oec_group_flex.module
+++ b/lib/modules/oec_group_flex/oec_group_flex.module
@@ -132,3 +132,18 @@ function oec_group_flex_group_flex_group_visibility_info_alter(array &$definitio
     $definitions['private']['class'] = '\Drupal\oec_group_flex\Plugin\GroupVisibility\PrivateVisibility';
   }
 }
+
+/**
+ * Implements hook_views_data().
+ */
+function oec_group_flex_views_data() {
+  $data['groups_field_data']['table']['group'] = t('Group');
+  $data['groups_field_data']['group_visibility'] = [
+    'title' => t('Visibility'),
+    'help' => t('The visibility of the group.'),
+    'field' => [
+      'id' => 'group_visibility',
+    ],
+  ];
+  return $data;
+}

--- a/lib/modules/oec_group_flex/oec_group_flex.module
+++ b/lib/modules/oec_group_flex/oec_group_flex.module
@@ -137,12 +137,20 @@ function oec_group_flex_group_flex_group_visibility_info_alter(array &$definitio
  * Implements hook_views_data().
  */
 function oec_group_flex_views_data() {
+  // @todo Check if possible to group all those fields into a specific section.
   $data['groups_field_data']['table']['group'] = t('Group');
   $data['groups_field_data']['group_visibility'] = [
     'title' => t('Visibility'),
     'help' => t('The visibility of the group.'),
     'field' => [
       'id' => 'group_visibility',
+    ],
+  ];
+  $data['groups_field_data']['group_visibility_custom_restricted_email_domains'] = [
+    'title' => t('Visibility Custom: Restricted email domains'),
+    'help' => t('The chosen email domains for group Custom - Restricted email domains visibility.'),
+    'field' => [
+      'id' => 'group_visibility_custom_restricted_email_domains',
     ],
   ];
   return $data;

--- a/lib/modules/oec_group_flex/src/Plugin/views/field/GroupFlexFieldPluginBase.php
+++ b/lib/modules/oec_group_flex/src/Plugin/views/field/GroupFlexFieldPluginBase.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Drupal\oec_group_flex\Plugin\views\field;
+
+use Drupal\oec_group_flex\OECGroupFlexHelper;
+use Drupal\views\Plugin\views\field\FieldPluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Base class for views group flex fields.
+ *
+ * @ingroup views_field_handlers
+ */
+abstract class GroupFlexFieldPluginBase extends FieldPluginBase {
+
+  /**
+   * The OEC Group Flex service.
+   *
+   * @var \Drupal\oec_group_flex\OECGroupFlexHelper
+   */
+  protected $oecGroupFlexHelper;
+
+  /**
+   * Constructs a PluginBase object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\oec_group_flex\OECGroupFlexHelper $oec_group_flex_helper
+   *   The OEC Group Flex service.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, OECGroupFlexHelper $oec_group_flex_helper) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->oecGroupFlexHelper = $oec_group_flex_helper;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('oec_group_flex.helper')
+    );
+  }
+
+}

--- a/lib/modules/oec_group_flex/src/Plugin/views/field/GroupVisibility.php
+++ b/lib/modules/oec_group_flex/src/Plugin/views/field/GroupVisibility.php
@@ -4,10 +4,7 @@ namespace Drupal\oec_group_flex\Plugin\views\field;
 
 use Drupal\Core\TypedData\Exception\MissingDataException;
 use Drupal\group\Entity\GroupInterface;
-use Drupal\oec_group_flex\OECGroupFlexHelper;
-use Drupal\views\Plugin\views\field\FieldPluginBase;
 use Drupal\views\ResultRow;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * A handler to provide a field for group visibility.
@@ -16,43 +13,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @ViewsField("group_visibility")
  */
-class GroupVisibility extends FieldPluginBase {
-
-  /**
-   * The OEC Group Flex service.
-   *
-   * @var \Drupal\oec_group_flex\OECGroupFlexHelper
-   */
-  protected $oecGroupFlexHelper;
-
-  /**
-   * Constructs a PluginBase object.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin_id for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\oec_group_flex\OECGroupFlexHelper $oec_group_flex_helper
-   *   The OEC Group Flex service.
-   */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, OECGroupFlexHelper $oec_group_flex_helper) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->oecGroupFlexHelper = $oec_group_flex_helper;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get('oec_group_flex.helper')
-    );
-  }
+class GroupVisibility extends GroupFlexFieldPluginBase {
 
   /**
    * {@inheritdoc}

--- a/lib/modules/oec_group_flex/src/Plugin/views/field/GroupVisibility.php
+++ b/lib/modules/oec_group_flex/src/Plugin/views/field/GroupVisibility.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Drupal\oec_group_flex\Plugin\views\field;
+
+use Drupal\Core\TypedData\Exception\MissingDataException;
+use Drupal\group\Entity\GroupInterface;
+use Drupal\oec_group_flex\OECGroupFlexHelper;
+use Drupal\views\Plugin\views\field\FieldPluginBase;
+use Drupal\views\ResultRow;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * A handler to provide a field for group visibility.
+ *
+ * @ingroup views_field_handlers
+ *
+ * @ViewsField("group_visibility")
+ */
+class GroupVisibility extends FieldPluginBase {
+
+  /**
+   * The OEC Group Flex service.
+   *
+   * @var \Drupal\oec_group_flex\OECGroupFlexHelper
+   */
+  protected $oecGroupFlexHelper;
+
+  /**
+   * Constructs a PluginBase object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\oec_group_flex\OECGroupFlexHelper $oec_group_flex_helper
+   *   The OEC Group Flex service.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, OECGroupFlexHelper $oec_group_flex_helper) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->oecGroupFlexHelper = $oec_group_flex_helper;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('oec_group_flex.helper')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    // Do nothing -- to override the parent query.
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render(ResultRow $values) {
+    $group = $values->_entity;
+    if (!$group instanceof GroupInterface) {
+      return '';
+    }
+
+    try {
+      return $this->oecGroupFlexHelper->getGroupVisibilityTagLabel($group);
+    }
+    catch (MissingDataException $e) {
+      return '';
+    }
+  }
+
+}

--- a/lib/modules/oec_group_flex/src/Plugin/views/field/RestrictedEmailDomains.php
+++ b/lib/modules/oec_group_flex/src/Plugin/views/field/RestrictedEmailDomains.php
@@ -3,10 +3,7 @@
 namespace Drupal\oec_group_flex\Plugin\views\field;
 
 use Drupal\group\Entity\GroupInterface;
-use Drupal\oec_group_flex\OECGroupFlexHelper;
-use Drupal\views\Plugin\views\field\FieldPluginBase;
 use Drupal\views\ResultRow;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * A handler to provide a field for custom restricted email domains.
@@ -15,43 +12,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @ViewsField("group_visibility_custom_restricted_email_domains")
  */
-class RestrictedEmailDomains extends FieldPluginBase {
-
-  /**
-   * The OEC Group Flex service.
-   *
-   * @var \Drupal\oec_group_flex\OECGroupFlexHelper
-   */
-  protected $oecGroupFlexHelper;
-
-  /**
-   * Constructs a PluginBase object.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin_id for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\oec_group_flex\OECGroupFlexHelper $oec_group_flex_helper
-   *   The OEC Group Flex service.
-   */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, OECGroupFlexHelper $oec_group_flex_helper) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->oecGroupFlexHelper = $oec_group_flex_helper;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get('oec_group_flex.helper')
-    );
-  }
+class RestrictedEmailDomains extends GroupFlexFieldPluginBase {
 
   /**
    * {@inheritdoc}

--- a/lib/modules/oec_group_flex/src/Plugin/views/field/RestrictedEmailDomains.php
+++ b/lib/modules/oec_group_flex/src/Plugin/views/field/RestrictedEmailDomains.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Drupal\oec_group_flex\Plugin\views\field;
+
+use Drupal\group\Entity\GroupInterface;
+use Drupal\oec_group_flex\OECGroupFlexHelper;
+use Drupal\views\Plugin\views\field\FieldPluginBase;
+use Drupal\views\ResultRow;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * A handler to provide a field for custom restricted email domains.
+ *
+ * @ingroup views_field_handlers
+ *
+ * @ViewsField("group_visibility_custom_restricted_email_domains")
+ */
+class RestrictedEmailDomains extends FieldPluginBase {
+
+  /**
+   * The OEC Group Flex service.
+   *
+   * @var \Drupal\oec_group_flex\OECGroupFlexHelper
+   */
+  protected $oecGroupFlexHelper;
+
+  /**
+   * Constructs a PluginBase object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\oec_group_flex\OECGroupFlexHelper $oec_group_flex_helper
+   *   The OEC Group Flex service.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, OECGroupFlexHelper $oec_group_flex_helper) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->oecGroupFlexHelper = $oec_group_flex_helper;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('oec_group_flex.helper')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    // Do nothing -- to override the parent query.
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render(ResultRow $values) {
+    $group = $values->_entity;
+    if (!$group instanceof GroupInterface) {
+      return '';
+    }
+
+    $visibility_settings = $this->oecGroupFlexHelper->getGroupVisibilitySettings($group);
+    if ($visibility_settings['plugin_id'] != 'custom_restricted') {
+      return '';
+    }
+
+    $visibility_record_settings = $this->oecGroupFlexHelper->getGroupVisibilityRecordSettings($visibility_settings['settings']);
+    if (empty($visibility_record_settings['restricted_email_domains'])) {
+      return '';
+    }
+
+    if (empty($visibility_record_settings['restricted_email_domains']['options'])) {
+      return '';
+    }
+
+    return $visibility_record_settings['restricted_email_domains']['options'];
+  }
+
+}

--- a/lib/modules/oec_group_flex/src/Plugin/views/field/RestrictedUsers.php
+++ b/lib/modules/oec_group_flex/src/Plugin/views/field/RestrictedUsers.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Drupal\oec_group_flex\Plugin\views\field;
+
+use Drupal\group\Entity\GroupInterface;
+use Drupal\oec_group_flex\OECGroupFlexHelper;
+use Drupal\views\Plugin\views\field\FieldPluginBase;
+use Drupal\views\ResultRow;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * A handler to provide a field for custom restricted users.
+ *
+ * @ingroup views_field_handlers
+ *
+ * @ViewsField("group_visibility_custom_restricted_users")
+ */
+class RestrictedUsers extends FieldPluginBase {
+
+  /**
+   * The OEC Group Flex service.
+   *
+   * @var \Drupal\oec_group_flex\OECGroupFlexHelper
+   */
+  protected $oecGroupFlexHelper;
+
+  /**
+   * Constructs a PluginBase object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\oec_group_flex\OECGroupFlexHelper $oec_group_flex_helper
+   *   The OEC Group Flex service.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, OECGroupFlexHelper $oec_group_flex_helper) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->oecGroupFlexHelper = $oec_group_flex_helper;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('oec_group_flex.helper')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    // Do nothing -- to override the parent query.
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render(ResultRow $values) {
+    $group = $values->_entity;
+    if (!$group instanceof GroupInterface) {
+      return '';
+    }
+
+    $visibility_settings = $this->oecGroupFlexHelper->getGroupVisibilitySettings($group);
+    if ($visibility_settings['plugin_id'] != 'custom_restricted') {
+      return '';
+    }
+
+    $visibility_record_settings = $this->oecGroupFlexHelper->getGroupVisibilityRecordSettings($visibility_settings['settings']);
+    if (empty($visibility_record_settings['restricted_users'])) {
+      return '';
+    }
+
+    if (empty($visibility_record_settings['restricted_users']['options'])) {
+      return '';
+    }
+
+    // @todo Create formatting options for the field.
+    return implode(',', array_column($visibility_record_settings['restricted_users']['options'], 'target_id'));
+  }
+
+}

--- a/lib/modules/oec_group_flex/src/Plugin/views/field/RestrictedUsers.php
+++ b/lib/modules/oec_group_flex/src/Plugin/views/field/RestrictedUsers.php
@@ -3,10 +3,7 @@
 namespace Drupal\oec_group_flex\Plugin\views\field;
 
 use Drupal\group\Entity\GroupInterface;
-use Drupal\oec_group_flex\OECGroupFlexHelper;
-use Drupal\views\Plugin\views\field\FieldPluginBase;
 use Drupal\views\ResultRow;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * A handler to provide a field for custom restricted users.
@@ -15,43 +12,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @ViewsField("group_visibility_custom_restricted_users")
  */
-class RestrictedUsers extends FieldPluginBase {
-
-  /**
-   * The OEC Group Flex service.
-   *
-   * @var \Drupal\oec_group_flex\OECGroupFlexHelper
-   */
-  protected $oecGroupFlexHelper;
-
-  /**
-   * Constructs a PluginBase object.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin_id for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\oec_group_flex\OECGroupFlexHelper $oec_group_flex_helper
-   *   The OEC Group Flex service.
-   */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, OECGroupFlexHelper $oec_group_flex_helper) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->oecGroupFlexHelper = $oec_group_flex_helper;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get('oec_group_flex.helper')
-    );
-  }
+class RestrictedUsers extends GroupFlexFieldPluginBase {
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
### Improvements

This PR provides following views field plugins to the `oec_group_flex` module:

- Visibility
- Visibility Custom: Restricted email domains
- Visibility Custom: Restricted users

Also following views field plugins to the `eic_groups` module:

- Visibility Custom: Restricted organisations
- Visibility Custom: Restricted organisation types
- Group members

### Tests

- [x] Create a group based view
- [x] Make sure you have one group based on restricted domains, one with restricted users, one with restricted organisations and one with restricted organisation types
- [x] Add all the mentioned fields
- [x] Check that the view outputs correct values for all the fields

### Remarks

This PR doesn't provide in any way a data export, this is just a first chunk.