### PR TITLE
EICNET-1872: Display breadcrumb bellow page banner in topic detail page

### DIFF
--- a/config/sync/context.context.global_breadcrumbs.yml
+++ b/config/sync/context.context.global_breadcrumbs.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   module:
+    - route_condition
     - system
 name: global_breadcrumbs
 label: 'Global - Breadcrumbs'
@@ -11,11 +12,11 @@ description: ''
 requireAllConditions: false
 disabled: false
 conditions:
-  request_path_exclusion:
-    id: request_path_exclusion
+  route:
+    id: route
+    routes: "entity.overview_page.canonical\r\nentity.taxonomy_term.canonical"
     negate: true
-    pages: "/articles\r\n/events\r\n/groups\r\n/people\r\n/search"
-    uuid: 67b08cb2-557c-41fa-b404-4bfcb6aed9df
+    uuid: d8a54054-50a9-4f1a-a581-af9ee18b86af
     context_mapping: {  }
 reactions:
   blocks:

--- a/lib/themes/eic_community/includes/preprocess/taxonomy/taxonomy_term.inc
+++ b/lib/themes/eic_community/includes/preprocess/taxonomy/taxonomy_term.inc
@@ -29,6 +29,8 @@ function eic_community_preprocess_page__taxonomy__term(&$variables) {
   $file_url = $file ? file_url_transform_relative(file_create_url($file->get('uri')->value)) : NULL;
   $variables['banner_image_url'] = $file_url;
   $variables['topic_title'] = $term->label();
+  // Adds breadcrumbs block to the theme variables.
+  $variables['eic_community_breadcrumbs'] = _eic_community_load_breadcrumb_block();
 }
 
 /**

--- a/lib/themes/eic_community/templates/layout/page--taxonomy--term.html.twig
+++ b/lib/themes/eic_community/templates/layout/page--taxonomy--term.html.twig
@@ -21,6 +21,7 @@
     },
   } only %}
   {{ page.page_header }}
+  {{ eic_community_breadcrumbs }}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
### Improvements

- Show breadcrumb bellow page banner when viewing topic detail page.

### Tests

- [x] Go to a topic detail page
- [x] Make sure the breadcrumb is shown bellow the page banner