### PR TITLE
[EICNET-1634]fix: Handle events group menu active on detail

### DIFF
--- a/lib/modules/eic_groups/src/Plugin/Block/GroupMenuBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/GroupMenuBlock.php
@@ -128,6 +128,13 @@ class GroupMenuBlock extends GroupMenuBlockBase implements ContainerFactoryPlugi
         );
         break;
 
+      case 'event':
+        $url = GroupOverviewPages::getGroupOverviewPageUrl(
+          'events',
+          $group
+        );
+        break;
+
       case 'wiki_page':
         // Gets group wiki url.
         $group_book_page_nid = $this->eicGroupsHelper->getGroupBookPage($group);

--- a/lib/modules/eic_overviews/src/GroupOverviewPages.php
+++ b/lib/modules/eic_overviews/src/GroupOverviewPages.php
@@ -69,6 +69,10 @@ class GroupOverviewPages {
         $page_id = self::FILES;
         break;
 
+      case 'events':
+        $page_id = self::EVENTS;
+        break;
+
       case 'members':
         $page_id = self::MEMBERS;
         break;


### PR DESCRIPTION
How to test:

- [x] Clear your cache
- [x] Go to a group and navigate through a Event detail page
- [x] Check if "Events" menu item is active