### PR TITLE
[EICNET-1851]  group library overview teaser rework

### DIFF
--- a/lib/themes/eic_community/images/sprite/custom/document.svg
+++ b/lib/themes/eic_community/images/sprite/custom/document.svg
@@ -3,10 +3,9 @@
   <path
      d="M 6,1 C 4.9072693,1 4,1.9072816 4,3 l 0,18 c 0,1.092731 0.9072936,2 2,2 l 12,0 c 1.092707,0 2,-0.907293 2,-2 L 20,7 14,1 6,1 Z M 6,3 13.171875,3 18,7.828125 18,21 6,21 6,3 Z"
      id="path4160"
-     fill="#0B4691" />
+     fill="currentColor" />
   <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#707070;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      d="m 13,2 0,7 6,0 0,-2 -4,0 0,-5 -2,0 z"
      id="path4162"
-     fill="#0B4691" />
+     fill="currentColor" />
 </svg>

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Library/DocumentLibraryResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Library/DocumentLibraryResultItem.js
@@ -60,7 +60,7 @@ class DocumentLibraryResultItem extends React.Component {
           <div className="ecl-teaser__content">
             <h2 className="ecl-teaser__title">
               <a href={this.props.result.ss_url}>
-                <span className="ecl-teaser__title-overflow"><span>{this.props.result.tm_global_title}</span></span>
+                <span className="ecl-teaser__title-overflow"><span>{this.props.result.tm_global_title} {filenames.length > 1 && `(${filenames.length} files in total)`}</span></span>
               </a>
             </h2>
             <div className="ecl-teaser__tags">

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Library/DocumentLibraryResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Library/DocumentLibraryResultItem.js
@@ -43,12 +43,13 @@ class DocumentLibraryResultItem extends React.Component {
     }
     return (<div
         className={`ecl-teaser ecl-teaser--filelist ecl-teaser--is-highlightable ${isHighlighted && 'ecl-teaser--is-highlighted'} ecl-teaser-overview__item--library`}>
-        <a className={'ecl-teaser--filelist__thumbnail-link'} href={this.props.result.ss_url}>
-          <figure
-            className="ecl-teaser__image-wrapper"
+        <figure
+          className="ecl-teaser__image-wrapper">
+          <a
+            href={this.props.result.ss_url}
             dangerouslySetInnerHTML={{__html: svg(type[filetype] || type['default'], ' ecl-icon--l ecl-teaser__image-icon')}}
           />
-        </a>
+        </figure>
         <div className="ecl-teaser__main-wrapper">
           <div className="ecl-teaser__meta-header">
             <div className="ecl-teaser__meta-column">

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Library/DocumentLibraryResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Library/DocumentLibraryResultItem.js
@@ -42,7 +42,7 @@ class DocumentLibraryResultItem extends React.Component {
       'zip': 'document_zip',
     }
     return (<div
-        className={`ecl-teaser ecl-teaser--filelist ecl-teaser--is-highlightable ${isHighlighted && 'ecl-teaser--is-highlighted'}`}>
+        className={`ecl-teaser ecl-teaser--filelist ecl-teaser--is-highlightable ${isHighlighted && 'ecl-teaser--is-highlighted'} ecl-teaser-overview__item--library`}>
         <a className={'ecl-teaser--filelist__thumbnail-link'} href={this.props.result.ss_url}>
           <figure
             className="ecl-teaser__image-wrapper"

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Library/DocumentLibraryResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Library/DocumentLibraryResultItem.js
@@ -61,7 +61,7 @@ class DocumentLibraryResultItem extends React.Component {
           <div className="ecl-teaser__content">
             <h2 className="ecl-teaser__title">
               <a href={this.props.result.ss_url}>
-                <span className="ecl-teaser__title-overflow"><span>{this.props.result.tm_global_title} {filenames.length > 1 && `(${filenames.length} files in total)`}</span></span>
+                <span className="ecl-teaser__title-overflow"><span>{this.props.result.tm_global_title}{filenames.length > 1 && ` (${Drupal.t('@count files in total', {'@count': filenames.length}, {context: 'eic_group'})})`}</span></span>
               </a>
             </h2>
             <div className="ecl-teaser__tags">

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Library/DocumentLibraryResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Library/DocumentLibraryResultItem.js
@@ -3,6 +3,7 @@ import HighlightLink from "./Partials/HighlightLink";
 import {timeDifferenceFromNow} from "../../../../../../Services/TimeHelper";
 import LikeLink from "./Partials/LikeLink";
 import StatisticsFooterResult from "../Partials/StatisticsFooterResult";
+import Meta from "./Partials/Meta";
 
 const svg = require('../../../../../../svg/svg')
 
@@ -28,13 +29,25 @@ class DocumentLibraryResultItem extends React.Component {
     isHighlighted = typeof isHighlighted !== 'undefined' && isHighlighted !== false;
     const topics = this.props.result.sm_content_field_vocab_topics_string;
     const filenames = this.props.result.sm_filename;
-
+    const filetype = filenames.length > 1 ? 'multiple' : filenames[0].split('.')[1]
+    const type = {
+      'default': 'document',
+      'doc': 'document_doc',
+      'dwg': 'document_dwg',
+      'html': 'document_html',
+      'multiple': 'documents',
+      'ppt': 'document_ppt',
+      'txt': 'document_txt',
+      'xls': 'document_xls',
+      'zip': 'document_zip',
+    }
     return (<div
         className={`ecl-teaser ecl-teaser--filelist ecl-teaser--is-highlightable ${isHighlighted && 'ecl-teaser--is-highlighted'}`}>
-        <a href={this.props.result.ss_url}>
-          <figure className="ecl-teaser__image-wrapper">
-            <img className="ecl-teaser__image" src={this.props.result.ss_content_image_url} alt=""/>
-          </figure>
+        <a className={'ecl-teaser--filelist__thumbnail-link'} href={this.props.result.ss_url}>
+          <figure
+            className="ecl-teaser__image-wrapper"
+            dangerouslySetInnerHTML={{__html: svg(type[filetype] || type['default'], ' ecl-icon--l ecl-teaser__image-icon')}}
+          />
         </a>
         <div className="ecl-teaser__main-wrapper">
           <div className="ecl-teaser__meta-header">
@@ -60,31 +73,7 @@ class DocumentLibraryResultItem extends React.Component {
             <div className="ecl-teaser__files">
               {filenames && filenames.length > 0 && filenames.join(', ')}
             </div>
-            <div className="ecl-teaser__meta-content">
-              <div className="ecl-teaser__meta-content-item">
-                <div className="ecl-timestamp ">
-                  <span
-                    dangerouslySetInnerHTML={{__html: svg('time', 'ecl-icon ecl-icon--s ecl-timestamp__icon')}}
-                  />
-                  <time
-                    className="ecl-timestamp__label">{timeDifferenceFromNow(this.props.result.ss_drupal_timestamp)}</time>
-                </div>
-              </div>
-              <div className="ecl-teaser__meta-content-item">
-                <svg className="ecl-icon ecl-icon--s" focusable="false" aria-hidden="true">
-                </svg>
-                English
-              </div>
-              <div className="ecl-teaser__meta-content-item">
-                <svg className="ecl-icon ecl-icon--s" focusable="false" aria-hidden="true">
-                </svg>
-                {!this.props.isAnonymous ? (
-                  <a href={this.props.result.ss_global_user_url}>{this.props.translations.uploaded_by} {this.props.result.ss_global_fullname}</a>
-                ) : (
-                  <span>{this.props.translations.uploaded_by} {this.props.result.ss_global_fullname}</span>
-                )}
-              </div>
-            </div>
+            <Meta result={this.props.result} isAnonymous={this.props.isAnonymous} translations={this.props.translations}  />
             <HighlightLink
               updateHighlight={this.updateHighlight}
               isHighlighted={isHighlighted}

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Library/GalleryLibraryResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Library/GalleryLibraryResultItem.js
@@ -3,6 +3,7 @@ import HighlightLink from "./Partials/HighlightLink";
 import {timeDifferenceFromNow} from "../../../../../../Services/TimeHelper";
 import LikeLink from "./Partials/LikeLink";
 import StatisticsFooterResult from "../Partials/StatisticsFooterResult";
+import Meta from "./Partials/Meta";
 
 const svg = require('../../../../../../svg/svg')
 
@@ -78,26 +79,7 @@ class GalleryLibraryResultItem extends React.Component {
                 </div>)
               })}
             </div>
-            <div className="ecl-teaser__meta-content">
-              <div className="ecl-teaser__meta-content-item">
-                <div className="ecl-timestamp ">
-                  <span
-                    dangerouslySetInnerHTML={{__html: svg('time', 'ecl-icon ecl-icon--s ecl-timestamp__icon')}}
-                  />
-                  <time className="ecl-timestamp__label">{timeDifferenceFromNow(this.props.result.ss_drupal_timestamp)}</time>
-                </div>
-              </div>
-              <div className="ecl-teaser__meta-content-item">
-                <svg className="ecl-icon ecl-icon--s" focusable="false" aria-hidden="true">
-                </svg>
-                English
-              </div>
-              <div className="ecl-teaser__meta-content-item">
-                <svg className="ecl-icon ecl-icon--s" focusable="false" aria-hidden="true">
-                </svg>
-                <a href={this.props.result.ss_global_user_url}>{this.props.translations.uploaded_by} {this.props.result.ss_global_fullname}</a>
-              </div>
-            </div>
+            <Meta result={this.props.result} isAnonymous={this.props.isAnonymous} translations={this.props.translations}  />
             <HighlightLink
               updateHighlight={this.updateHighlight}
               isHighlighted={isHighlighted}

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Library/GalleryLibraryResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Library/GalleryLibraryResultItem.js
@@ -35,7 +35,7 @@ class GalleryLibraryResultItem extends React.Component {
 
     const firstSlides = typeof this.state.slides !== "undefined" ? this.state.slides.slice(0, 3) : [];
 
-    return (<div className="ecl-teaser-overview__item ">
+    return (<div className="ecl-teaser-overview__item ecl-teaser-overview__item--library">
 
       <div  className={`ecl-teaser ecl-teaser--gallery ecl-teaser--is-highlightable ${isHighlighted && 'ecl-teaser--is-highlighted'}`}>
         <a href={this.props.result.ss_url}>

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Library/Partials/LikeLink.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Library/Partials/LikeLink.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import svg from "../../../../../../../svg/svg";
 
 class LikeLink extends React.Component {
   constructor(props) {
@@ -12,14 +13,17 @@ class LikeLink extends React.Component {
 
   //@todo wait for like endpoint
   render() {
-    return '';
-    // return (<div className="ecl-teaser__like">
-    //   <a href="#">
-    //     <svg className="ecl-icon ecl-icon--xs ecl-teaser__like-icon" focusable="false" aria-hidden="true">
-    //     </svg>
-    //     {this.props.translations.like}
-    //   </a>
-    // </div>);
+    return (
+      <div className="ecl-teaser__like">
+        <a href="#">
+          <span
+            dangerouslySetInnerHTML={{__html: svg('like', 'ecl-icon ecl-icon--xs')}}
+          />
+          &nbsp;
+          {this.props.translations.like}
+        </a>
+      </div>
+    );
   }
 }
 

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Library/Partials/Meta.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Library/Partials/Meta.js
@@ -1,0 +1,37 @@
+import svg from "../../../../../../../svg/svg";
+import {timeDifferenceFromNow} from "../../../../../../../Services/TimeHelper";
+import React from "react";
+
+
+const Meta = (props) => {
+  return (
+    <div className="ecl-teaser__meta-content">
+      <div className="ecl-teaser__meta-content-item">
+        <div className="ecl-timestamp ">
+          <span
+            dangerouslySetInnerHTML={{__html: svg('time', 'ecl-icon ecl-icon--s ecl-timestamp__icon')}}
+          />
+          <time className="ecl-timestamp__label">{timeDifferenceFromNow(props.result.ss_drupal_timestamp)}</time>
+        </div>
+      </div>
+      <div className="ecl-teaser__meta-content-item">
+        <span
+          dangerouslySetInnerHTML={{__html: svg('document', 'ecl-icon ecl-icon--s ecl-timestamp__icon')}}
+        />
+        {props.result.ss_content_language_string}
+      </div>
+      <div className="ecl-teaser__meta-content-item">
+                <span
+                  dangerouslySetInnerHTML={{__html: svg('remote', 'ecl-icon ecl-icon--s ecl-timestamp__icon')}}
+                />
+        {!props.isAnonymous ? (
+          <a href={props.result.ss_global_user_url}>{props.translations.uploaded_by} {props.result.ss_global_fullname}</a>
+        ) : (
+          <span>{props.translations.uploaded_by} {props.result.ss_global_fullname}</span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default Meta

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Library/VideoLibraryResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Library/VideoLibraryResultItem.js
@@ -30,7 +30,7 @@ class VideoLibraryResultItem extends React.Component {
     const topics = this.props.result.sm_content_field_vocab_topics_string;
     const thumbnails =  `<img class="ecl-teaser__image" src="${this.props.result.ss_content_image_url}" alt=""/>  ${svg('play', ' ecl-icon--xl ecl-teaser__image-play-icon')}`
 
-    return (<div className="ecl-teaser-overview__item ">
+    return (<div className="ecl-teaser-overview__item ecl-teaser-overview__item--library ">
 
       <div
         className={`ecl-teaser ecl-teaser--video ecl-teaser--is-highlightable ${isHighlighted && 'ecl-teaser--is-highlighted'}`}>

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Library/VideoLibraryResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Library/VideoLibraryResultItem.js
@@ -3,6 +3,7 @@ import HighlightLink from "./Partials/HighlightLink";
 import {timeDifferenceFromNow} from "../../../../../../Services/TimeHelper";
 import LikeLink from "./Partials/LikeLink";
 import StatisticsFooterResult from "../Partials/StatisticsFooterResult";
+import Meta from "./Partials/Meta";
 
 const svg = require('../../../../../../svg/svg')
 
@@ -27,17 +28,16 @@ class VideoLibraryResultItem extends React.Component {
     let isHighlighted = this.state.isHighlighted;
     isHighlighted = typeof isHighlighted !== 'undefined' && isHighlighted !== false;
     const topics = this.props.result.sm_content_field_vocab_topics_string;
+    const thumbnails =  `<img class="ecl-teaser__image" src="${this.props.result.ss_content_image_url}" alt=""/>  ${svg('play', ' ecl-icon--xl ecl-teaser__image-play-icon')}`
 
     return (<div className="ecl-teaser-overview__item ">
 
       <div
         className={`ecl-teaser ecl-teaser--video ecl-teaser--is-highlightable ${isHighlighted && 'ecl-teaser--is-highlighted'}`}>
         <a href={this.props.result.ss_url}>
-          <figure className="ecl-teaser__image-wrapper">
-            <img className="ecl-teaser__image" src={this.props.result.ss_content_image_url} alt=""/>
-            <svg className="ecl-icon ecl-icon--xl ecl-teaser__image-play-icon" focusable="false" aria-hidden="true">
-            </svg>
-          </figure>
+          <figure
+            className="ecl-teaser__image-wrapper"
+            dangerouslySetInnerHTML={{__html:thumbnails}} />
         </a>
         <div className="ecl-teaser__main-wrapper">
           <div className="ecl-teaser__meta-header">
@@ -60,27 +60,7 @@ class VideoLibraryResultItem extends React.Component {
                 </div>)
               })}
             </div>
-            <div className="ecl-teaser__meta-content">
-              <div className="ecl-teaser__meta-content-item">
-                <div className="ecl-timestamp ">
-                  <span
-                    dangerouslySetInnerHTML={{__html: svg('time', 'ecl-icon ecl-icon--s ecl-timestamp__icon')}}
-                  />
-                  <time
-                    className="ecl-timestamp__label">{timeDifferenceFromNow(this.props.result.ss_drupal_timestamp)}</time>
-                </div>
-              </div>
-              <div className="ecl-teaser__meta-content-item">
-                <svg className="ecl-icon ecl-icon--s" focusable="false" aria-hidden="true">
-                </svg>
-                English
-              </div>
-              <div className="ecl-teaser__meta-content-item">
-                <svg className="ecl-icon ecl-icon--s" focusable="false" aria-hidden="true">
-                </svg>
-                <a href={this.props.result.ss_global_user_url}>{this.props.translations.uploaded_by} {this.props.result.ss_global_fullname}</a>
-              </div>
-            </div>
+            <Meta result={this.props.result} isAnonymous={this.props.isAnonymous} translations={this.props.translations}  />
             <HighlightLink
               updateHighlight={this.updateHighlight}
               isHighlighted={isHighlighted}

--- a/lib/themes/eic_community/sass/compositions/_teaser.scss
+++ b/lib/themes/eic_community/sass/compositions/_teaser.scss
@@ -82,10 +82,6 @@
     }
   }
 
-  &--filelist__thumbnail-link {
-    display: flex;
-  }
-
   [class*=ecl-featured-content] &--organisation &__image-wrapper, [class*=ecl-featured-content] &--organisation &__image-wrapper &__image {
     width: 80px;
     height: 80px;

--- a/lib/themes/eic_community/sass/compositions/_teaser.scss
+++ b/lib/themes/eic_community/sass/compositions/_teaser.scss
@@ -1058,6 +1058,12 @@
 
   &__like {
     flex-grow: 1;
+
+    & a,
+    & span {
+      display: flex;
+      align-items: center;
+    }
   }
 
   &__gallery {

--- a/lib/themes/eic_community/sass/compositions/_teaser.scss
+++ b/lib/themes/eic_community/sass/compositions/_teaser.scss
@@ -1137,4 +1137,8 @@
       z-index: 2;
     }
   }
+
+  &-overview__item--library {
+    border-bottom: none;
+  }
 }

--- a/lib/themes/eic_community/sass/compositions/_teaser.scss
+++ b/lib/themes/eic_community/sass/compositions/_teaser.scss
@@ -82,6 +82,10 @@
     }
   }
 
+  &--filelist__thumbnail-link {
+    display: flex;
+  }
+
   [class*=ecl-featured-content] &--organisation &__image-wrapper, [class*=ecl-featured-content] &--organisation &__image-wrapper &__image {
     width: 80px;
     height: 80px;
@@ -1025,6 +1029,11 @@
     margin-top: map-get($ecl-spacing, 's');
     margin-right: map-get($ecl-spacing, 'm');
 
+    > span {
+      display: flex;
+      align-items: center;
+    }
+
     > a {
       color: ecl-typography('color', 'meta');
       text-decoration: none;
@@ -1067,6 +1076,8 @@
       img {
         display: block;
         width: 100%;
+        height: 100%;
+        object-fit: cover;
       }
 
       @include ecl-media-breakpoint-down('xs') {


### PR DESCRIPTION
### what I did

https://citnet.tech.ec.europa.eu/CITnet/jira/secure/RapidBoard.jspa?rapidView=6628&projectKey=EICNET&view=detail&selectedIssue=EICNET-1851&quickFilter=26822

The thumbnail for single file should be a file icon. Currently it is empty or showing an image of the file which is incorrect
The thumbnail for multiple files should be a multiple files icon. Currently it is empty or showing an image of the file which is incorrect
The thumbnail should be displayed as cover 1:1 ratio. It is currently display as fit. This is the case for videos and single image
The language icon is missing for the language meta-data
The uploaded by icon is missing for the uploaded by meta-data
The like action is not displayed. It should be.
The highlight action is not displated. It should be.
For multiple files, we need to display the counter after the title "(X files in total)"
There's one separator too much between teasers

