### PR TITLE
EICNET-1602: Fix URL aliases for group content entities

### DIFF
--- a/lib/modules/eic_content/modules/eic_content_book/src/Hooks/BookTokens.php
+++ b/lib/modules/eic_content/modules/eic_content_book/src/Hooks/BookTokens.php
@@ -88,7 +88,15 @@ class BookTokens implements ContainerInjectionInterface {
     foreach ($tokens as $name => $original) {
       switch ($name) {
         case 'node_book_parent_url':
-          if (($node = $data['node']) && !$node instanceof NodeInterface) {
+          // Grabs the node object from the data.
+          if (!empty($data['entity'])) {
+            $node = $data['entity'];
+          }
+          elseif (!empty($data['node'])) {
+            $node = $data['node'];
+          }
+
+          if (!$node instanceof NodeInterface) {
             break;
           }
 

--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Cache\Cache;
+use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityForm;
 use Drupal\Core\Entity\EntityInterface;
@@ -32,6 +33,7 @@ use Drupal\eic_groups\Hooks\Preprocess;
 use Drupal\eic_user\UserHelper;
 use Drupal\group\Access\GroupAccessResult;
 use Drupal\group\Entity\GroupContent;
+use Drupal\pathauto\PathautoGeneratorInterface;
 
 /**
  * Implements hook_theme().
@@ -161,6 +163,29 @@ function eic_groups_preprocess_views_view_field(&$vars) {
 function eic_groups_group_insert(EntityInterface $entity) {
   \Drupal::classResolver(EntityOperations::class)
     ->groupInsert($entity);
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_insert().
+ */
+function eic_groups_group_content_insert(EntityInterface $entity) {
+  $pathauto_config = \Drupal::config('pathauto.settings');
+  $related_entity = $entity->getEntity();
+  // Re-creates URL alias of the group content related entity if pathauto
+  // settings "update_action" setting is set to 0 (UPDATE_ACTION_NO_NEW).
+  if (
+    $pathauto_config->get('update_action') === PathautoGeneratorInterface::UPDATE_ACTION_NO_NEW &&
+    $related_entity->hasLinkTemplate('canonical') &&
+    $related_entity instanceof ContentEntityInterface &&
+    $related_entity->hasField('path') &&
+    $related_entity->getFieldDefinition('path')->getType() == 'path'
+  ) {
+    // Deletes old alias.
+    \Drupal::service('pathauto.alias_storage_helper')->deleteEntityPathAll($related_entity);
+    $related_entity->get('path')->first()->get('pathauto')->purge();
+    // Re-create entity alias.
+    \Drupal::service('pathauto.generator')->createEntityAlias($related_entity, 'insert');
+  }
 }
 
 /**


### PR DESCRIPTION
### Fixes

- Re-creates URL alias of the group content related entity if pathauto settings "update_action" setting is set to 0;
- Fix URL alias generation for patterns using "node_book_parent_url" token.

### Tests

- [x] Create a new group content (Discussion, wiki page, etc...)
- [x] Make sure the group content URL is prefixed with the group URL