### PR TITLE
[EICNET-1604]fix: Encapsulate the email FROm by <>

### DIFF
--- a/lib/modules/eic_private_message/src/Form/PrivateMessageForm.php
+++ b/lib/modules/eic_private_message/src/Form/PrivateMessageForm.php
@@ -117,7 +117,7 @@ class PrivateMessageForm extends FormBase {
         '"@fullname at @site_name" @site_email',
         [
           '@fullname' => $this->userHelper->getFullName(),
-          '@site_email' => $this->systemSettings->get('mail'),
+          '@site_email' => '<' . $this->systemSettings->get('mail') . '>',
           '@site_name' => $this->systemSettings->get('name'),
         ],
         ['context' => 'eic_private_message']


### PR DESCRIPTION
How to test:

- [ ] Contact a user
- [ ] Be sure you have "<>" around the email in the "FROM"

![image](https://user-images.githubusercontent.com/11585507/149669085-5d3965cb-5ce4-4214-8323-a2cf5270672c.png)
