### PR TITLE
EICNET-1937: Custom restriction visibility options not shown in group add form

### DIFF
--- a/lib/modules/oec_group_flex/src/Plugin/GroupVisibility/CustomRestrictedVisibility.php
+++ b/lib/modules/oec_group_flex/src/Plugin/GroupVisibility/CustomRestrictedVisibility.php
@@ -128,20 +128,19 @@ class CustomRestrictedVisibility extends RestrictedGroupVisibilityBase implement
       ],
     ];
 
-    $group_visibility_record = NULL;
+    $group_visibility_record = FALSE;
     if (!$group->isNew()) {
       $group_visibility_record = $this->groupVisibilityStorage->load($group->id());
+    }
+
+    // We force the group visibility to NULL if not found.
+    if (!$group_visibility_record) {
+      $group_visibility_record = NULL;
     }
 
     /** @var \Drupal\oec_group_flex\Plugin\CustomRestrictedVisibilityBase $pluginInstance */
     foreach ($this->plugins as $id => $pluginInstance) {
       foreach ($pluginInstance->getPluginForm() as $pluginForm) {
-
-        // In some rare cases, group_visibility_record is null.
-        if (!$group_visibility_record) {
-          continue;
-        }
-
         $form[$form_fields_container][$id] = $pluginInstance->setDefaultFormValues($pluginForm, $group_visibility_record);
       }
     }


### PR DESCRIPTION
### Fixes

- Fix issue where custom restriction visibility options were not shown in group add form;
- Fix error when editing a group without visibility.

### Tests

- [x] As SA/SCM, try to create a group and select the custom restricted visibility
- [x] Make sure the custom restricted options are shown in the form