### PR TITLE
EICNET-1649: Display local tasks in a select field (rework)

### DIFF
--- a/config/sync/user.role.content_administrator.yml
+++ b/config/sync/user.role.content_administrator.yml
@@ -22,6 +22,7 @@ permissions:
   - 'access toolbar'
   - 'access user profiles'
   - 'add content to books'
+  - 'administer book outlines'
   - 'administer comments'
   - 'administer menu'
   - 'administer message templates'

--- a/config/sync/user.role.site_admin.yml
+++ b/config/sync/user.role.site_admin.yml
@@ -22,6 +22,7 @@ permissions:
   - 'access toolbar'
   - 'access user profiles'
   - 'add content to books'
+  - 'administer book outlines'
   - 'administer comments'
   - 'administer menu'
   - 'administer message templates'

--- a/lib/modules/eic_content/modules/eic_content_book/eic_content_book.module
+++ b/lib/modules/eic_content/modules/eic_content_book/eic_content_book.module
@@ -11,6 +11,7 @@
 
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\eic_content_book\Hooks\BookTokens;
 use Drupal\eic_content_book\Hooks\EntityOperations;
@@ -48,4 +49,14 @@ function eic_content_book_tokens($type, $tokens, array $data, array $options, Bu
   /** @var \Drupal\eic_content_book\Hooks\BookTokens $class */
   $class = \Drupal::classResolver(BookTokens::class);
   return $class->tokens($type, $tokens, $data, $options, $bubbleable_metadata);
+}
+
+/**
+ * Implements hook_form_alter().
+ */
+function eic_content_book_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  if (strpos($form_id, '_book_outline_form') !== FALSE) {
+    // We don't allow users to select the book.
+    $form['book']['bid']['#access'] = FALSE;
+  }
 }

--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
@@ -211,7 +211,6 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
       $operation_links['anonymous_user_link'] = $login_link;
     }
 
-    $this->processInviteUserPermission($group, $user_operation_links);
     $this->processLeaveGroupPermission($group, $user_operation_links);
 
     // Moves group joining methods operations to the operation_links array.
@@ -391,33 +390,6 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
     }
 
     return $group_flags;
-  }
-
-  /**
-   * Removes the invite members link.
-   *
-   * If group does not allow to invite members, hide invite group link from the
-   * group header.
-   *
-   * @param \Drupal\group\Entity\GroupInterface $group
-   *   The group entity.
-   * @param array $user_operation_links
-   *   Array of user operation links.
-   */
-  private function processInviteUserPermission(GroupInterface $group, array &$user_operation_links) {
-    $key = 'invite-user';
-
-    if (!array_key_exists($key, $user_operation_links)) {
-      return;
-    }
-
-    $user_can_invite = (int) $group->get('field_group_invite_members')->value;
-
-    if ($user_can_invite) {
-      return;
-    }
-
-    unset($user_operation_links[$key]);
   }
 
   /**


### PR DESCRIPTION
### Improvements

- Fix access to invite users when user is not a member of a group and also depending on the group status.
- Allow SA/SCM users to update book outlines.

### Tests

Invite members:

- [x] As GO of a public group, edit the group and enable the option "Invite members"
- [x] As TU and not member of the group, navigate to the group page and make sure the link to invite member is not visible and you cannot access the form via URL
- [x] Join the group, and make sure you can now see the link to invite a member in the group header 
- [x] As SA/SCM, send the group back to the pending status
- [x] As GO, make sure the link to invite member is not shown and you cannot access the form to invite a member via URL
- [x] As SA/SCM, change the group status to draft
- [x] As GO, make sure you can now see the link to invite a member in the group header and you can access the form to invite a member 

Book outline

- [x] As SA/SCM, navigate to a wiki page of a group
- [x] Make sure you can see the link "Outline" via the "Manage content" dropdown