### PR TITLE
EICNET-1977: Error when creating a Global event as a Trusted user

### DIFF
--- a/config/sync/group.type.event.yml
+++ b/config/sync/group.type.event.yml
@@ -19,4 +19,5 @@ description: ''
 new_revision: true
 creator_membership: true
 creator_wizard: false
-creator_roles: {  }
+creator_roles:
+  - event-owner


### PR DESCRIPTION
### Fixes

- Assign owner role to the Event group creator.

### Tests

- [x] As TU, try to create a new global event (group type event) and make sure there is no error and the group gets created.