### PR TITLE
EICNET-1927: TU cannot create draft from published story

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2513,7 +2513,8 @@
                 },
                 "patches_applied": {
                     "3007424 - Multiple usages of FieldPluginBase::getEntity do not check for NULL, leading to WSOD": "https://www.drupal.org/files/issues/2021-01-06/3007424-108.patch",
-                    "2973863 - ValidReferenceConstraintValidator should not try to enforce data integrity on pre-existing references": "https://www.drupal.org/files/issues/2018-11-04/2973863-24.patch"
+                    "2973863 - ValidReferenceConstraintValidator should not try to enforce data integrity on pre-existing references": "https://www.drupal.org/files/issues/2018-11-04/2973863-24.patch",
+                    "2918537 - Cannot save unpublished versions of published content for users without manage book privileges": "https://www.drupal.org/files/issues/2021-11-16/2918537-68.patch"
                 }
             },
             "autoload": {

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -2,7 +2,8 @@
   "patches": {
     "drupal/core": {
       "3007424 - Multiple usages of FieldPluginBase::getEntity do not check for NULL, leading to WSOD": "https://www.drupal.org/files/issues/2021-01-06/3007424-108.patch",
-      "2973863 - ValidReferenceConstraintValidator should not try to enforce data integrity on pre-existing references": "https://www.drupal.org/files/issues/2018-11-04/2973863-24.patch"
+      "2973863 - ValidReferenceConstraintValidator should not try to enforce data integrity on pre-existing references": "https://www.drupal.org/files/issues/2018-11-04/2973863-24.patch",
+      "2918537 - Cannot save unpublished versions of published content for users without manage book privileges": "https://www.drupal.org/files/issues/2021-11-16/2918537-68.patch"
     },
     "drupal/address": {
       "2812659 - Integrate Address with Search API (adds a Search API processor to convert country code to full country name)": "https://www.drupal.org/files/issues/2021-06-14/integrate-address-searchapi-2812659-57_0.patch"

--- a/config/sync/user.role.content_administrator.yml
+++ b/config/sync/user.role.content_administrator.yml
@@ -112,6 +112,7 @@ permissions:
   - 'view all revisions'
   - 'view any member profile'
   - 'view any profile'
+  - 'view latest version'
   - 'view news revisions'
   - 'view own member profile'
   - 'view own profile'

--- a/config/sync/user.role.trusted_user.yml
+++ b/config/sync/user.role.trusted_user.yml
@@ -48,6 +48,7 @@ permissions:
   - 'use text format filtered_html'
   - 'view any member profile'
   - 'view any profile'
+  - 'view latest version'
   - 'view own member profile'
   - 'view own profile'
   - 'view own unpublished content'


### PR DESCRIPTION
### Fixes

- Apply patch to fix issue where user cannot save draft version of a published story because of book privileges.
- Allow content owners to access latest revision.

### Tests

- [x] As TU, create a new story
- [x] As SA/SCM, publish the story
- [x] As TU, edit the story and create a new draft
- [x] Check that you have access to the latest revision /stories/story-name/latest