### PR TITLE
[EICNET-1917] Comments front-end mobile

### DIFF
--- a/lib/themes/eic_community/react/components/Block/CommentsDiscussion/Partials/Answer.js
+++ b/lib/themes/eic_community/react/components/Block/CommentsDiscussion/Partials/Answer.js
@@ -47,9 +47,9 @@ class Answer extends React.Component {
               <div className="ecl-comment__author-info">
                 <a href={child.user_url}
                    className="ecl-link ecl-link--standalone ecl-comment__author-name">{child.user_fullname}</a>
-                <span className="ecl-comment__origin">{getTranslation('in_reply_to')}</span>
+                <span className="ecl-comment__origin">{getTranslation('in_reply_to')}&nbsp;</span>
                 <a href={`${this.props.parent.user_url}`}
-                   className="ecl-link ecl-link--standalone ecl-comment__author-name">&nbsp;{this.props.parent.user_fullname}</a>
+                   className="ecl-link ecl-link--standalone ecl-comment__author-name">{this.props.parent.user_fullname}</a>
               </div>
               <div className="ecl-timestamp ecl-comment__timestamp ecl-timestamp--meta">
                 <TimeStatus comment={child} />

--- a/lib/themes/eic_community/react/components/Block/CommentsDiscussion/Partials/CommentForm.js
+++ b/lib/themes/eic_community/react/components/Block/CommentsDiscussion/Partials/CommentForm.js
@@ -19,6 +19,8 @@ class CommentForm extends React.Component {
     this.settings = window.drupalSettings.overview;
     this.updateTaggedUsers = this.updateTaggedUsers.bind(this);
     this.submit = this.submit.bind(this);
+    this.handleChange = this.handleChange.bind(this);
+    this.commentArea = React.createRef()
   }
 
   submit(e) {
@@ -33,6 +35,32 @@ class CommentForm extends React.Component {
     this.setState({
       taggedUsers: users,
     })
+  }
+
+  getScrollHeight(elm){
+    var savedValue = elm.value
+    elm.value = ''
+    const baseScrollHeight = elm.scrollHeight
+    elm.value = savedValue
+
+    return baseScrollHeight
+  }
+
+  handleChange(e) {
+    const textarea = e.currentTarget
+    const minRows = 2
+    const maxRows = 10
+    textarea.rows = minRows
+    const rows = Math.ceil((textarea.scrollHeight - this.getScrollHeight(textarea)) / 18)
+    if (rows < maxRows) {
+      textarea.style.cssText = 'overflow:hidden;';
+      textarea.rows = rows
+    } else {
+      textarea.style.cssText = 'overflow:auto;';
+      textarea.rows = maxRows
+    }
+
+    this.props.onChangeCommentText(e.target.value, this.props.parentComment)
   }
 
   render() {
@@ -55,13 +83,14 @@ class CommentForm extends React.Component {
                        htmlFor="ecl-comment-form-reply">{this.props.title}</label>
                 <div className="ecl-comment-form__textarea-wrapper">
                 <textarea
-                  onChange={(e) => this.props.onChangeCommentText(e.target.value, this.props.parentComment)}
+                  onChange={this.handleChange}
                   value={(this.props.commentText || this.props.commentTextReply) || ''}
                   className="ecl-text-area ecl-comment-form__textarea"
                   id="ecl-comment-form-reply"
                   name=""
                   placeholder={getTranslation('comment_placeholder')}
                   required={true}
+                  rows={2}
                 />
                 </div>
                 <TaggedUsers taggedUsers={this.state.taggedUsers} />

--- a/lib/themes/eic_community/sass/compositions/_comment-form.scss
+++ b/lib/themes/eic_community/sass/compositions/_comment-form.scss
@@ -77,6 +77,7 @@
 
   &__textarea {
     width: 100%;
+    height:auto;
     box-sizing: border-box;
     resize: vertical;
     background-color: map-get($ecl-colors, 'grey-10');

--- a/lib/themes/eic_community/sass/compositions/_discussion-thread.scss
+++ b/lib/themes/eic_community/sass/compositions/_discussion-thread.scss
@@ -260,8 +260,12 @@
         display: flex;
       }
 
-      &__author-info {
-        flex-grow: 1;
+      &__author {
+        left: 1rem;
+        &-info {
+          padding-left: 1.5rem !important;
+          flex-grow: 1;
+        }
       }
 
       &__footer {


### PR DESCRIPTION
https://citnet.tech.ec.europa.eu/CITnet/jira/secure/RapidBoard.jspa?rapidView=6628&projectKey=EICNET&view=detail&selectedIssue=EICNET-1917&quickFilter=26822

- [x] The comment shown on discussions displays avatar very small and is placed wrong
- [ ] When indenting to level 3 I see a small horizontal rule instead of the vertical ruler
- [x] There is a small indent on "name in reply to name" when text goes on second line
- [x] When adding a comment I would like to see a larger comment box. Now it can only contain 2.5 lines (on my device). 4 would be more comfortable to add a slightly larger comment and it would not interfere with anything else. On desktop we can drag and make it larger, on mobile we cannot do this.

### Remarks

_When indenting to level 3 I see a small horizontal rule instead of the vertical ruler_
> It's only for mobile because the desktop version take to much place on mobile so it's a variant 


