### PR TITLE
EICNET-1858: group ownership transfer confirmation (rework expiration)

### DIFF
--- a/config/sync/core.entity_form_display.message.notify_transf_owner_expire_admin.default.yml
+++ b/config/sync/core.entity_form_display.message.notify_transf_owner_expire_admin.default.yml
@@ -1,0 +1,52 @@
+uuid: f57e9e55-04d4-4809-96e1-e4445d3c9987
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.message.notify_transf_owner_expire_admin.field_entity_type
+    - field.field.message.notify_transf_owner_expire_admin.field_entity_url
+    - field.field.message.notify_transf_owner_expire_admin.field_referenced_entity_label
+    - field.field.message.notify_transf_owner_expire_admin.field_referenced_flag
+    - message.template.notify_transf_owner_expire_admin
+  module:
+    - link
+id: message.notify_transf_owner_expire_admin.default
+targetEntityType: message
+bundle: notify_transf_owner_expire_admin
+mode: default
+content:
+  field_entity_type:
+    weight: 3
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_entity_url:
+    weight: 0
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+  field_referenced_entity_label:
+    weight: 1
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_referenced_flag:
+    weight: 2
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+hidden: {  }

--- a/config/sync/core.entity_form_display.message.notify_transf_owner_expire_owner.default.yml
+++ b/config/sync/core.entity_form_display.message.notify_transf_owner_expire_owner.default.yml
@@ -1,0 +1,52 @@
+uuid: 830eedb2-975e-4363-96de-121b3e817d79
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.message.notify_transf_owner_expire_owner.field_entity_type
+    - field.field.message.notify_transf_owner_expire_owner.field_entity_url
+    - field.field.message.notify_transf_owner_expire_owner.field_referenced_entity_label
+    - field.field.message.notify_transf_owner_expire_owner.field_referenced_flag
+    - message.template.notify_transf_owner_expire_owner
+  module:
+    - link
+id: message.notify_transf_owner_expire_owner.default
+targetEntityType: message
+bundle: notify_transf_owner_expire_owner
+mode: default
+content:
+  field_entity_type:
+    weight: 1
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_entity_url:
+    weight: 3
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+  field_referenced_entity_label:
+    weight: 2
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_referenced_flag:
+    weight: 0
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+hidden: {  }

--- a/config/sync/core.entity_view_display.message.notify_transf_owner_expire_admin.default.yml
+++ b/config/sync/core.entity_view_display.message.notify_transf_owner_expire_admin.default.yml
@@ -1,0 +1,65 @@
+uuid: 2e94ecea-3052-492a-a8a0-ef69c4d1d0af
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.message.notify_transf_owner_expire_admin.field_entity_type
+    - field.field.message.notify_transf_owner_expire_admin.field_entity_url
+    - field.field.message.notify_transf_owner_expire_admin.field_referenced_entity_label
+    - field.field.message.notify_transf_owner_expire_admin.field_referenced_flag
+    - message.template.notify_transf_owner_expire_admin
+  module:
+    - link
+id: message.notify_transf_owner_expire_admin.default
+targetEntityType: message
+bundle: notify_transf_owner_expire_admin
+mode: default
+content:
+  field_entity_type:
+    weight: 4
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_entity_url:
+    weight: 1
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+  field_referenced_entity_label:
+    weight: 2
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_referenced_flag:
+    weight: 3
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  partial_0:
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  partial_1:
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.notify_transf_owner_expire_admin.mail_body.yml
+++ b/config/sync/core.entity_view_display.message.notify_transf_owner_expire_admin.mail_body.yml
@@ -1,0 +1,26 @@
+uuid: d0a9f474-e7cf-4831-ab06-5bb7fee4bbc5
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.message.mail_body
+    - field.field.message.notify_transf_owner_expire_admin.field_entity_type
+    - field.field.message.notify_transf_owner_expire_admin.field_entity_url
+    - field.field.message.notify_transf_owner_expire_admin.field_referenced_entity_label
+    - field.field.message.notify_transf_owner_expire_admin.field_referenced_flag
+    - message.template.notify_transf_owner_expire_admin
+id: message.notify_transf_owner_expire_admin.mail_body
+targetEntityType: message
+bundle: notify_transf_owner_expire_admin
+mode: mail_body
+content:
+  partial_1:
+    weight: 0
+    region: content
+hidden:
+  field_entity_type: true
+  field_entity_url: true
+  field_referenced_entity_label: true
+  field_referenced_flag: true
+  partial_0: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.notify_transf_owner_expire_admin.mail_subject.yml
+++ b/config/sync/core.entity_view_display.message.notify_transf_owner_expire_admin.mail_subject.yml
@@ -1,0 +1,26 @@
+uuid: 1bb816a6-7d57-41e1-ba09-4266ee83c90f
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.message.mail_subject
+    - field.field.message.notify_transf_owner_expire_admin.field_entity_type
+    - field.field.message.notify_transf_owner_expire_admin.field_entity_url
+    - field.field.message.notify_transf_owner_expire_admin.field_referenced_entity_label
+    - field.field.message.notify_transf_owner_expire_admin.field_referenced_flag
+    - message.template.notify_transf_owner_expire_admin
+id: message.notify_transf_owner_expire_admin.mail_subject
+targetEntityType: message
+bundle: notify_transf_owner_expire_admin
+mode: mail_subject
+content:
+  partial_0:
+    weight: 0
+    region: content
+hidden:
+  field_entity_type: true
+  field_entity_url: true
+  field_referenced_entity_label: true
+  field_referenced_flag: true
+  partial_1: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.notify_transf_owner_expire_owner.default.yml
+++ b/config/sync/core.entity_view_display.message.notify_transf_owner_expire_owner.default.yml
@@ -1,0 +1,65 @@
+uuid: c4f401a9-2847-4e7a-b98e-2b4a03def206
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.message.notify_transf_owner_expire_owner.field_entity_type
+    - field.field.message.notify_transf_owner_expire_owner.field_entity_url
+    - field.field.message.notify_transf_owner_expire_owner.field_referenced_entity_label
+    - field.field.message.notify_transf_owner_expire_owner.field_referenced_flag
+    - message.template.notify_transf_owner_expire_owner
+  module:
+    - link
+id: message.notify_transf_owner_expire_owner.default
+targetEntityType: message
+bundle: notify_transf_owner_expire_owner
+mode: default
+content:
+  field_entity_type:
+    weight: 2
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_entity_url:
+    weight: 4
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+  field_referenced_entity_label:
+    weight: 3
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_referenced_flag:
+    weight: 1
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  partial_0:
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  partial_1:
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.notify_transf_owner_expire_owner.mail_body.yml
+++ b/config/sync/core.entity_view_display.message.notify_transf_owner_expire_owner.mail_body.yml
@@ -1,0 +1,26 @@
+uuid: 90378691-37b4-4aae-b216-a86323a5c819
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.message.mail_body
+    - field.field.message.notify_transf_owner_expire_owner.field_entity_type
+    - field.field.message.notify_transf_owner_expire_owner.field_entity_url
+    - field.field.message.notify_transf_owner_expire_owner.field_referenced_entity_label
+    - field.field.message.notify_transf_owner_expire_owner.field_referenced_flag
+    - message.template.notify_transf_owner_expire_owner
+id: message.notify_transf_owner_expire_owner.mail_body
+targetEntityType: message
+bundle: notify_transf_owner_expire_owner
+mode: mail_body
+content:
+  partial_1:
+    weight: 0
+    region: content
+hidden:
+  field_entity_type: true
+  field_entity_url: true
+  field_referenced_entity_label: true
+  field_referenced_flag: true
+  partial_0: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.notify_transf_owner_expire_owner.mail_subject.yml
+++ b/config/sync/core.entity_view_display.message.notify_transf_owner_expire_owner.mail_subject.yml
@@ -1,0 +1,26 @@
+uuid: 776b295b-f5fc-4b13-a698-ea8b4fda63de
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.message.mail_subject
+    - field.field.message.notify_transf_owner_expire_owner.field_entity_type
+    - field.field.message.notify_transf_owner_expire_owner.field_entity_url
+    - field.field.message.notify_transf_owner_expire_owner.field_referenced_entity_label
+    - field.field.message.notify_transf_owner_expire_owner.field_referenced_flag
+    - message.template.notify_transf_owner_expire_owner
+id: message.notify_transf_owner_expire_owner.mail_subject
+targetEntityType: message
+bundle: notify_transf_owner_expire_owner
+mode: mail_subject
+content:
+  partial_0:
+    weight: 0
+    region: content
+hidden:
+  field_entity_type: true
+  field_entity_url: true
+  field_referenced_entity_label: true
+  field_referenced_flag: true
+  partial_1: true
+  search_api_excerpt: true

--- a/config/sync/field.field.message.notify_transf_owner_expire_admin.field_entity_type.yml
+++ b/config/sync/field.field.message.notify_transf_owner_expire_admin.field_entity_type.yml
@@ -1,0 +1,19 @@
+uuid: f020e434-406a-4632-af53-8de248efa19c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_entity_type
+    - message.template.notify_transf_owner_expire_admin
+id: message.notify_transf_owner_expire_admin.field_entity_type
+field_name: field_entity_type
+entity_type: message
+bundle: notify_transf_owner_expire_admin
+label: 'Entity type'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.message.notify_transf_owner_expire_admin.field_entity_url.yml
+++ b/config/sync/field.field.message.notify_transf_owner_expire_admin.field_entity_url.yml
@@ -1,0 +1,23 @@
+uuid: 6aab9bcc-10b0-4bac-b553-5f47dd9c932c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_entity_url
+    - message.template.notify_transf_owner_expire_admin
+  module:
+    - link
+id: message.notify_transf_owner_expire_admin.field_entity_url
+field_name: field_entity_url
+entity_type: message
+bundle: notify_transf_owner_expire_admin
+label: 'Entity URL'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 1
+  title: 0
+field_type: link

--- a/config/sync/field.field.message.notify_transf_owner_expire_admin.field_referenced_entity_label.yml
+++ b/config/sync/field.field.message.notify_transf_owner_expire_admin.field_referenced_entity_label.yml
@@ -1,0 +1,19 @@
+uuid: c4e86273-5d58-471f-978d-5ec19e6134bd
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_referenced_entity_label
+    - message.template.notify_transf_owner_expire_admin
+id: message.notify_transf_owner_expire_admin.field_referenced_entity_label
+field_name: field_referenced_entity_label
+entity_type: message
+bundle: notify_transf_owner_expire_admin
+label: 'Entity Label'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.message.notify_transf_owner_expire_admin.field_referenced_flag.yml
+++ b/config/sync/field.field.message.notify_transf_owner_expire_admin.field_referenced_flag.yml
@@ -1,0 +1,29 @@
+uuid: 828ae586-daaf-4453-85c6-f5b60b8d44a3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_referenced_flag
+    - flag.flag.transfer_owner_request_group
+    - message.template.notify_transf_owner_expire_admin
+id: message.notify_transf_owner_expire_admin.field_referenced_flag
+field_name: field_referenced_flag
+entity_type: message
+bundle: notify_transf_owner_expire_admin
+label: 'Referenced Flag'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:flagging'
+  handler_settings:
+    target_bundles:
+      transfer_owner_request_group: transfer_owner_request_group
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.message.notify_transf_owner_expire_owner.field_entity_type.yml
+++ b/config/sync/field.field.message.notify_transf_owner_expire_owner.field_entity_type.yml
@@ -1,0 +1,19 @@
+uuid: 771f8c4e-196f-4c16-87bb-084386cbefee
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_entity_type
+    - message.template.notify_transf_owner_expire_owner
+id: message.notify_transf_owner_expire_owner.field_entity_type
+field_name: field_entity_type
+entity_type: message
+bundle: notify_transf_owner_expire_owner
+label: 'Entity type'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.message.notify_transf_owner_expire_owner.field_entity_url.yml
+++ b/config/sync/field.field.message.notify_transf_owner_expire_owner.field_entity_url.yml
@@ -1,0 +1,23 @@
+uuid: 43fd156c-4dfc-41d0-b7e2-e7aa4025bf14
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_entity_url
+    - message.template.notify_transf_owner_expire_owner
+  module:
+    - link
+id: message.notify_transf_owner_expire_owner.field_entity_url
+field_name: field_entity_url
+entity_type: message
+bundle: notify_transf_owner_expire_owner
+label: 'Entity URL'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 1
+  title: 0
+field_type: link

--- a/config/sync/field.field.message.notify_transf_owner_expire_owner.field_referenced_entity_label.yml
+++ b/config/sync/field.field.message.notify_transf_owner_expire_owner.field_referenced_entity_label.yml
@@ -1,0 +1,19 @@
+uuid: 6faa4da0-719d-4a62-b310-f45b9ee7dda1
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_referenced_entity_label
+    - message.template.notify_transf_owner_expire_owner
+id: message.notify_transf_owner_expire_owner.field_referenced_entity_label
+field_name: field_referenced_entity_label
+entity_type: message
+bundle: notify_transf_owner_expire_owner
+label: 'Entity Label'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.message.notify_transf_owner_expire_owner.field_referenced_flag.yml
+++ b/config/sync/field.field.message.notify_transf_owner_expire_owner.field_referenced_flag.yml
@@ -1,0 +1,29 @@
+uuid: 11494d47-7e26-47e7-b7b4-31f90796a1ea
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_referenced_flag
+    - flag.flag.transfer_owner_request_group
+    - message.template.notify_transf_owner_expire_owner
+id: message.notify_transf_owner_expire_owner.field_referenced_flag
+field_name: field_referenced_flag
+entity_type: message
+bundle: notify_transf_owner_expire_owner
+label: 'Referenced Flag'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:flagging'
+  handler_settings:
+    target_bundles:
+      transfer_owner_request_group: transfer_owner_request_group
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/language/en/message.template.notify_transf_owner_expire_admin.yml
+++ b/config/sync/language/en/message.template.notify_transf_owner_expire_admin.yml
@@ -1,0 +1,7 @@
+text:
+  -
+    value: "<p>Your request to become owner of [message:field_entity_type:value] [message:field_referenced_entity_label:value]&nbsp;has been expired</p>\r\n"
+    format: full_html
+  -
+    value: "<p>Dear <a href=\"[message:author:url]\">[message:author:field_first_name:value]&nbsp;[message:author:field_last_name:value]</a>,</p>\r\n\r\n<p>Your request to become the owner [message:field_entity_type:value] [message:field_referenced_entity_label:value]&nbsp;has been expired.</p>\r\n\r\n<p>The EIC Community team</p>\r\n"
+    format: full_html

--- a/config/sync/language/en/message.template.notify_transf_owner_expire_owner.yml
+++ b/config/sync/language/en/message.template.notify_transf_owner_expire_owner.yml
@@ -1,0 +1,7 @@
+text:
+  -
+    value: "<p>Your request to transfer ownership to [message:field_referenced_flag:entity:field_new_owner_ref:entity:field_first_name:value] [message:field_referenced_flag:entity:field_new_owner_ref:entity:field_last_name:value] has been expired</p>\r\n"
+    format: full_html
+  -
+    value: "<p>Dear <a href=\"[message:author:url]\">[message:author:field_first_name:value]&nbsp;[message:author:field_last_name:value]</a>,</p>\r\n\r\n<p>Your request to transfer ownership to&nbsp;<a href=\"[message:field_referenced_flag:entity:field_new_owner_ref:entity:url]\">[message:field_referenced_flag:entity:field_new_owner_ref:entity:field_first_name:value] [message:field_referenced_flag:entity:field_new_owner_ref:entity:field_last_name:value]</a> has been expired and therefore you are still the owner of [message:field_entity_type:value] <a href=\"[message:field_entity_url:uri]\">[message:field_referenced_entity_label:value]</a>.</p>\r\n\r\n<p>The EIC Community team</p>\r\n"
+    format: full_html

--- a/config/sync/message.template.notify_transf_owner_expire_admin.yml
+++ b/config/sync/message.template.notify_transf_owner_expire_admin.yml
@@ -1,0 +1,27 @@
+uuid: 1658a26b-c864-4b2c-89a9-d5372f4dab43
+langcode: en
+status: true
+dependencies:
+  config:
+    - filter.format.full_html
+  module:
+    - eic_messages
+third_party_settings:
+  eic_messages:
+    message_template_type: notification
+template: notify_transf_owner_expire_admin
+label: 'NOTIFY :: MT:: Transfer ownership request - request timeout (admin)'
+description: ''
+text:
+  -
+    value: "<p>Your request to become owner of [message:field_entity_type:value] [message:field_referenced_entity_label:value]&nbsp;has been expired</p>\r\n"
+    format: full_html
+  -
+    value: "<p>Dear <a href=\"[message:author:url]\">[message:author:field_first_name:value]&nbsp;[message:author:field_last_name:value]</a>,</p>\r\n\r\n<p>Your request to become the owner [message:field_entity_type:value] [message:field_referenced_entity_label:value]&nbsp;has been expired.</p>\r\n\r\n<p>The EIC Community team</p>\r\n"
+    format: full_html
+settings:
+  'token options':
+    clear: false
+    'token replace': true
+  purge_override: false
+  purge_methods: {  }

--- a/config/sync/message.template.notify_transf_owner_expire_owner.yml
+++ b/config/sync/message.template.notify_transf_owner_expire_owner.yml
@@ -1,0 +1,27 @@
+uuid: 12127c20-b641-4fa1-8333-a0d2d011221a
+langcode: en
+status: true
+dependencies:
+  config:
+    - filter.format.full_html
+  module:
+    - eic_messages
+third_party_settings:
+  eic_messages:
+    message_template_type: notification
+template: notify_transf_owner_expire_owner
+label: 'NOTIFY :: MT:: Transfer ownership request - request timeout (owner)'
+description: ''
+text:
+  -
+    value: "<p>Your request to transfer ownership to [message:field_referenced_flag:entity:field_new_owner_ref:entity:field_first_name:value] [message:field_referenced_flag:entity:field_new_owner_ref:entity:field_last_name:value] has been expired</p>\r\n"
+    format: full_html
+  -
+    value: "<p>Dear <a href=\"[message:author:url]\">[message:author:field_first_name:value]&nbsp;[message:author:field_last_name:value]</a>,</p>\r\n\r\n<p>Your request to transfer ownership to&nbsp;<a href=\"[message:field_referenced_flag:entity:field_new_owner_ref:entity:url]\">[message:field_referenced_flag:entity:field_new_owner_ref:entity:field_first_name:value] [message:field_referenced_flag:entity:field_new_owner_ref:entity:field_last_name:value]</a> has been expired and therefore you are still the owner of [message:field_entity_type:value] <a href=\"[message:field_entity_url:uri]\">[message:field_referenced_entity_label:value]</a>.</p>\r\n\r\n<p>The EIC Community team</p>\r\n"
+    format: full_html
+settings:
+  'token options':
+    clear: false
+    'token replace': true
+  purge_override: false
+  purge_methods: {  }

--- a/lib/modules/eic_flags/eic_flags.api.php
+++ b/lib/modules/eic_flags/eic_flags.api.php
@@ -69,5 +69,32 @@ function hook_request_close(
 }
 
 /**
+ * Respond to a request being expired.
+ *
+ * @param \Drupal\flag\FlaggingInterface $flagging
+ *   The flag that has been created and applied to the content.
+ * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+ *   The content entity the flag has been applied to.
+ * @param string $type
+ *   The type of the flag (delete, archive, etc.).
+ */
+function hook_request_timeout(
+  FlaggingInterface $flagging,
+  ContentEntityInterface $entity,
+  string $type
+) {
+  // Create a log entry with some info.
+  \Drupal::logger('eic_flags')
+    ->notice(
+      'Request @flag_id with type @type has been handled. Response @response given',
+      [
+        '@flag_id' => $flagging->id(),
+        '@type' => $type,
+        '@response' => 'request timeout',
+      ]
+    );
+}
+
+/**
  * @} End of "addtogroup hooks".
  */

--- a/lib/modules/eic_flags/eic_flags.module
+++ b/lib/modules/eic_flags/eic_flags.module
@@ -14,6 +14,7 @@ use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\eic_flags\Form\NewRequestForm;
 use Drupal\eic_flags\Form\RequestCloseForm;
+use Drupal\eic_flags\Hooks\CronOperations;
 use Drupal\eic_flags\Hooks\EntityOperations;
 use Drupal\eic_flags\Hooks\FlagTokens;
 use Drupal\eic_flags\RequestStatus;
@@ -82,6 +83,9 @@ function eic_flags_cron() {
     $row = (array) $row;
     $queue->createItem($row);
   }
+
+  $class = \Drupal::classResolver(CronOperations::class);
+  $class->processRequestTimeouts();
 }
 
 /**

--- a/lib/modules/eic_flags/eic_flags.services.yml
+++ b/lib/modules/eic_flags/eic_flags.services.yml
@@ -5,22 +5,22 @@ services:
       - { name: service_collector, tag: request_handler, call: addHandler }
   eic_flags.delete_request_handler:
     class: Drupal\eic_flags\Service\DeleteRequestHandler
-    arguments: [ '@module_handler', '@entity_type.manager', '@flag', '@content_moderation.moderation_information', '@request_stack' ]
+    arguments: [ '@module_handler', '@entity_type.manager', '@flag', '@content_moderation.moderation_information', '@request_stack', '@entity_field.manager' ]
     tags:
       - { name: request_handler }
   eic_flags.delete_archive_handler:
     class: Drupal\eic_flags\Service\ArchiveRequestHandler
-    arguments: [ '@module_handler', '@entity_type.manager', '@flag', '@content_moderation.moderation_information', '@request_stack' ]
+    arguments: [ '@module_handler', '@entity_type.manager', '@flag', '@content_moderation.moderation_information', '@request_stack', '@entity_field.manager' ]
     tags:
       - { name: request_handler }
   eic_flags.block_request_handler:
     class: Drupal\eic_flags\Service\BlockRequestHandler
-    arguments: [ '@module_handler', '@entity_type.manager', '@flag', '@content_moderation.moderation_information', '@request_stack' ]
+    arguments: [ '@module_handler', '@entity_type.manager', '@flag', '@content_moderation.moderation_information', '@request_stack', '@entity_field.manager' ]
     tags:
       - { name: request_handler }
   eic_flags.transfer_ownership_request_handler:
     class: Drupal\eic_flags\Service\TransferOwnershipRequestHandler
-    arguments: [ '@module_handler', '@entity_type.manager', '@flag', '@content_moderation.moderation_information', '@request_stack' ]
+    arguments: [ '@module_handler', '@entity_type.manager', '@flag', '@content_moderation.moderation_information', '@request_stack', '@entity_field.manager' ]
     tags:
       - { name: request_handler }
   eic_flags.request_access_checker:

--- a/lib/modules/eic_flags/src/Hooks/CronOperations.php
+++ b/lib/modules/eic_flags/src/Hooks/CronOperations.php
@@ -82,13 +82,12 @@ class CronOperations implements ContainerInjectionInterface {
       $container->get('entity_type.manager'),
       $container->get('entity_field.manager'),
       $container->get('eic_flags.handler_collector'),
-      $container->get('database'),
-      $container->get('module_handler')
+      $container->get('database')
     );
   }
 
   /**
-   * Process message subscriptions queue.
+   * Process request timeouts.
    *
    * @todo In the future this method should be called by ultimate cron module.
    */
@@ -118,8 +117,10 @@ class CronOperations implements ContainerInjectionInterface {
           $query->fields('f', ['id', 'flag_id', 'entity_type', 'entity_id']);
           $result = $query->execute()->fetchAll();
           foreach ($result as $row) {
+            /** @var \Drupal\flag\FlaggingInterface $flag */
             $flag = $this->entityTypeManager->getStorage('flagging')
               ->load($row->id);
+            /** @var \Drupal\Core\Entity\ContentEntityInterface $flagged_entity */
             $flagged_entity = $this->entityTypeManager->getStorage($row->entity_type)
               ->load($row->entity_id);
             if (!$flag || !$flagged_entity) {

--- a/lib/modules/eic_flags/src/Hooks/CronOperations.php
+++ b/lib/modules/eic_flags/src/Hooks/CronOperations.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Drupal\eic_flags\Hooks;
+
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\eic_flags\RequestStatus;
+use Drupal\eic_flags\Service\HandlerInterface;
+use Drupal\eic_flags\Service\RequestHandlerCollector;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class CronOperations.
+ *
+ * Implementations for hook_cron().
+ */
+class CronOperations implements ContainerInjectionInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The entity field manager.
+   *
+   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
+   */
+  protected $entityFieldManager;
+
+  /**
+   * The request handler collector.
+   *
+   * @var \Drupal\eic_flags\Service\RequestHandlerCollector
+   */
+  protected $requestHandlerCollector;
+
+  /**
+   * The database connection.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected $database;
+
+  /**
+   * Constructs a CronOperations object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager
+   *   The entity field manager.
+   * @param \Drupal\eic_flags\Service\RequestHandlerCollector $request_handler_collector
+   *   The request handler collector.
+   * @param \Drupal\Core\Database\Connection $database
+   *   The database connection.
+   */
+  public function __construct(
+    EntityTypeManagerInterface $entity_type_manager,
+    EntityFieldManagerInterface $entity_field_manager,
+    RequestHandlerCollector $request_handler_collector,
+    Connection $database
+  ) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->entityFieldManager = $entity_field_manager;
+    $this->requestHandlerCollector = $request_handler_collector;
+    $this->database = $database;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('entity_field.manager'),
+      $container->get('eic_flags.handler_collector'),
+      $container->get('database'),
+      $container->get('module_handler')
+    );
+  }
+
+  /**
+   * Process message subscriptions queue.
+   *
+   * @todo In the future this method should be called by ultimate cron module.
+   */
+  public function processRequestTimeouts() {
+    /** @var \Drupal\eic_flags\Service\HandlerInterface[] $request_handlers */
+    $request_handlers = $this->requestHandlerCollector->getHandlers();
+
+    $now = DrupalDateTime::createFromTimestamp(time());
+    // Gets all request flags that have a timeout limit and close them.
+    foreach ($request_handlers as $request_handler) {
+      $supported_flags[$request_handler->getType()] = [];
+      foreach ($request_handler->getSupportedEntityTypes() as $flag_id) {
+        $fields = $this->entityFieldManager->getFieldDefinitions('flagging', $flag_id);
+
+        if (
+          isset($fields[HandlerInterface::REQUEST_TIMEOUT_FIELD]) &&
+          !in_array($flag_id, $supported_flags[$request_handler->getType()])
+        ) {
+
+          $query = $this->database->select('flagging', 'f');
+          $query->join('flagging__field_request_timeout', 'frt', 'f.id = frt.entity_id');
+          $query->join('flagging__field_request_status', 'frs', 'f.id = frs.entity_id');
+          $query->condition('f.flag_id', $flag_id);
+          $query->condition('frs.field_request_status_value', RequestStatus::OPEN);
+          $query->condition('frt.field_request_timeout_value', 0, '>');
+          $query->where($now->getTimestamp() . ' >= ((frt.field_request_timeout_value * 86400) + f.created)');
+          $query->fields('f', ['id', 'flag_id', 'entity_type', 'entity_id']);
+          $result = $query->execute()->fetchAll();
+          foreach ($result as $row) {
+            $flag = $this->entityTypeManager->getStorage('flagging')
+              ->load($row->id);
+            $flagged_entity = $this->entityTypeManager->getStorage($row->entity_type)
+              ->load($row->entity_id);
+            if (!$flag || !$flagged_entity) {
+              continue;
+            }
+            $request_handler->requestTimeout($flag, $flagged_entity);
+          }
+        }
+      }
+    }
+  }
+
+}

--- a/lib/modules/eic_flags/src/RequestStatus.php
+++ b/lib/modules/eic_flags/src/RequestStatus.php
@@ -17,4 +17,6 @@ final class RequestStatus {
 
   const OPEN = 'open';
 
+  const TIMEOUT = 'timeout';
+
 }

--- a/lib/modules/eic_flags/src/Service/AbstractRequestHandler.php
+++ b/lib/modules/eic_flags/src/Service/AbstractRequestHandler.php
@@ -6,6 +6,7 @@ use Drupal\content_moderation\ModerationInformationInterface;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Session\AccountInterface;
@@ -68,6 +69,13 @@ abstract class AbstractRequestHandler implements HandlerInterface {
   protected $currentRequest;
 
   /**
+   * The entity field manager.
+   *
+   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
+   */
+  protected $entityFieldManager;
+
+  /**
    * AbstractRequestHandler constructor.
    *
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
@@ -80,19 +88,23 @@ abstract class AbstractRequestHandler implements HandlerInterface {
    *   Core's moderation information service.
    * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
    *   The request stack object.
+   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager
+   *   The entity field manager.
    */
   public function __construct(
     ModuleHandlerInterface $module_handler,
     EntityTypeManagerInterface $entity_type_manager,
     FlagService $flag_service,
     ModerationInformationInterface $moderation_information,
-    RequestStack $request_stack
+    RequestStack $request_stack,
+    EntityFieldManagerInterface $entity_field_manager
   ) {
     $this->moduleHandler = $module_handler;
     $this->entityTypeManager = $entity_type_manager;
     $this->flagService = $flag_service;
     $this->moderationInformation = $moderation_information;
     $this->currentRequest = $request_stack->getCurrentRequest();
+    $this->entityFieldManager = $entity_field_manager;
   }
 
   /**
@@ -426,6 +438,73 @@ abstract class AbstractRequestHandler implements HandlerInterface {
       RequestStatus::ACCEPTED,
       RequestStatus::ARCHIVED,
     ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function hasExpiration(FlaggingInterface $flag) {
+    $fields = $this->entityFieldManager->getFieldDefinitions('flagging', $flag->getFlagId());
+    if (
+      isset($fields[HandlerInterface::REQUEST_TIMEOUT_FIELD]) &&
+      $flag->get(HandlerInterface::REQUEST_TIMEOUT_FIELD)->value > 0
+    ) {
+      return TRUE;
+    }
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function hasExpired(FlaggingInterface $flag) {
+    $fields = $this->entityFieldManager->getFieldDefinitions('flagging', $flag->getFlagId());
+    if (
+      isset($fields[HandlerInterface::REQUEST_TIMEOUT_FIELD]) &&
+      $flag->get(HandlerInterface::REQUEST_TIMEOUT_FIELD)->value > 0
+    ) {
+      $now = DrupalDateTime::createFromTimestamp(time());
+      $limit = ($flag->get(HandlerInterface::REQUEST_TIMEOUT_FIELD)->value * 86400) + $flag->get('created')->value;
+
+      if ($now->getTimestamp() >= $limit) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function requestTimeout(
+    FlaggingInterface $flagging,
+    ContentEntityInterface $content_entity
+  ) {
+    $now = DrupalDateTime::createFromTimestamp(time());
+
+    // For some requests, field request response is not presented.
+    if ($flagging->hasField('field_request_response')) {
+      $flagging->set('field_request_response', $this->t('Request timeout'));
+    }
+
+    $flagging->set('field_request_status', RequestStatus::DENIED);
+    $flagging->set(
+      'field_request_closed_date',
+      $now->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT)
+    );
+    $flagging->save();
+
+    $this->moduleHandler->invokeAll(
+      'request_timeout',
+      [
+        $flagging,
+        $content_entity,
+        $this->getType(),
+      ]
+    );
+
+    // We trigger the deny method to clear all related caches.
+    $this->deny($flagging, $content_entity);
   }
 
 }

--- a/lib/modules/eic_flags/src/Service/AbstractRequestHandler.php
+++ b/lib/modules/eic_flags/src/Service/AbstractRequestHandler.php
@@ -445,32 +445,23 @@ abstract class AbstractRequestHandler implements HandlerInterface {
    */
   public function hasExpiration(FlaggingInterface $flag) {
     $fields = $this->entityFieldManager->getFieldDefinitions('flagging', $flag->getFlagId());
-    if (
-      isset($fields[HandlerInterface::REQUEST_TIMEOUT_FIELD]) &&
-      $flag->get(HandlerInterface::REQUEST_TIMEOUT_FIELD)->value > 0
-    ) {
-      return TRUE;
-    }
-    return FALSE;
+
+    return isset($fields[HandlerInterface::REQUEST_TIMEOUT_FIELD]) &&
+      $flag->get(HandlerInterface::REQUEST_TIMEOUT_FIELD)->value > 0;
   }
 
   /**
    * {@inheritdoc}
    */
   public function hasExpired(FlaggingInterface $flag) {
-    $fields = $this->entityFieldManager->getFieldDefinitions('flagging', $flag->getFlagId());
-    if (
-      isset($fields[HandlerInterface::REQUEST_TIMEOUT_FIELD]) &&
-      $flag->get(HandlerInterface::REQUEST_TIMEOUT_FIELD)->value > 0
-    ) {
-      $now = DrupalDateTime::createFromTimestamp(time());
-      $limit = ($flag->get(HandlerInterface::REQUEST_TIMEOUT_FIELD)->value * 86400) + $flag->get('created')->value;
-
-      if ($now->getTimestamp() >= $limit) {
-        return TRUE;
-      }
+    if (!$this->hasExpiration($flag)) {
+      return FALSE;
     }
-    return FALSE;
+
+    $now = DrupalDateTime::createFromTimestamp(time());
+    $limit = ($flag->get(HandlerInterface::REQUEST_TIMEOUT_FIELD)->value * 86400) + $flag->get('created')->value;
+
+    return $now->getTimestamp() >= $limit;
   }
 
   /**

--- a/lib/modules/eic_flags/src/Service/HandlerInterface.php
+++ b/lib/modules/eic_flags/src/Service/HandlerInterface.php
@@ -247,4 +247,39 @@ interface HandlerInterface {
    */
   public function getSupportedResponsesForClosedRequests();
 
+  /**
+   * Whether or not the request flag has been expired.
+   *
+   * @param \Drupal\flag\FlaggingInterface $flag
+   *   The flagging entity to alter.
+   *
+   * @return bool
+   *   TRUE if has expiration.
+   */
+  public function hasExpiration(FlaggingInterface $flag);
+
+  /**
+   * Whether or not the request flag has been expired.
+   *
+   * @param \Drupal\flag\FlaggingInterface $flag
+   *   The flagging entity to alter.
+   *
+   * @return bool
+   *   TRUE if request has expired.
+   */
+  public function hasExpired(FlaggingInterface $flag);
+
+  /**
+   * Triggers request timeout.
+   *
+   * @param \Drupal\flag\FlaggingInterface $flagging
+   *   The flag object representing the request.
+   * @param \Drupal\Core\Entity\ContentEntityInterface $content_entity
+   *   The concerned entity.
+   */
+  public function requestTimeout(
+    FlaggingInterface $flagging,
+    ContentEntityInterface $content_entity
+  );
+
 }

--- a/lib/modules/eic_groups/modules/eic_group_membership/src/Plugin/views/field/TransferOwnershipStatus.php
+++ b/lib/modules/eic_groups/modules/eic_group_membership/src/Plugin/views/field/TransferOwnershipStatus.php
@@ -84,9 +84,21 @@ class TransferOwnershipStatus extends FieldPluginBase {
     }
 
     if ($handler->hasOpenRequest($group_content, $group_content->getEntity())) {
-      $output = [
-        '#markup' => $this->t('pending ownership transfer'),
-      ];
+
+      $open_requests = $handler->getOpenRequests($group_content);
+      $request = reset($open_requests);
+
+      // If request has expiration, we show a different message.
+      if ($handler->hasExpiration($request) && $handler->hasExpired($request)) {
+        $output = [
+          '#markup' => $this->t('ownership transfer expired'),
+        ];
+      }
+      else {
+        $output = [
+          '#markup' => $this->t('pending ownership transfer'),
+        ];
+      }
     }
 
     return $output;

--- a/lib/modules/eic_messages/eic_messages.module
+++ b/lib/modules/eic_messages/eic_messages.module
@@ -127,6 +127,19 @@ function eic_messages_request_close(
 }
 
 /**
+ * Implements hook_request_timeout().
+ */
+function eic_messages_request_timeout(
+  FlaggingInterface $flag,
+  ContentEntityInterface $entity,
+  string $type
+) {
+  /** @var Drupal\eic_messages\Service\RequestMessageCreator $class */
+  $class = \Drupal::classResolver(RequestMessageCreator::class);
+  $class->requestTimeout($flag, $entity, $type);
+}
+
+/**
  * Implements hook_entity_extra_field_info().
  */
 function eic_messages_entity_extra_field_info() {


### PR DESCRIPTION
### Improvements

- Create new message types to send notification when a request to transfer ownership has been expired;
- Create cron task to close expired requests and send notifications;
- Do not allow users to accept/deny expired request;
- Show information about expired request when viewing list of group members.

### Tests

- [ ] When requesting a new ownership transfer, make sure there is a new field to provide the timeout for the request to be automatically closed
- [ ] When request has expired, make sure you see a message in the list of members bellow the user that was requested
- [ ] Try to access the accept/deny links and make sure you get an access denied
- [ ] Run cron and make sure the request was automatically closed and you get 2 notifications (1 for the author of the request and another one for the user who didn't accept the request)
