### PR TITLE
EICNET-1860: Group latest activity

### DIFF
--- a/lib/modules/eic_comments/src/Constants/Comments.php
+++ b/lib/modules/eic_comments/src/Constants/Comments.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\eic_comments\Constants;
+
+/**
+ * Defines constants for comments stuff.
+ *
+ * @package Drupal\eic_comments\Constants
+ */
+final class Comments {
+
+  /**
+   * The default field for comments being used on nodes.
+   *
+   * @var string
+   */
+  const DEFAULT_NODE_COMMENTS_FIELD = 'field_comments';
+
+  /**
+   * The default comment type for comments being used on nodes.
+   *
+   * @var string
+   */
+  const DEFAULT_NODE_COMMENTS_TYPE = 'node_comment';
+
+}

--- a/lib/modules/eic_groups/src/EICGroupsHelper.php
+++ b/lib/modules/eic_groups/src/EICGroupsHelper.php
@@ -572,6 +572,31 @@ class EICGroupsHelper implements EICGroupsHelperInterface {
   }
 
   /**
+   * Returns the list of enabled group_node plugins for the given group type.
+   *
+   * @param \Drupal\group\Entity\GroupTypeInterface $group_type
+   *   The group type object.
+   *
+   * @return array
+   *   An array of plugin type IDs.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  public function getGroupTypeEnabledContentPlugins(GroupTypeInterface $group_type) {
+    $plugins = [];
+    /** @var \Drupal\node\NodeTypeInterface $node_type */
+    foreach ($this->entityTypeManager->getStorage('node_type')->loadMultiple() as $node_type) {
+      if ($this->isGroupTypePluginEnabled($group_type, 'group_node', $node_type->id())) {
+        // @todo Get real content type config id?
+        // @see \Drupal\group\Plugin\GroupContentEnablerBase::getContentTypeConfigId().
+        $plugins[] = $group_type->id() . '-group_node-' . $node_type->id();
+      }
+    }
+    return $plugins;
+  }
+
+  /**
    * Checks if a plugin is enabled for the given group type.
    *
    * @param \Drupal\group\Entity\GroupTypeInterface $group_type

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.module
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.module
@@ -96,6 +96,9 @@ function eic_group_statistics_comment_insert(EntityInterface $entity) {
 
   $group_content = reset($group_contents);
 
+  // Invalidate cache for group latest activity.
+  \Drupal::service('eic_group_statistics.helper')->invalidateGroupLatestActivity($group_content->getGroup());
+
   // Increments group comments statistic counter.
   \Drupal::service('eic_group_statistics.storage')->increment($group_content->getGroup(), GroupStatisticTypes::STAT_TYPE_COMMENTS);
 
@@ -127,6 +130,9 @@ function eic_group_statistics_comment_delete(EntityInterface $entity) {
   }
 
   $group_content = reset($group_contents);
+
+  // Invalidate cache for group latest activity.
+  \Drupal::service('eic_group_statistics.helper')->invalidateGroupLatestActivity($group_content->getGroup());
 
   // Decrements group comments statistic counter.
   \Drupal::service('eic_group_statistics.storage')->decrement($group_content->getGroup(), GroupStatisticTypes::STAT_TYPE_COMMENTS);
@@ -163,4 +169,19 @@ function eic_group_statistics_node_update(EntityInterface $entity) {
       break;
 
   }
+}
+
+/**
+ * Implements hook_views_data().
+ */
+function eic_group_statistics_views_data() {
+  $data['groups_field_data']['group_latest_activity'] = [
+    'title' => t('Group latest activity'),
+    'help' => t('Displays the group latest activity.'),
+    'field' => [
+      'id' => 'group_latest_activity',
+    ],
+  ];
+
+  return $data;
 }

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.module
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.module
@@ -157,6 +157,8 @@ function eic_group_statistics_node_update(EntityInterface $entity) {
     case 'wiki_page':
       // We need to make sure the node belongs to a group content, otherwise we
       // don't need to update any group statistics.
+      // @todo Make sure the group_content entity is the right one.
+      // See eic_share_content module which also creates group_content entities.
       $group_contents = GroupContent::loadByEntity($entity);
       if (!$group_contents) {
         return;

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.services.yml
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.services.yml
@@ -7,4 +7,4 @@ services:
     arguments: ['@eic_group_statistics.storage']
   eic_group_statistics.helper:
     class: Drupal\eic_group_statistics\GroupStatisticsHelper
-    arguments: ['@entity_type.manager', '@eic_group_statistics.storage']
+    arguments: ['@cache.default', '@entity_type.manager', '@eic_group_statistics.storage', '@eic_groups.helper']

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsHelper.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/GroupStatisticsHelper.php
@@ -2,13 +2,25 @@
 
 namespace Drupal\eic_group_statistics;
 
+use Drupal\comment\CommentInterface;
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\eic_comments\Constants\Comments;
+use Drupal\eic_groups\EICGroupsHelper;
 use Drupal\group\Entity\GroupInterface;
 
 /**
  * Service that provides helper functions for groups statistics.
  */
 class GroupStatisticsHelper implements GroupStatisticsHelperInterface {
+
+  /**
+   * Cache backend.
+   *
+   * @var \Drupal\Core\Cache\CacheBackendInterface
+   */
+  protected $cacheBackend;
 
   /**
    * The entity type manager service.
@@ -25,16 +37,34 @@ class GroupStatisticsHelper implements GroupStatisticsHelperInterface {
   protected $groupStatisticsStorage;
 
   /**
+   * The EIC Groups helper service.
+   *
+   * @var \Drupal\eic_groups\EICGroupsHelper
+   */
+  protected $groupsHelper;
+
+  /**
    * Constructs a GroupStatisticsHelper object.
    *
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
+   *   The cache backend.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager service.
    * @param \Drupal\eic_group_statistics\GroupStatisticsStorageInterface $group_statistics_storage
    *   The Group statistics storage service.
+   * @param \Drupal\eic_groups\EICGroupsHelper $groups_helper
+   *   The EIC group statistics helper service.
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, GroupStatisticsStorageInterface $group_statistics_storage) {
+  public function __construct(
+    CacheBackendInterface $cache_backend,
+    EntityTypeManagerInterface $entity_type_manager,
+    GroupStatisticsStorageInterface $group_statistics_storage,
+    EICGroupsHelper $groups_helper
+  ) {
+    $this->cacheBackend = $cache_backend;
     $this->entityTypeManager = $entity_type_manager;
     $this->groupStatisticsStorage = $group_statistics_storage;
+    $this->groupsHelper = $groups_helper;
   }
 
   /**
@@ -102,6 +132,163 @@ class GroupStatisticsHelper implements GroupStatisticsHelperInterface {
 
     // Update groups statistics.
     $this->groupStatisticsStorage->setMultipleGroupStatistics($groups_statistics);
+  }
+
+  /**
+   * Returns the date of the latest content activity for the given group.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group object.
+   * @param array $conditions
+   *   An array of conditions to apply to the group_content query, with field as
+   *   key and value as the value.
+   *   E.g. entity_id.entity:node.status => 1
+   *   Or entity_id.entity:node.uid => 123
+   *   Check \Drupal\Core\Entity\Query\QueryInterface.
+   *
+   * @return int|null
+   *   A timestamp or null if there are no results.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  protected function queryGroupLatestContentActivity(GroupInterface $group, array $conditions = []) {
+    $content_plugins = $this->groupsHelper->getGroupTypeEnabledContentPlugins($group->getGroupType());
+    $group_content_storage = $this->entityTypeManager->getStorage('group_content');
+
+    // We need to query on group_content entities to get the latest node.
+    $query = $group_content_storage->getQuery();
+    $query->condition('type', $content_plugins, 'IN');
+    $query->condition('gid', $group->id());
+    foreach ($conditions as $field => $value) {
+      $query->condition($field, $value);
+    }
+    $query->sort('entity_id.entity:node.created', 'DESC');
+    $query->range(0, 1);
+    $results = $query->execute();
+
+    if (!empty($results)) {
+      /** @var \Drupal\group\Entity\GroupContentInterface $group_content */
+      $group_content = $this->entityTypeManager->getStorage('group_content')->load(reset($results));
+      /** @var \Drupal\node\NodeInterface $node */
+      $node = $group_content->getEntity();
+      return $node->getCreatedTime();
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Returns the date of the latest comment activity for the given group.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group object.
+   * @param array $conditions
+   *   An array of conditions to apply to the group_content query, with field as
+   *   key and value as the value.
+   *   E.g. entity_id.entity:node.status => 1
+   *   Or entity_id.entity:node.uid => 123
+   *   Check \Drupal\Core\Entity\Query\QueryInterface.
+   *
+   * @return int|null
+   *   A timestamp or null if there are no results.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  protected function queryGroupLatestCommentActivity(GroupInterface $group, array $conditions = []) {
+    $content_plugins = $this->groupsHelper->getGroupTypeEnabledContentPlugins($group->getGroupType());
+    $group_content_storage = $this->entityTypeManager->getStorage('group_content');
+
+    // We need to query on group_content entities to get the list of nodes that
+    // may contain comments.
+    /** @var \Drupal\Core\Entity\Query\QueryInterface $query */
+    $query = $group_content_storage->getQuery();
+    $query->condition('type', $content_plugins, 'IN');
+    $query->condition('gid', $group->id());
+    foreach ($conditions as $field => $value) {
+      $query->condition($field, $value);
+    }
+    $query->exists('entity_id.entity:node.' . Comments::DEFAULT_NODE_COMMENTS_FIELD);
+    $results = $query->execute();
+
+    // Get the list of related nodes.
+    $node_ids = [];
+    /** @var \Drupal\group\Entity\GroupContentInterface $group_content */
+    foreach ($group_content_storage->loadMultiple($results) as $group_content) {
+      $node_ids[] = $group_content->getEntity()->id();
+    }
+
+    // Now we can query comments based on the list of nodes.
+    if (!empty($node_ids)) {
+      $comment_storage = $this->entityTypeManager->getStorage('comment');
+      $query = $comment_storage->getQuery();
+      $query->condition('entity_id', $node_ids, 'IN');
+      $query->condition('comment_type', Comments::DEFAULT_NODE_COMMENTS_TYPE);
+      $query->condition('field_name', Comments::DEFAULT_NODE_COMMENTS_FIELD);
+      $query->condition('status', CommentInterface::PUBLISHED);
+      $query->sort('created', 'DESC');
+      $query->range(0, 1);
+      $results = $query->execute();
+
+      // Return the created date of the last comment.
+      if (!empty($results)) {
+        /** @var \Drupal\comment\CommentInterface $comment */
+        $comment = $this->entityTypeManager->getStorage('comment')->load(reset($results));
+        return $comment->getCreatedTime();
+      }
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Returns the latest activity timestamp for the given group.
+   *
+   * Latest activity is calculated based on published nodes/comments.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group object.
+   *
+   * @return int|null
+   *   The timestamp of the latest activity.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  public function getGroupLatestActivity(GroupInterface $group) {
+    $cid = 'group_latest_activity:' . $group->id();
+
+    // Look for the item in cache.
+    if ($item = $this->cacheBackend->get($cid)) {
+      return $item->data;
+    }
+
+    // Get the highest value for activity.
+    $activity = [];
+    $conditions = [
+      'entity_id.entity:node.status' => 1,
+    ];
+    $activity[] = $this->queryGroupLatestContentActivity($group, $conditions);
+    $activity[] = $this->queryGroupLatestCommentActivity($group);
+    $latest_activity = max($activity);
+
+    // Cache the result.
+    $this->cacheBackend->set($cid, $latest_activity, Cache::PERMANENT);
+
+    return $latest_activity;
+  }
+
+  /**
+   * Invalidates the latest activity cache for the given group entity.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group entity.
+   */
+  public function invalidateGroupLatestActivity(GroupInterface $group) {
+    // Invalidate cache for group latest activity.
+    $cid = 'group_latest_activity:' . $group->id();
+    $this->cacheBackend->invalidate($cid);
   }
 
 }

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/Plugin/views/field/GroupLatestActivity.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/Plugin/views/field/GroupLatestActivity.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Drupal\eic_group_statistics\Plugin\views\field;
+
+use Drupal\group\Entity\GroupInterface;
+use Drupal\views\Plugin\views\field\Date;
+use Drupal\views\ResultRow;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * A handler to provide a field for group latest activity.
+ *
+ * @ingroup views_field_handlers
+ *
+ * @ViewsField("group_latest_activity")
+ */
+class GroupLatestActivity extends Date {
+
+  /**
+   * The EIC Groups statistics helper service.
+   *
+   * @var \Drupal\eic_group_statistics\GroupStatisticsHelper
+   */
+  protected $groupsStatisticsHelper;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance->groupsStatisticsHelper = $container->get('eic_group_statistics.helper');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    // Do nothing -- to override the parent query.
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getValue(ResultRow $values, $field = NULL) {
+    $group = $values->_entity;
+    if (!$group instanceof GroupInterface) {
+      return NULL;
+    }
+
+    return $this->groupsStatisticsHelper->getGroupLatestActivity($group);
+  }
+
+}


### PR DESCRIPTION
### Improvements

- Provide logic to calculate group latest activity, with cache
- Provide a views field plugin to display the value

### Tests

- [ ] Create a test view based on group entity
- [ ] Add the `Group latest activity` field to the view (display also seconds for better testing)
- [x] Add a content to a group
- [x] Add a second content to a group => check that the field is updated with the new date
- [x] Add a comment to a content of the group => check that the field is updated with the new date
- [x] Delete the last content created in the group => check that the field is updated with the new date (should be older)

### Remarks

- The date should also be updated when deleting a comment, but since we don't hard-delete comments, it doesn't apply