### PR TITLE
EICNET-852: Overview page banner (rework)

### DIFF
--- a/lib/modules/eic_overviews/src/Entity/OverviewPage.php
+++ b/lib/modules/eic_overviews/src/Entity/OverviewPage.php
@@ -26,7 +26,7 @@ use Drupal\eic_overviews\OverviewPageInterface;
  *       "delete" = "Drupal\Core\Entity\ContentEntityDeleteForm"
  *     },
  *     "route_provider" = {
- *       "html" = "Drupal\Core\Entity\Routing\AdminHtmlRouteProvider",
+ *       "html" = "Drupal\eic_overviews\OverviewPageHtmlRouteProvider",
  *     }
  *   },
  *   base_table = "overview_page",

--- a/lib/modules/eic_overviews/src/OverviewPageHtmlRouteProvider.php
+++ b/lib/modules/eic_overviews/src/OverviewPageHtmlRouteProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\eic_overviews;
+
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\Routing\AdminHtmlRouteProvider;
+
+/**
+ * Provides HTML routes for overview page entities.
+ *
+ * @see \Drupal\Core\Entity\Routing\AdminHtmlRouteProvider.
+ */
+class OverviewPageHtmlRouteProvider extends AdminHtmlRouteProvider {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getCollectionRoute(EntityTypeInterface $entity_type) {
+    $route = parent::getCollectionRoute($entity_type);
+    $route->setRequirement('_permission', 'access overview page overview');
+    return $route;
+  }
+
+}


### PR DESCRIPTION
### Improvements

- Create OverviewPageHtmlRouteProvider class to set permission requirement when access overview page collection route.

### Tests

- [x] As SA/SCM, make sure you can access the list of overview pages via the administration menu or via URL -> `/admin/community/overview-pages`