### PR TITLE
EICNET-1920: Fix breadcrumb for News and Stories.

### DIFF
--- a/lib/modules/eic_content/src/ContentBreadcrumbBuilder.php
+++ b/lib/modules/eic_content/src/ContentBreadcrumbBuilder.php
@@ -8,6 +8,7 @@ use Drupal\Core\Link;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\eic_overviews\GlobalOverviewPages;
 use Drupal\node\NodeInterface;
 
 /**
@@ -69,13 +70,8 @@ class ContentBreadcrumbBuilder implements BreadcrumbBuilderInterface {
 
       switch ($node->bundle()) {
         case 'news':
-          // @todo Replace link route with overview page route when available.
-          $links[] = Link::createFromRoute($this->t('News'), '<front>');
-          break;
-
         case 'story':
-          // @todo Replace link route with overview page route when available.
-          $links[] = Link::createFromRoute($this->t('Stories'), '<front>');
+          $links[] = GlobalOverviewPages::getGlobalOverviewPageLink(GlobalOverviewPages::NEWS_STORIES);
           break;
 
       }


### PR DESCRIPTION
### Tests

- [x] Go on a Story detail page, check that the breadcrumb shows "News & Stories" link which leads to `/articles`
- [ ] Go on a global News detail page (not in a group), check that the breadcrumb shows "News & Stories" link which leads to `/articles`