### PR TITLE
EICNET-1974: Fix Group feature permissions issue

### DIFF
--- a/lib/modules/eic_groups/src/Plugin/GroupFeature/EicGroupsGroupFeaturePluginBase.php
+++ b/lib/modules/eic_groups/src/Plugin/GroupFeature/EicGroupsGroupFeaturePluginBase.php
@@ -115,8 +115,8 @@ class EicGroupsGroupFeaturePluginBase extends GroupFeaturePluginBase {
       ) {
         // Disable menu item.
         $menu_name = GroupContentMenuInterface::MENU_PREFIX . $group_menu
-            ->getEntity()
-            ->id();
+          ->getEntity()
+          ->id();
         switch ($op) {
           case 'enable':
             $this->enableMenuItem($this->getMenuItem($url, $menu_name));
@@ -157,7 +157,14 @@ class EicGroupsGroupFeaturePluginBase extends GroupFeaturePluginBase {
         'eic_groups.group_features.' . $this->getPluginId()
       );
 
-      $roles = $config->get('roles');
+      // Filter out roles that don't belong to the group type.
+      $group_type_roles = [];
+      foreach ($config->get('roles') as $role) {
+        if (strpos($role, $group->getGroupType()->id() . '-') !== 0) {
+          continue;
+        }
+        $group_type_roles[] = $role;
+      }
 
       // Initialize array of public role IDs to update group permissions.
       $public_role_ids = [];
@@ -178,7 +185,7 @@ class EicGroupsGroupFeaturePluginBase extends GroupFeaturePluginBase {
       switch ($op) {
         case 'enable':
           // Adds group permission for the private roles.
-          foreach ($roles as $role) {
+          foreach ($group_type_roles as $role) {
             $group_permissions = $this->addRolePermissionsToGroup(
               $group_permissions,
               $role,
@@ -198,7 +205,7 @@ class EicGroupsGroupFeaturePluginBase extends GroupFeaturePluginBase {
 
         case 'disable':
           // Removes permission from the private roles.
-          foreach ($roles as $role) {
+          foreach ($group_type_roles as $role) {
             $group_permissions = $this->removeRolePermissionsFromGroup(
               $group_permissions,
               $role,
@@ -255,8 +262,10 @@ class EicGroupsGroupFeaturePluginBase extends GroupFeaturePluginBase {
    * or from canonical with anchor.
    *
    * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group entity.
    *
    * @return \Drupal\Core\Url
+   *   The URL object.
    */
   protected function generateFeatureUrl(GroupInterface $group) {
     $url_params = ['group' => $group->id()];

--- a/lib/modules/oec_group_features/src/GroupFeaturePluginBase.php
+++ b/lib/modules/oec_group_features/src/GroupFeaturePluginBase.php
@@ -215,6 +215,10 @@ abstract class GroupFeaturePluginBase extends PluginBase implements GroupFeature
   /**
    * Add role permissions to the group.
    *
+   * This method is a verbatim from
+   * \Drupal\group_flex\GroupFlexGroupSaver::addRolePermissionsToGroup() as it
+   * is currently private.
+   *
    * @param \Drupal\group_permissions\Entity\GroupPermissionInterface $groupPermission
    *   The group permission object to add the permissions to.
    * @param string $role
@@ -244,6 +248,10 @@ abstract class GroupFeaturePluginBase extends PluginBase implements GroupFeature
 
   /**
    * Remove role permissions from the group.
+   *
+   * This method is a verbatim from
+   * \Drupal\group_flex\GroupFlexGroupSaver::removeRolePermissionsFromGroup() as
+   * it is currently private.
    *
    * @param \Drupal\group_permissions\Entity\GroupPermissionInterface $groupPermission
    *   The group permission object to set the permissions to.

--- a/lib/modules/oec_group_features/src/Hooks/EntityOperations.php
+++ b/lib/modules/oec_group_features/src/Hooks/EntityOperations.php
@@ -2,8 +2,10 @@
 
 namespace Drupal\oec_group_features\Hooks;
 
+use Drupal\Component\Plugin\Exception\PluginException;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelTrait;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\group\Entity\Group;
@@ -18,7 +20,16 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class EntityOperations implements ContainerInjectionInterface {
 
+  use LoggerChannelTrait;
   use StringTranslationTrait;
+
+
+  /**
+   * The OEC group feature helper service.
+   *
+   * @var \Drupal\oec_group_features\GroupFeatureHelper
+   */
+  protected $groupFeatureHelper;
 
   /**
    * The entity type manager.
@@ -44,6 +55,8 @@ class EntityOperations implements ContainerInjectionInterface {
   /**
    * Constructs a new GroupFeatures object.
    *
+   * @param \Drupal\oec_group_features\GroupFeatureHelper $oec_group_features_helper
+   *   The OEC group feature helper service.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
    * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
@@ -51,7 +64,13 @@ class EntityOperations implements ContainerInjectionInterface {
    * @param \Drupal\oec_group_features\GroupFeaturePluginManager $group_feature_plugin_manager
    *   The current route match service.
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, RouteMatchInterface $route_match, GroupFeaturePluginManager $group_feature_plugin_manager) {
+  public function __construct(
+    GroupFeatureHelper $oec_group_features_helper,
+    EntityTypeManagerInterface $entity_type_manager,
+    RouteMatchInterface $route_match,
+    GroupFeaturePluginManager $group_feature_plugin_manager
+  ) {
+    $this->groupFeatureHelper = $oec_group_features_helper;
     $this->entityTypeManager = $entity_type_manager;
     $this->routeMatch = $route_match;
     $this->groupFeaturePluginManager = $group_feature_plugin_manager;
@@ -62,6 +81,7 @@ class EntityOperations implements ContainerInjectionInterface {
    */
   public static function create(ContainerInterface $container) {
     return new static(
+      $container->get('oec_group_features.helper'),
       $container->get('entity_type.manager'),
       $container->get('current_route_match'),
       $container->get('plugin.manager.group_feature')
@@ -101,10 +121,16 @@ class EntityOperations implements ContainerInjectionInterface {
       return;
     }
 
-    // Get all available global features.
+    // Get all available features for this group type.
     $available_features = [];
-    foreach ($this->groupFeaturePluginManager->getDefinitions() as $definition) {
-      $available_features[$definition['id']] = $this->groupFeaturePluginManager->createInstance($definition['id']);
+    foreach ($this->groupFeatureHelper->getGroupTypeAvailableFeatures($group->getGroupType()->id()) as $plugin_id => $label) {
+      try {
+        $available_features[$plugin_id] = $this->groupFeaturePluginManager->createInstance($plugin_id);
+      }
+      catch (PluginException $e) {
+        $logger = $this->getLogger('oec_group_features');
+        $logger->error($e->getMessage());
+      }
     }
 
     // Get group enabled features.


### PR DESCRIPTION
### Tests

- [x] As GO (non SA/SCM/DA), create an event
- [x] After event creattion, edit the event and enable News feature
- [x] Make sure the menu item is visible, that you can create a News and access the News overview
- [x] Edit the event again to disable the News feature
- [x] Make sure the menu item is not visible, that you cannot create a News and can't access the News overview