### PR TITLE
EICNET-1761: Fix footer menu links

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/layout/page.inc
+++ b/lib/themes/eic_community/includes/preprocess/layout/page.inc
@@ -133,6 +133,11 @@ function eic_community_preprocess_page(array &$variables): void {
       $section['section_class_name'] = 'ecl-footer-core__section--separator';
     }
 
+    // If there are more than 3 links, we need to split the menu in 2 columns.
+    if (count($links) > 3) {
+      $section['list_class_name'] = 'ecl-footer-core__list--columns';
+    }
+
     $footer_sections[] = $section;
   }
 


### PR DESCRIPTION
### Improvements

- Split footer menu links in 2 columns if there are more than 3 links.

### Tests

- [x] Create more than 3 menu links in the European Union menu
- [x] Go to the site homepage
- [x] Make sure the European Union menu (in the footer region) is splitted in 2 columns