### PR TITLE
[EICNET-1728]fix: remove empty email when trying to invite people

### DIFF
--- a/lib/modules/eic_user/src/Hooks/FormAlter.php
+++ b/lib/modules/eic_user/src/Hooks/FormAlter.php
@@ -126,6 +126,11 @@ class FormAlter {
       $emails[] = $user->getEmail();
     }
 
+    // Remove empty string.
+    $emails = array_filter($emails, function ($email) {
+      return !empty($email);
+    });
+
     $tempstore_params['emails'] = $emails;
     $tempstore->set('params', $tempstore_params);
   }


### PR DESCRIPTION
How to test it:

- [x] Go to a group detail
- [x] Click on "invite multiple users" from  the group actions
- [x] Only select existing users
- [x] Submit. You should not have a 500 error