### PR TITLE
EICNET-1689: Homepage last updated groups (rework 2)

### DIFF
--- a/config/sync/views.view.groups_homepage.yml
+++ b/config/sync/views.view.groups_homepage.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - search_api.index.global
   module:
+    - eic_search
     - search_api
 id: groups_homepage
 label: 'Groups - Homepage'
@@ -15,23 +16,73 @@ base_table: search_api_index_global
 base_field: search_api_id
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Default
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: none
-        options: {  }
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
+      title: 'Most active groups'
+      fields:
+        aggregated_changed:
+          id: aggregated_changed
+          table: search_api_index_global
+          field: aggregated_changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: search_api
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          link_to_item: false
+          use_highlighting: false
+          multi_type: separator
+          multi_separator: ', '
+      pager:
+        type: some
         options:
-          bypass_access: false
-          skip_access: false
-          preserve_facet_query_args: false
+          offset: 0
+          items_per_page: 3
       exposed_form:
         type: basic
         options:
@@ -42,11 +93,193 @@ display:
           expose_sort_order: true
           sort_asc_label: Asc
           sort_desc_label: Desc
-      pager:
-        type: some
-        options:
-          items_per_page: 3
-          offset: 0
+      access:
+        type: none
+        options: {  }
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        group_changed:
+          id: group_changed
+          table: search_api_index_global
+          field: group_changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: group_changed
+          exposed: false
+      arguments: {  }
+      filters:
+        search_api_datasource:
+          id: search_api_datasource
+          table: search_api_index_global
+          field: search_api_datasource
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_datasource
+          operator: or
+          value:
+            'entity:group': 'entity:group'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+        group_status:
+          id: group_status
+          table: search_api_index_global
+          field: group_status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        group_type:
+          id: group_type
+          table: search_api_index_global
+          field: group_type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_options
+          operator: or
+          value:
+            group: group
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+        group_moderation_state:
+          id: group_moderation_state
+          table: search_api_index_global
+          field: group_moderation_state
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_string
+          operator: '='
+          value:
+            min: ''
+            max: ''
+            value: published
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            min_placeholder: ''
+            max_placeholder: ''
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       style:
         type: default
       row:
@@ -131,241 +364,18 @@ display:
               wiki_page: default
             'entity:user':
               user: default
-      fields:
-        aggregated_changed:
-          table: search_api_index_global
-          field: aggregated_changed
-          id: aggregated_changed
-          entity_type: null
-          entity_field: null
-          plugin_id: search_api
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: ''
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          link_to_item: false
-          use_highlighting: false
-          multi_type: separator
-          multi_separator: ', '
-      filters:
-        search_api_datasource:
-          id: search_api_datasource
-          table: search_api_index_global
-          field: search_api_datasource
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: or
-          value:
-            'entity:group': 'entity:group'
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            reduce: false
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          reduce_duplicates: false
-          plugin_id: search_api_datasource
-        group_status:
-          id: group_status
-          table: search_api_index_global
-          field: group_status
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: '1'
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          plugin_id: search_api_boolean
-        group_type:
-          id: group_type
-          table: search_api_index_global
-          field: group_type
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: or
-          value:
-            group: group
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            reduce: false
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          reduce_duplicates: false
-          plugin_id: search_api_options
-        group_moderation_state:
-          id: group_moderation_state
-          table: search_api_index_global
-          field: group_moderation_state
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value:
-            min: ''
-            max: ''
-            value: published
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            placeholder: ''
-            min_placeholder: ''
-            max_placeholder: ''
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          plugin_id: search_api_string
-      sorts:
-        group_changed:
-          id: group_changed
-          table: search_api_index_global
-          field: group_changed
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: DESC
-          exposed: false
-          expose:
-            label: ''
-          plugin_id: search_api
-      title: 'Most active groups'
+      query:
+        type: views_query
+        options:
+          bypass_access: false
+          skip_access: false
+          preserve_facet_query_args: false
+      relationships: {  }
+      use_more: true
+      use_more_always: false
+      use_more_text: 'View all groups'
+      link_display: custom_url
+      link_url: /groups
       header:
         area_text_custom:
           id: area_text_custom
@@ -374,20 +384,12 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          empty: false
-          tokenize: false
-          content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'
           plugin_id: text_custom
+          empty: false
+          content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'
+          tokenize: false
       footer: {  }
-      empty: {  }
-      relationships: {  }
-      arguments: {  }
       display_extenders: {  }
-      use_more: true
-      use_more_always: false
-      use_more_text: 'View all groups'
-      link_url: /groups
-      link_display: custom_url
     cache_metadata:
       max-age: -1
       contexts:
@@ -396,24 +398,41 @@ display:
       tags:
         - 'config:search_api.index.global'
   block_events_homepage:
-    display_plugin: block
     id: block_events_homepage
     display_title: 'Block - Events homepage'
+    display_plugin: block
     position: 1
     display_options:
-      display_extenders: {  }
-      display_description: ''
       title: 'Upcoming events'
-      defaults:
-        title: false
-        filters: false
-        filter_groups: false
-        sorts: false
-        link_display: false
-        link_url: false
-        header: false
-        empty: false
-        cache: false
+      cache:
+        type: search_api_tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: 'Currently there are no upcoming events.'
+          tokenize: false
+      sorts:
+        group_field_date_range:
+          id: group_field_date_range
+          table: search_api_index_global
+          field: group_field_date_range
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: group_field_date_range
+          exposed: false
       filters:
         search_api_datasource:
           id: search_api_datasource
@@ -422,6 +441,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: search_api_datasource
           operator: or
           value:
             'entity:group': 'entity:group'
@@ -455,7 +475,6 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          plugin_id: search_api_datasource
         group_status:
           id: group_status
           table: search_api_index_global
@@ -463,6 +482,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: search_api_boolean
           operator: '='
           value: '1'
           group: 1
@@ -493,7 +513,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: search_api_boolean
         group_type:
           id: group_type
           table: search_api_index_global
@@ -501,6 +520,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: search_api_options
           operator: or
           value:
             event: event
@@ -534,7 +554,6 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          plugin_id: search_api_options
         group_moderation_state:
           id: group_moderation_state
           table: search_api_index_global
@@ -542,6 +561,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: search_api_string
           operator: '='
           value:
             min: ''
@@ -563,9 +583,9 @@ display:
             multiple: false
             remember_roles:
               authenticated: authenticated
-            placeholder: ''
             min_placeholder: ''
             max_placeholder: ''
+            placeholder: ''
           is_grouped: false
           group_info:
             label: ''
@@ -578,7 +598,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: search_api_string
         group_field_date_range_end_value:
           id: group_field_date_range_end_value
           table: search_api_index_global
@@ -586,6 +605,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: search_api_date
           operator: '>='
           value:
             min: ''
@@ -608,9 +628,9 @@ display:
             multiple: false
             remember_roles:
               authenticated: authenticated
-            placeholder: ''
             min_placeholder: ''
             max_placeholder: ''
+            placeholder: ''
           is_grouped: false
           group_info:
             label: ''
@@ -623,42 +643,25 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: search_api_date
       filter_groups:
         operator: AND
         groups:
           1: AND
-      sorts:
-        group_field_date_range:
-          id: group_field_date_range
-          table: search_api_index_global
-          field: group_field_date_range
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-          plugin_id: search_api
+      defaults:
+        empty: false
+        cache: false
+        title: false
+        link_display: false
+        link_url: false
+        sorts: false
+        filters: false
+        filter_groups: false
+        header: false
+      display_description: ''
       link_display: custom_url
       link_url: /events
       header: {  }
-      empty:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content: 'Currently there are no upcoming events.'
-          plugin_id: text_custom
-      cache:
-        type: search_api_tag
-        options: {  }
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -667,26 +670,23 @@ display:
       tags:
         - 'config:search_api.index.global'
   block_groups_homepage:
-    display_plugin: block
     id: block_groups_homepage
     display_title: 'Block - Groups homepage'
+    display_plugin: block
     position: 1
     display_options:
-      display_extenders: {  }
-      display_description: ''
       cache:
-        type: search_api_time
-        options:
-          results_lifespan: 3600
-          results_lifespan_custom: 0
-          output_lifespan: 3600
-          output_lifespan_custom: 0
+        type: search_api_tag_per_user
+        options: {  }
       defaults:
         cache: false
+      display_description: ''
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
         - 'languages:language_interface'
+        - user
         - 'user.node_grants:view'
       tags:
         - 'config:search_api.index.global'

--- a/lib/modules/eic_search/src/Plugin/views/cache/SearchApiTagCachePerUser.php
+++ b/lib/modules/eic_search/src/Plugin/views/cache/SearchApiTagCachePerUser.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\eic_search\Plugin\views\cache;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\search_api\Plugin\views\cache\SearchApiTagCache;
+
+/**
+ * Defines a tag-based per user cache plugin for use with Search API views.
+ *
+ * @see SearchApiTagCache
+ *
+ * @ingroup views_cache_plugins
+ *
+ * @ViewsCache(
+ *   id = "search_api_tag_per_user",
+ *   title = @Translation("Search API (tag-based per user)"),
+ *   help = @Translation("Cache results until the associated cache tags are invalidated. Useful for small sites that use the database search backend. <strong>Caution:</strong> Can lead to stale results and might harm performance for complex search pages.")
+ * )
+ */
+class SearchApiTagCachePerUser extends SearchApiTagCache {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterCacheMetadata(CacheableMetadata $cache_metadata) {
+    parent::alterCacheMetadata($cache_metadata);
+    // Add cache context per user.
+    $cache_metadata->addCacheContexts(['user']);
+  }
+
+}


### PR DESCRIPTION
### Bug fixes

- Change groups homepage view cache to tag based per user because group visibility can be changed and there is an issue where anonymous users can see private groups in the list.

### Tests

- [x] As anonymous, go to the homepage and make sure you see only public groups
- [x] Login as SA/SCM
- [x] Change one of the public groups that shows in the homepage for anonymous users. Change the group to private.
- [x] Log out and navigate to the homepage
- [x] Make sure the private group is not shown in the homepage 