### PR TITLE
EICNET-XXXX: Group URL alias cron issues

### DIFF
--- a/lib/modules/eic_groups/src/Hooks/Pathauto.php
+++ b/lib/modules/eic_groups/src/Hooks/Pathauto.php
@@ -188,8 +188,9 @@ class Pathauto implements ContainerInjectionInterface {
   protected function groupAliasAlter(&$alias, array &$context, GroupInterface $group) {
     // If group alias has changed we add the group id into a queue so that
     // all group content url aliases can be updated at a later stage with
-    // cron.
-    if ($group->get('path')->alias !== $alias) {
+    // cron. If pathauto generator is being used to return path alias
+    // (op = return), then we do nothing.
+    if ($group->get('path')->alias !== $alias && $context['op'] !== 'return') {
       $this->createGroupUrlAliasUpdateQueueItem($group);
     }
   }


### PR DESCRIPTION
### Fixes

- Fix issue where group alias url queue was being filled when using pathauto generator to retrieve a group URL alias.

### Tests

- [x] Import DB from QA
- [x] Run cron (the first time, eic_groups_cron() execution will take a bit of time since there are multiple groups with URL alias to be updated)
- [x] Run cron and make sure this time cron runs faster. You can check the DB logs and make sure the eic_groups_cron() execution didn't take too long.