### PR TITLE
EICNET-1835: User profile my groups (rework)

### DIFF
--- a/config/sync/views.view.groups.yml
+++ b/config/sync/views.view.groups.yml
@@ -270,3 +270,21 @@ display:
         - 'languages:language_interface'
         - url
       tags: {  }
+  block_user_profile_my_groups:
+    display_plugin: block
+    id: block_user_profile_my_groups
+    display_title: 'Block - User profile my groups'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      title: 'My groups'
+      defaults:
+        title: false
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+      tags: {  }

--- a/lib/themes/eic_community/includes/preprocess/users/user.inc
+++ b/lib/themes/eic_community/includes/preprocess/users/user.inc
@@ -192,11 +192,7 @@ function eic_community_preprocess_user(array &$variables) {
       $user_item['flagged_groups'] = [
         'title' => $current_user->id() === $user->id() ? t('My groups') : t('Groups'),
         'content' => $current_user->id() === $user->id()
-          ? _eic_community_get_rendered_view(
-            'groups',
-            'block_user_profile_my_groups',
-            [$user->id()]
-          )
+          ? _eic_community_get_rendered_view('groups', 'block_user_profile_my_groups', [$user->id()])
           : _eic_community_get_rendered_view('groups', 'block_user_profile_groups', [$user->id()]),
       ];
 

--- a/lib/themes/eic_community/includes/preprocess/users/user.inc
+++ b/lib/themes/eic_community/includes/preprocess/users/user.inc
@@ -171,7 +171,7 @@ function eic_community_preprocess_user(array &$variables) {
       ];
 
       $user_item['flagged_interests'] = [
-        'title' => t('My Interests'),
+        'title' => $current_user->id() === $user->id() ? t('My Interests') : t('Interests'),
         'items' => [],
       ];
       // Gets user topics of interest.
@@ -190,8 +190,14 @@ function eic_community_preprocess_user(array &$variables) {
       }
 
       $user_item['flagged_groups'] = [
-        'title' => t('My groups'),
-        'content' => _eic_community_get_rendered_view('groups', 'block_user_profile_groups', [$user->id()]),
+        'title' => $current_user->id() === $user->id() ? t('My groups') : t('Groups'),
+        'content' => $current_user->id() === $user->id()
+          ? _eic_community_get_rendered_view(
+            'groups',
+            'block_user_profile_my_groups',
+            [$user->id()]
+          )
+          : _eic_community_get_rendered_view('groups', 'block_user_profile_groups', [$user->id()]),
       ];
 
       $variables['user_item'] = $user_item;

--- a/lib/themes/eic_community/templates/user/user--full.html.twig
+++ b/lib/themes/eic_community/templates/user/user--full.html.twig
@@ -5,7 +5,7 @@
 {% include "@theme/patterns/compositions/member/member.full.html.twig" with user_item|default({})|merge({
   sidebar_title: 'Contact information'|t,
   flagged_interests: {
-    title: 'Interests'|t,
+    title: user_item.flagged_interests.title,
     content: user_interests,
   },
 }) %}


### PR DESCRIPTION
### Improvements

- Fix titles in user profile tabs.

### Tests

- [x] Go to the user profile detail page of your own current account and make sure you see the titles "My groups" and "My interests"
- [x] Go to the user profile detail page of another account besides your own and make sure you see the titles "Groups" and "Interests"