### PR TITLE
EICNET-1373: Keep user invite members choice when creating a group

### DIFF
--- a/config/sync/field.field.group.group.field_group_invite_members.yml
+++ b/config/sync/field.field.group.group.field_group_invite_members.yml
@@ -15,7 +15,7 @@ required: false
 translatable: false
 default_value:
   -
-    value: 0
+    value: 1
 default_value_callback: ''
 settings:
   on_label: 'On'

--- a/lib/modules/oec_group_flex/src/Entity/Form/GroupForm.php
+++ b/lib/modules/oec_group_flex/src/Entity/Form/GroupForm.php
@@ -220,8 +220,6 @@ class GroupForm extends GroupFormBase {
    */
   public function save(array $form, FormStateInterface $form_state): int {
     $group = $this->entity;
-    $is_new = $group->isNew();
-
     $return = parent::save($form, $form_state);
 
     if (!$groupFlexSettings = $this->getGroupFlexSettingsFormValues($form, $form_state)) {
@@ -273,21 +271,7 @@ class GroupForm extends GroupFormBase {
       }
     }
 
-    // If the group is new and the selected joining method is "tu_open_method",
-    // we enable member invitations by default.
-    // This logic needs to be triggered during this process because the group
-    // visibility and joining methods are saved previously after the group is
-    // saved in the Database.
-    if ($is_new &&
-      $group->hasField('field_group_invite_members') &&
-      $groupFlexSettings['settings']['joining_methods'] === 'tu_open_method'
-    ) {
-      $group->set('field_group_invite_members', TRUE);
-      $group->save();
-    }
-
     $this->clearTempStore($form, $form_state);
-
     return $return;
   }
 


### PR DESCRIPTION
### Changes

- Revert logic that automatically enables membership invitations when creating a group.
- Make Invite members checkbox enabled by default when a user creates a group.

### Test

- [x] Try to create a new group
- [x] Select the joining method to "Open"
- [x] Uncheck the Invite members checkbox
- [x] Save the group and make sure the invite members checkbox remains unchecked