### PR TITLE
EICNET-1835: Fix title in user profile tab "My interests"

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/users/user.inc
+++ b/lib/themes/eic_community/includes/preprocess/users/user.inc
@@ -171,7 +171,7 @@ function eic_community_preprocess_user(array &$variables) {
       ];
 
       $user_item['flagged_interests'] = [
-        'title' => $current_user->id() === $user->id() ? t('My Interests') : t('Interests'),
+        'title' => $current_user->id() === $user->id() ? t('My interests') : t('Interests'),
         'items' => [],
       ];
       // Gets user topics of interest.
@@ -191,9 +191,10 @@ function eic_community_preprocess_user(array &$variables) {
 
       $user_item['flagged_groups'] = [
         'title' => $current_user->id() === $user->id() ? t('My groups') : t('Groups'),
-        'content' => $current_user->id() === $user->id()
+        'content' => ($current_user->id() === $user->id()
           ? _eic_community_get_rendered_view('groups', 'block_user_profile_my_groups', [$user->id()])
-          : _eic_community_get_rendered_view('groups', 'block_user_profile_groups', [$user->id()]),
+          : _eic_community_get_rendered_view('groups', 'block_user_profile_groups', [$user->id()])
+        ),
       ];
 
       $variables['user_item'] = $user_item;


### PR DESCRIPTION
### Fixes

- Fix titles in user profile tab "My interests"

### Tests

- [x] Navigate to your own profile detail page
- [x] Make sure the title of the tab "My Interests" is "My interests" (non capitalized on the second word)