### PR TITLE
EICNET-962: Group alias update create redirects (rework group content node URL alias)

### DIFF
--- a/lib/modules/eic_groups/src/Plugin/QueueWorker/GroupContentUrlAliasUpdate.php
+++ b/lib/modules/eic_groups/src/Plugin/QueueWorker/GroupContentUrlAliasUpdate.php
@@ -6,8 +6,10 @@ use Drupal\Core\Cache\Cache;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Queue\QueueWorkerBase;
 use Drupal\group\Entity\GroupContent;
+use Drupal\group\Entity\GroupContentInterface;
 use Drupal\node\NodeInterface;
 use Drupal\pathauto\PathautoGeneratorInterface;
+use Drupal\redirect\Entity\Redirect;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -70,12 +72,53 @@ class GroupContentUrlAliasUpdate extends QueueWorkerBase implements ContainerFac
     // Update url alias of node that belongs to the group content that is
     // being processed.
     if (($node = $group_content->getEntity()) && $node instanceof NodeInterface) {
-      $this->pathautoGenerator->updateEntityAlias($node, 'update');
-      Cache::invalidateTags($node->getCacheTags());
+      $this->updateNodeAlias($node);
     }
 
-    // Update url alias of the group content.
-    $this->pathautoGenerator->updateEntityAlias($group_content, 'update');
+    // Update url alias of group content.
+    $this->updateGroupContentAlias($group_content);
+  }
+
+  /**
+   * Updates node URL alias and creates a new redirect.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node entity.
+   */
+  private function updateNodeAlias(NodeInterface $node) {
+    $current_alias = $node->get('path')->alias;
+    // Deletes old alias.
+    \Drupal::service('pathauto.alias_storage_helper')->deleteEntityPathAll($node);
+    // Re-create entity alias.
+    $new_alias = $this->pathautoGenerator->createEntityAlias($node, 'insert');
+    // Delete all redirects having the same source as this alias.
+    redirect_delete_by_path($new_alias['alias'], $new_alias['langcode'], FALSE);
+    // Creates a new redirect.
+    if ($current_alias != $new_alias['alias']) {
+      if (!redirect_repository()->findMatchingRedirect($current_alias, [], $node->language()->getId())) {
+        $redirect = Redirect::create();
+        $redirect->setSource($node->get('path')->alias);
+        $redirect->setRedirect($new_alias['alias']);
+        $redirect->setLanguage($new_alias['langcode']);
+        $redirect->setStatusCode(303);
+        $redirect->save();
+      }
+    }
+    // Invalidates node cache tags.
+    Cache::invalidateTags($node->getCacheTags());
+  }
+
+  /**
+   * Updates group content URL alias.
+   *
+   * @param \Drupal\group\Entity\GroupContentInterface $group_content
+   *   The group content entity.
+   */
+  private function updateGroupContentAlias(GroupContentInterface $group_content) {
+    // Deletes old group content URL alias.
+    \Drupal::service('pathauto.alias_storage_helper')->deleteEntityPathAll($group_content);
+    // Re-create group content URL alias.
+    $this->pathautoGenerator->createEntityAlias($group_content, 'insert');
     Cache::invalidateTags($group_content->getCacheTags());
   }
 


### PR DESCRIPTION
### Fixes:

- Create redirect for the old group content node url alias when group alias changes.

### Tests

- [x] As SA/SCM, edit a group and change it's URL alias to a manual one
- [x] Go to a discussion detail page of that group and save the URL of the page somewhere
- [x] Run cron
- [x] Go to the old URL of the discussion
- [ ] Make sure you get redirected to the new URL alias of the discussion which includes the group URL alias change