### PR TITLE
EICNET-1754: Footer site name

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/layout/page.inc
+++ b/lib/themes/eic_community/includes/preprocess/layout/page.inc
@@ -78,13 +78,13 @@ function eic_community_preprocess_page(array &$variables): void {
 
   $first_section = array_shift($first_section);
 
-  if (!empty($block_content['#derivative_plugin_id'])) {
+  if (!empty($first_section['#derivative_plugin_id'])) {
     $block_content = \Drupal::service('entity.repository')
       ->loadEntityByUuid('block_content', $first_section['#derivative_plugin_id']);
 
     $footer_sections[] = [
       'title' => $block_content->field_title->value,
-      'description' => strip_tags($block_content->body->value),
+      'description' => $block_content->body->value,
     ];
   }
 
@@ -92,20 +92,6 @@ function eic_community_preprocess_page(array &$variables): void {
     return strpos($key, 'menu') !== FALSE;
   }, ARRAY_FILTER_USE_BOTH);
   $menu_sections = array_values($menu_sections);
-
-  $footer_sections[] = [
-    'title' => t(
-      '@site_name Community',
-      ['@site_name' => \Drupal::config('system.site')->get('name')],
-      ['context' => 'eic_community']
-    ),
-    'description' => t(
-      'This site is managed by the Directorate-General for Communication',
-      [],
-      ['context' => 'eic_community']
-    ),
-    'list_class_name' => 'ecl-footer-core__section ecl-footer-core__section1',
-  ];
 
   foreach ($menu_sections as $key => $menu) {
     $menu_name = $menu['#derivative_plugin_id'];

--- a/lib/themes/eic_community/includes/preprocess/layout/page.inc
+++ b/lib/themes/eic_community/includes/preprocess/layout/page.inc
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Menu\MenuTreeParameters;
+use Drupal\Core\Render\Markup;
 use Drupal\Core\Template\Attribute;
 use Drupal\Core\Url;
 use Drupal\eic_community\ValueObject\ImageValueObject;
@@ -84,7 +85,7 @@ function eic_community_preprocess_page(array &$variables): void {
 
     $footer_sections[] = [
       'title' => $block_content->field_title->value,
-      'description' => $block_content->body->value,
+      'description' => Markup::create($block_content->body->value),
     ];
   }
 


### PR DESCRIPTION
### Fixes

- Add footer site info block to the footer section.

### Tests

- [x] Go to the homepage
- [x] Make sure the first section in the footer shows the **Footer - Site info** (from `/admin/content/block-content`)

### Todo:

- [x] The description html tags are shown as plain text and this needs to be fixed in the template (`site-footer.html.twig`)