### PR TITLE
EICNET-1369: EICNET-1369 Adapt comment section on video detail page (rework)

### DIFF
--- a/lib/modules/eic_content/src/Hooks/EntityOperationsContributor.php
+++ b/lib/modules/eic_content/src/Hooks/EntityOperationsContributor.php
@@ -208,6 +208,9 @@ class EntityOperationsContributor implements ContainerInjectionInterface {
     $query->condition('c.entity_type', 'node');
     // Skip anonymous users.
     $query->condition('c.uid', 0, '<>');
+    // Skip contributors with deleted comments.
+    $query->join('comment__field_comment_is_soft_deleted', 'csf', 'c.cid = csf.entity_id');
+    $query->condition('csf.field_comment_is_soft_deleted_value', FALSE);
     // We group by uid to avoid duplicated results.
     $query->groupBy('c.uid');
     $results = $query->execute()->fetchAll(\PDO::FETCH_ASSOC);

--- a/lib/modules/eic_groups/src/Plugin/Block/CommentsFromDiscussionBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/CommentsFromDiscussionBlock.php
@@ -284,7 +284,7 @@ class CommentsFromDiscussionBlock extends BlockBase implements ContainerFactoryP
         ),
       ],
       'translations' => [
-        'title' => $this->t('Comments', [], ['context' => 'eic_groups']),
+        'title' => $this->t('Replies', [], ['context' => 'eic_groups']),
         'no_results_title' => $this->t(
           "We haven't found any comments",
           [],


### PR DESCRIPTION
### Improvements

- Show users who commented nodes as contributors next to the comment section;
- Change comment section title to "Replies"
- Fix cache issues when showing the comment avatar after user logs in with a different account;
- Fix coding standards.

### Tests

- [x] As TU/GM, go to a discussion/document/video detail page where comments are enabled and check if the title of the section is "Replies" instead of "Comments"
- [x] Place a new comment
- [x] Refresh the page and make sure the user avatar is shown in the contributors next to the comment section
- [x] Login as a different GM, go to the discussion/document/video detail page and make sure your avatar is shown next to the comment textbox and not the avatar from the previous logged in GM
- [x] As SA/SCM, remove the comment (soft delete) and make sure the TU/GM is not shown anymore in the list of contributors after refreshing the page