### PR TITLE
[EICNET-1238]feat: Disable by default field notification and activity for certain types

### DIFF
--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Hooks/FormOperations.php
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Hooks/FormOperations.php
@@ -113,6 +113,13 @@ class FormOperations implements ContainerInjectionInterface {
     FormStateInterface $form_state,
     string $form_id
   ) {
+    // All types that is by default unchecked.
+    $field_disable_by_default_types = [
+      'document',
+      'video',
+      'gallery',
+    ];
+
     /** @var \Drupal\Core\Entity\EntityInterface $entity */
     $entity = $form_state->getFormObject()->getEntity();
     $show_notification_field = FALSE;
@@ -131,7 +138,7 @@ class FormOperations implements ContainerInjectionInterface {
       $form['field_send_notification'] = [
         '#title' => $this->t('Send notification'),
         '#type' => 'checkbox',
-        '#default_value' => $entity->isNew(),
+        '#default_value' => $entity->isNew() && !in_array($entity->bundle(), $field_disable_by_default_types),
       ];
       $form['actions']['submit']['#submit'][] = [
         $this,

--- a/lib/modules/eic_messages/src/Hooks/FormOperations.php
+++ b/lib/modules/eic_messages/src/Hooks/FormOperations.php
@@ -98,6 +98,15 @@ class FormOperations implements ContainerInjectionInterface {
     FormStateInterface $form_state,
     string $form_id
   ) {
+    // All types that is by default unchecked.
+    $field_disable_by_default_types = [
+      'document',
+      'video',
+      'gallery',
+    ];
+
+    /** @var \Drupal\Core\Entity\EntityInterface $entity */
+    $entity = $form_state->getFormObject()->getEntity();
     $is_group_content = FALSE;
     $is_new_content = FALSE;
 
@@ -123,7 +132,7 @@ class FormOperations implements ContainerInjectionInterface {
         $form['field_post_activity'] = [
           '#title' => $this->t('Post message in the activity stream'),
           '#type' => 'checkbox',
-          '#default_value' => $is_new_content,
+          '#default_value' => $is_new_content && !in_array($entity->bundle(), $field_disable_by_default_types),
         ];
         $form['actions']['submit']['#submit'][] = [$this, 'postActivitySubmit'];
       }


### PR DESCRIPTION
How to test:

- [x] From a group add a document/gallery/video 
- [x] Be sure you have the send notification and post activity unchecked