### PR TITLE
EICNET-1699: SA & SCM cannot add documents to a blocked group

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3703,7 +3703,7 @@
                     "2881769 - group/{group}/node/create uses the permissions of group/{group}/node/add": "https://www.drupal.org/files/issues/2020-10-01/2881769-22.patch",
                     "2746839 - Add Devel plugin for generating groups": "patches/group/2746839-add-devel-plugin-for-generating-groups-12.patch",
                     "2815971 - More contexts needed": "https://www.drupal.org/files/issues/2021-02-19/2815971-28.patch",
-                    "3071489 - Incorrect Access Check on Media Library": "https://www.drupal.org/files/issues/2020-02-27/incorrect-access-check-on-media-library-3071489-9.patch",
+                    "3071489 - Incorrect Access Check on Media Library": "https://www.drupal.org/files/issues/2022-01-11/incorrect-access-check-on-media-library-3071489-24.patch",
                     "3132084 - Add/Remove group role for a user programmatically": "https://www.drupal.org/files/issues/2021-08-23/3132084-10.patch"
                 }
             },

--- a/composer.lock
+++ b/composer.lock
@@ -3703,7 +3703,7 @@
                     "2881769 - group/{group}/node/create uses the permissions of group/{group}/node/add": "https://www.drupal.org/files/issues/2020-10-01/2881769-22.patch",
                     "2746839 - Add Devel plugin for generating groups": "patches/group/2746839-add-devel-plugin-for-generating-groups-12.patch",
                     "2815971 - More contexts needed": "https://www.drupal.org/files/issues/2021-02-19/2815971-28.patch",
-                    "3071489 - Incorrect Access Check on Media Library": "https://www.drupal.org/files/issues/2022-01-11/incorrect-access-check-on-media-library-3071489-24.patch",
+                    "3071489 - Incorrect Access Check on Media Library": "https://www.drupal.org/files/issues/2022-01-11/incorrect-access-check-on-media-library-3071489-25.patch",
                     "3132084 - Add/Remove group role for a user programmatically": "https://www.drupal.org/files/issues/2021-08-23/3132084-10.patch"
                 }
             },

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -20,7 +20,7 @@
       "2881769 - group/{group}/node/create uses the permissions of group/{group}/node/add": "https://www.drupal.org/files/issues/2020-10-01/2881769-22.patch",
       "2746839 - Add Devel plugin for generating groups": "patches/group/2746839-add-devel-plugin-for-generating-groups-12.patch",
       "2815971 - More contexts needed": "https://www.drupal.org/files/issues/2021-02-19/2815971-28.patch",
-      "3071489 - Incorrect Access Check on Media Library": "https://www.drupal.org/files/issues/2020-02-27/incorrect-access-check-on-media-library-3071489-9.patch",
+      "3071489 - Incorrect Access Check on Media Library": "https://www.drupal.org/files/issues/2022-01-11/incorrect-access-check-on-media-library-3071489-25.patch",
       "3132084 - Add/Remove group role for a user programmatically": "https://www.drupal.org/files/issues/2021-08-23/3132084-10.patch"
     },
     "drupal/group_content_menu": {


### PR DESCRIPTION
### Improvements

- Apply patch to fix access issues when selecting a media in a blocked group.

### Test

- [x] As SA/SCM, try to add a document to a group where you're **not** a member
- [x] Make sure you can select medias or upload new ones using the media library widget