### PR TITLE
Feature/eicnet 1785 organisation webservice

### DIFF
--- a/config/sync/core.entity_form_display.group.organisation.default.yml
+++ b/config/sync/core.entity_form_display.group.organisation.default.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.group.organisation.field_organisation_link
     - field.field.group.organisation.field_organisation_turnover
     - field.field.group.organisation.field_organisation_type
+    - field.field.group.organisation.field_smed_id
     - field.field.group.organisation.field_social_links
     - field.field.group.organisation.field_team_members
     - field.field.group.organisation.field_thumbnail
@@ -277,6 +278,14 @@ content:
     weight: 9
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_smed_id:
+    type: string_textfield
+    weight: 28
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_social_links:
     type: social_links

--- a/config/sync/core.entity_view_display.group.organisation.default.yml
+++ b/config/sync/core.entity_view_display.group.organisation.default.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.group.organisation.field_organisation_link
     - field.field.group.organisation.field_organisation_turnover
     - field.field.group.organisation.field_organisation_type
+    - field.field.group.organisation.field_smed_id
     - field.field.group.organisation.field_social_links
     - field.field.group.organisation.field_team_members
     - field.field.group.organisation.field_thumbnail
@@ -67,6 +68,14 @@ content:
       link: ''
     third_party_settings: {  }
     weight: 3
+    region: content
+  field_smed_id:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 9
     region: content
   field_team_members:
     type: entity_reference_revisions_entity_view

--- a/config/sync/field.field.group.organisation.field_address.yml
+++ b/config/sync/field.field.group.organisation.field_address.yml
@@ -22,16 +22,24 @@ settings:
   langcode_override: ''
   field_overrides:
     givenName:
-      override: required
+      override: hidden
     additionalName:
       override: hidden
     familyName:
-      override: required
+      override: hidden
+    organization:
+      override: optional
     addressLine1:
-      override: required
+      override: optional
+    addressLine2:
+      override: optional
     postalCode:
-      override: required
+      override: optional
+    dependentLocality:
+      override: optional
     locality:
-      override: required
+      override: optional
+    administrativeArea:
+      override: optional
   fields: {  }
 field_type: address

--- a/config/sync/field.field.group.organisation.field_smed_id.yml
+++ b/config/sync/field.field.group.organisation.field_smed_id.yml
@@ -1,0 +1,19 @@
+uuid: a3c24085-4994-4aa2-bc6a-ab3302400469
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.group.field_smed_id
+    - group.type.organisation
+id: group.organisation.field_smed_id
+field_name: field_smed_id
+entity_type: group
+bundle: organisation
+label: 'SME Dashboard ID'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/rest.resource.eic_webservices_organisation.yml
+++ b/config/sync/rest.resource.eic_webservices_organisation.yml
@@ -1,0 +1,20 @@
+uuid: 0a5de065-7b44-41ec-90c1-3b376ae86ffc
+langcode: en
+status: true
+dependencies:
+  module:
+    - basic_auth
+    - eic_webservices
+    - group
+    - hal
+id: eic_webservices_organisation
+plugin_id: eic_webservices_organisation
+granularity: resource
+configuration:
+  methods:
+    - GET
+    - POST
+  formats:
+    - hal_json
+  authentication:
+    - basic_auth

--- a/config/sync/rest.resource.eic_webservices_organisation_update.yml
+++ b/config/sync/rest.resource.eic_webservices_organisation_update.yml
@@ -1,0 +1,18 @@
+uuid: b032b11e-a16d-47d8-8539-a1f463aa669d
+langcode: en
+status: true
+dependencies:
+  module:
+    - basic_auth
+    - eic_webservices
+    - hal
+id: eic_webservices_organisation_update
+plugin_id: eic_webservices_organisation_update
+granularity: resource
+configuration:
+  methods:
+    - POST
+  formats:
+    - hal_json
+  authentication:
+    - basic_auth

--- a/config/sync/user.role.service_authentication.yml
+++ b/config/sync/user.role.service_authentication.yml
@@ -6,6 +6,7 @@ dependencies:
     - filter.format.basic_text
     - filter.format.filtered_html
     - filter.format.full_html
+    - rest.resource.eic_webservices_organisation_update
     - rest.resource.eic_webservices_user_update
     - workflows.workflow.groups
   module:
@@ -26,6 +27,7 @@ permissions:
   - 'bypass group access'
   - 'restful get eic_webservices_organisation'
   - 'restful post eic_webservices_organisation'
+  - 'restful post eic_webservices_organisation_update'
   - 'restful post eic_webservices_user_update'
   - 'use groups transition block'
   - 'use groups transition create_new_group'

--- a/config/sync/user.role.service_authentication.yml
+++ b/config/sync/user.role.service_authentication.yml
@@ -3,11 +3,15 @@ langcode: en
 status: true
 dependencies:
   config:
+    - filter.format.basic_text
+    - filter.format.filtered_html
+    - filter.format.full_html
     - rest.resource.eic_webservices_user_update
     - workflows.workflow.groups
   module:
     - comment
     - content_moderation
+    - filter
     - group
     - node
     - rest
@@ -29,5 +33,8 @@ permissions:
   - 'use groups transition unblock'
   - 'use groups transition unpublish'
   - 'use groups transition upgrade_to_draft'
+  - 'use text format basic_text'
+  - 'use text format filtered_html'
+  - 'use text format full_html'
   - 'view own unpublished content'
   - 'view user email addresses'

--- a/config/sync/user.role.service_authentication.yml
+++ b/config/sync/user.role.service_authentication.yml
@@ -4,10 +4,11 @@ status: true
 dependencies:
   config:
     - rest.resource.eic_webservices_user_update
-    - workflows.workflow.news_stories
+    - workflows.workflow.groups
   module:
     - comment
     - content_moderation
+    - group
     - node
     - rest
 id: service_authentication
@@ -18,7 +19,15 @@ permissions:
   - 'access user profiles'
   - 'administer comments'
   - 'administer users'
+  - 'bypass group access'
+  - 'restful get eic_webservices_organisation'
+  - 'restful post eic_webservices_organisation'
   - 'restful post eic_webservices_user_update'
-  - 'use news_stories transition archived'
+  - 'use groups transition block'
+  - 'use groups transition create_new_group'
+  - 'use groups transition publish'
+  - 'use groups transition unblock'
+  - 'use groups transition unpublish'
+  - 'use groups transition upgrade_to_draft'
   - 'view own unpublished content'
   - 'view user email addresses'

--- a/lib/modules/eic_groups/modules/eic_organisations/src/OrganisationsHelper.php
+++ b/lib/modules/eic_groups/modules/eic_organisations/src/OrganisationsHelper.php
@@ -106,11 +106,17 @@ class OrganisationsHelper {
     return array_unique($user_organisation_types);
   }
 
-  public static function setRequiredFieldsDefaultValues(GroupInterface &$group) {
+  /**
+   * Sets default values for defined fields that don't have a value yet.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group entity.
+   */
+  public static function setRequiredFieldsDefaultValues(GroupInterface &$group): void {
     $fields = [
       'field_body' => [
         'value' => ' ',
-        //'format' => 'filtered_html',  // @todo Check if mandatory and why it doesn't work.
+        'format' => 'filtered_html',
       ],
     ];
 

--- a/lib/modules/eic_groups/modules/eic_organisations/src/OrganisationsHelper.php
+++ b/lib/modules/eic_groups/modules/eic_organisations/src/OrganisationsHelper.php
@@ -6,6 +6,7 @@ use Drupal\Core\Logger\LoggerChannelTrait;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\eic_organisations\Constants\Organisations;
+use Drupal\group\Entity\GroupInterface;
 use Drupal\group\GroupMembershipLoader;
 
 /**
@@ -103,6 +104,32 @@ class OrganisationsHelper {
     }
 
     return array_unique($user_organisation_types);
+  }
+
+  public static function setRequiredFieldsDefaultValues(GroupInterface &$group) {
+    $fields = [
+      'field_body' => [
+        'value' => ' ',
+        //'format' => 'filtered_html',  // @todo Check if mandatory and why it doesn't work.
+      ],
+    ];
+
+    foreach ($fields as $field_name => $values) {
+      // Check if field exists.
+      if (!$group->hasField($field_name)) {
+        continue;
+      }
+
+      // Check if field is empty.
+      if (!$group->get($field_name)->isEmpty()) {
+        continue;
+      }
+
+      // Set the values for this field.
+      foreach ($values as $key => $value) {
+        $group->{$field_name}->{$key} = $value;
+      }
+    }
   }
 
 }

--- a/lib/modules/eic_webservices/eic_webservices.services.yml
+++ b/lib/modules/eic_webservices/eic_webservices.services.yml
@@ -2,6 +2,9 @@ services:
   eic_webservices.ws_helper:
     class: Drupal\eic_webservices\Utility\EicWsHelper
     arguments: ['@config.factory', '@entity_type.manager']
+  eic_webservices.taxonomy_helper:
+    class: Drupal\eic_webservices\Utility\SmedTaxonomyHelper
+    arguments: ['@config.factory', '@entity_type.manager', '@entity_field.manager']
   paramconverter.eic_webservices.entity_smed_id:
     parent: paramconverter.entity
     class: Drupal\eic_webservices\ParamConverter\SmedIdConverter

--- a/lib/modules/eic_webservices/src/ParamConverter/SmedIdConverter.php
+++ b/lib/modules/eic_webservices/src/ParamConverter/SmedIdConverter.php
@@ -22,6 +22,8 @@ class SmedIdConverter extends EntityConverter {
 
   /**
    * {@inheritdoc}
+   *
+   * @todo Handle different sets of SMED IDs depending on the group type.
    */
   public function convert($value, $definition, $name, array $defaults) {
     // Get the field name that contains the SMED ID.

--- a/lib/modules/eic_webservices/src/ParamConverter/SmedIdConverter.php
+++ b/lib/modules/eic_webservices/src/ParamConverter/SmedIdConverter.php
@@ -41,14 +41,22 @@ class SmedIdConverter extends EntityConverter {
    * {@inheritdoc}
    */
   public function applies($definition, $name, Route $route) {
+    // Check the endpoint path prefix first.
+    if (strpos($route->getPath(), '/smed/api/') !== 0) {
+      return FALSE;
+    }
+
+    // Define an array of applicable entity types and parameter names.
     $types = [
-      'entity:user',
+      'entity:group' => 'group',
+      'entity:user' => 'user',
     ];
 
-    if (strpos($route->getPath(), '/smed/api/') === 0 &&
-      isset($route->getOption('parameters')['user']) &&
-      !empty($definition['type']) && in_array($definition['type'], $types)) {
-      return TRUE;
+    foreach ($types as $entity_type => $parameter_name) {
+      if (isset($route->getOption('parameters')[$parameter_name]) &&
+        !empty($definition['type']) && $definition['type'] == $entity_type) {
+        return TRUE;
+      }
     }
 
     return FALSE;

--- a/lib/modules/eic_webservices/src/Plugin/rest/resource/OrganisationResource.php
+++ b/lib/modules/eic_webservices/src/Plugin/rest/resource/OrganisationResource.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Drupal\eic_webservices\Plugin\rest\resource;
+
+use Drupal\Component\Plugin\PluginManagerInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\eic_organisations\OrganisationsHelper;
+use Drupal\eic_webservices\Utility\EicWsHelper;
+use Drupal\rest\Plugin\rest\resource\EntityResource;
+use Drupal\rest\ResourceResponse;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Represents EIC Organisation Resource records as resources.
+ *
+ * @RestResource (
+ *   id = "eic_webservices_organisation",
+ *   label = @Translation("EIC Organisation Resource"),
+ *   entity_type = "group",
+ *   serialization_class = "Drupal\group\Entity\Group",
+ *   uri_paths = {
+ *     "canonical" = "/smed/api/v1/organisation/{group}",
+ *     "create" = "/smed/api/v1/organisation"
+ *   }
+ * )
+ */
+class OrganisationResource extends EntityResource {
+
+  /**
+   * The EIC Webservices helper class.
+   *
+   * @var \Drupal\eic_webservices\Utility\EicWsHelper
+   */
+  protected $wsHelper;
+
+  /**
+   * Constructs a EicUserResource object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param array $serializer_formats
+   *   The available serialization formats.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   A logger instance.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   * @param \Drupal\Component\Plugin\PluginManagerInterface $link_relation_type_manager
+   *   The link relation type manager.
+   * @param \Drupal\eic_webservices\Utility\EicWsHelper $eic_ws_helper
+   *   The EIC Webservices helper class.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, array $serializer_formats, LoggerInterface $logger, ConfigFactoryInterface $config_factory, PluginManagerInterface $link_relation_type_manager, EicWsHelper $eic_ws_helper) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $serializer_formats, $logger, $config_factory, $link_relation_type_manager);
+    $this->wsHelper = $eic_ws_helper;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+      $container->getParameter('serializer.formats'),
+      $container->get('logger.factory')->get('rest'),
+      $container->get('config.factory'),
+      $container->get('plugin.manager.link_relation_type'),
+      $container->get('eic_webservices.ws_helper')
+    );
+  }
+
+  /**
+   * Responds to POST requests.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface|null $entity
+   *   The entity.
+   *
+   * @return \Drupal\rest\ResourceResponseInterface
+   *   The response.
+   */
+  public function post(EntityInterface $entity = NULL) {
+    // Get the field name that contains the SMED ID.
+    $smed_id_field = $this->configFactory->get('eic_webservices.settings')->get('smed_id_field');
+
+    // Check if organisation already exists.
+    if (!empty($entity->{$smed_id_field}->value) &&
+      $organisation = $this->wsHelper->getGroupBySmedId($entity->{$smed_id_field}->value, 'organisation')) {
+
+      // Send custom response.
+      $data = [
+        'message' => 'Unprocessable Entity: validation failed. Organisation already exists.',
+        $smed_id_field => $organisation->{$smed_id_field}->value,
+      ];
+
+      return new ResourceResponse($data, 422);
+    }
+
+    // Process SMED taxonomy fields to convert the SMED ID to Term ID.
+
+    // Initialise required fields if not provided.
+    OrganisationsHelper::setRequiredFieldsDefaultValues($entity);
+
+    return parent::post($entity);
+  }
+
+}

--- a/lib/modules/eic_webservices/src/Plugin/rest/resource/OrganisationResource.php
+++ b/lib/modules/eic_webservices/src/Plugin/rest/resource/OrganisationResource.php
@@ -65,7 +65,7 @@ class OrganisationResource extends EntityResource {
    *   The link relation type manager.
    * @param \Drupal\eic_webservices\Utility\EicWsHelper $eic_ws_helper
    *   The EIC Webservices helper class.
-   * @param \Drupal\eic_webservices\Utility\SmedTaxonomyHelper $eic_smec_taxonomy_helper
+   * @param \Drupal\eic_webservices\Utility\SmedTaxonomyHelper $eic_smed_taxonomy_helper
    *   The SMED taxonomy helper class.
    */
   public function __construct(
@@ -78,11 +78,11 @@ class OrganisationResource extends EntityResource {
     ConfigFactoryInterface $config_factory,
     PluginManagerInterface $link_relation_type_manager,
     EicWsHelper $eic_ws_helper,
-    SmedTaxonomyHelper $eic_smec_taxonomy_helper
+    SmedTaxonomyHelper $eic_smed_taxonomy_helper
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $serializer_formats, $logger, $config_factory, $link_relation_type_manager);
     $this->wsHelper = $eic_ws_helper;
-    $this->smedTaxonomyHelper = $eic_smec_taxonomy_helper;
+    $this->smedTaxonomyHelper = $eic_smed_taxonomy_helper;
   }
 
   /**

--- a/lib/modules/eic_webservices/src/Plugin/rest/resource/OrganisationResource.php
+++ b/lib/modules/eic_webservices/src/Plugin/rest/resource/OrganisationResource.php
@@ -8,6 +8,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\eic_organisations\OrganisationsHelper;
 use Drupal\eic_webservices\Utility\EicWsHelper;
+use Drupal\eic_webservices\Utility\SmedTaxonomyHelper;
 use Drupal\rest\Plugin\rest\resource\EntityResource;
 use Drupal\rest\ResourceResponse;
 use Psr\Log\LoggerInterface;
@@ -37,6 +38,13 @@ class OrganisationResource extends EntityResource {
   protected $wsHelper;
 
   /**
+   * The SMED taxonomy helper class.
+   *
+   * @var \Drupal\eic_webservices\Utility\SmedTaxonomyHelper
+   */
+  protected $smedTaxonomyHelper;
+
+  /**
    * Constructs a EicUserResource object.
    *
    * @param array $configuration
@@ -57,10 +65,24 @@ class OrganisationResource extends EntityResource {
    *   The link relation type manager.
    * @param \Drupal\eic_webservices\Utility\EicWsHelper $eic_ws_helper
    *   The EIC Webservices helper class.
+   * @param \Drupal\eic_webservices\Utility\SmedTaxonomyHelper $eic_smec_taxonomy_helper
+   *   The SMED taxonomy helper class.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, array $serializer_formats, LoggerInterface $logger, ConfigFactoryInterface $config_factory, PluginManagerInterface $link_relation_type_manager, EicWsHelper $eic_ws_helper) {
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    EntityTypeManagerInterface $entity_type_manager,
+    array $serializer_formats,
+    LoggerInterface $logger,
+    ConfigFactoryInterface $config_factory,
+    PluginManagerInterface $link_relation_type_manager,
+    EicWsHelper $eic_ws_helper,
+    SmedTaxonomyHelper $eic_smec_taxonomy_helper
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $serializer_formats, $logger, $config_factory, $link_relation_type_manager);
     $this->wsHelper = $eic_ws_helper;
+    $this->smedTaxonomyHelper = $eic_smec_taxonomy_helper;
   }
 
   /**
@@ -76,7 +98,8 @@ class OrganisationResource extends EntityResource {
       $container->get('logger.factory')->get('rest'),
       $container->get('config.factory'),
       $container->get('plugin.manager.link_relation_type'),
-      $container->get('eic_webservices.ws_helper')
+      $container->get('eic_webservices.ws_helper'),
+      $container->get('eic_webservices.taxonomy_helper')
     );
   }
 
@@ -107,6 +130,7 @@ class OrganisationResource extends EntityResource {
     }
 
     // Process SMED taxonomy fields to convert the SMED ID to Term ID.
+    $this->smedTaxonomyHelper->convertEntitySmedTaxonomyIds($entity);
 
     // Initialise required fields if not provided.
     OrganisationsHelper::setRequiredFieldsDefaultValues($entity);

--- a/lib/modules/eic_webservices/src/Plugin/rest/resource/OrganisationResource.php
+++ b/lib/modules/eic_webservices/src/Plugin/rest/resource/OrganisationResource.php
@@ -104,13 +104,7 @@ class OrganisationResource extends EntityResource {
   }
 
   /**
-   * Responds to POST requests.
-   *
-   * @param \Drupal\Core\Entity\EntityInterface|null $entity
-   *   The entity.
-   *
-   * @return \Drupal\rest\ResourceResponseInterface
-   *   The response.
+   * {@inheritdoc}
    */
   public function post(EntityInterface $entity = NULL) {
     // Get the field name that contains the SMED ID.
@@ -136,6 +130,15 @@ class OrganisationResource extends EntityResource {
     OrganisationsHelper::setRequiredFieldsDefaultValues($entity);
 
     return parent::post($entity);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function patch(EntityInterface $original_entity, EntityInterface $entity = NULL) {
+    // Process SMED taxonomy fields to convert the SMED ID to Term ID.
+    $this->smedTaxonomyHelper->convertEntitySmedTaxonomyIds($entity);
+    return parent::patch($original_entity, $entity);
   }
 
 }

--- a/lib/modules/eic_webservices/src/Plugin/rest/resource/OrganisationUpdateResource.php
+++ b/lib/modules/eic_webservices/src/Plugin/rest/resource/OrganisationUpdateResource.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Drupal\eic_webservices\Plugin\rest\resource;
+
+use Drupal\Component\Serialization\Json;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\eic_webservices\Controller\SubRequestController;
+use Drupal\rest\Plugin\ResourceBase;
+use Drupal\rest\Plugin\Type\ResourcePluginManager;
+use Drupal\rest\ResourceResponse;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\HttpKernel;
+
+/**
+ * Provides a resource to update organisations through a POST method.
+ *
+ * @RestResource(
+ *   id = "eic_webservices_organisation_update",
+ *   label = @Translation("EIC Organisation Update Resource"),
+ *   entity_type = "group",
+ *   serialization_class = "Drupal\group\Entity\Group",
+ *   uri_paths = {
+ *     "canonical" = "/smed/api/v1/organisation/{group}",
+ *     "create" = "/smed/api/v1/organisation/update/{group}"
+ *   }
+ * )
+ */
+class OrganisationUpdateResource extends ResourceBase {
+
+  /**
+   * Request stack.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
+   * HTTP kernel.
+   *
+   * @var \Symfony\Component\HttpKernel\HttpKernel
+   */
+  protected $httpKernel;
+
+  /**
+   * Resource plugin manager.
+   *
+   * @var \Drupal\rest\Plugin\Type\ResourcePluginManager
+   */
+  protected $resourcePluginManager;
+
+  /**
+   * Constructs a Drupal\rest\Plugin\ResourceBase object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param array $serializer_formats
+   *   The available serialization formats.
+   * @param \Drupal\Core\Logger\LoggerChannelInterface $logger
+   *   A logger instance.
+   * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
+   *   The request stack.
+   * @param \Symfony\Component\HttpKernel\HttpKernel $httpKernel
+   *   The HTTP kernel.
+   * @param \Drupal\rest\Plugin\Type\ResourcePluginManager $resourcePluginManager
+   *   The REST resource plugin manager.
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    array $serializer_formats,
+    LoggerChannelInterface $logger,
+    RequestStack $requestStack,
+    HttpKernel $httpKernel,
+    ResourcePluginManager $resourcePluginManager
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $serializer_formats,
+      $logger);
+    $this->requestStack = $requestStack;
+    $this->httpKernel = $httpKernel;
+    $this->resourcePluginManager = $resourcePluginManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(
+    ContainerInterface $container,
+    array $configuration,
+    $plugin_id,
+    $plugin_definition
+  ) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->getParameter('serializer.formats'),
+      $container->get('logger.factory')->get('rest'),
+      $container->get('request_stack'),
+      $container->get('http_kernel.basic'),
+      $container->get('plugin.manager.rest')
+    );
+  }
+
+  /**
+   * Responds to POST requests.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface|null $entity
+   *   The entity.
+   */
+  public function post(EntityInterface $entity = NULL) {
+    // Prepare the request.
+    $sub_request = new SubRequestController($this->httpKernel, $this->requestStack);
+    $current_request = $this->requestStack->getCurrentRequest();
+    $smed_id = $current_request->attributes->get('group');
+
+    // Get the parent resource endpoint URI.
+    $parent_resource = $this->resourcePluginManager->getDefinition('eic_webservices_organisation');
+    $uri = str_replace('{group}', $smed_id, $parent_resource['uri_paths']['canonical']);
+    $uri .= '?_format=hal_json';
+
+    // Perform the sub-request and return the result.
+    $response = $sub_request->subRequest(
+      $uri,
+      Request::METHOD_PATCH,
+      [],
+      $current_request->cookies->all(),
+      $current_request->files->all(),
+      $current_request->getContent(),
+      $current_request->headers->all()
+    );
+
+    return new ResourceResponse(Json::decode($response->getContent()), $response->getStatusCode());
+  }
+
+}

--- a/lib/modules/eic_webservices/src/Utility/EicWsHelper.php
+++ b/lib/modules/eic_webservices/src/Utility/EicWsHelper.php
@@ -58,7 +58,7 @@ class EicWsHelper {
     $entity_query->condition($smed_id_field, $smed_id);
     $entity_query->range(NULL, 1);
     $uids = $entity_query->execute();
-    return empty($uids) ? NULL : $this->entityTypeManager->getStorage('user')->load(array_pop($uids));
+    return empty($uids) ? NULL : $this->entityTypeManager->getStorage('user')->load(reset($uids));
   }
 
   /**
@@ -88,7 +88,7 @@ class EicWsHelper {
     $entity_query->condition($smed_id_field, $smed_id);
     $entity_query->range(NULL, 1);
     $ids = $entity_query->execute();
-    return empty($ids) ? NULL : $this->entityTypeManager->getStorage('group')->load(array_pop($ids));
+    return empty($ids) ? NULL : $this->entityTypeManager->getStorage('group')->load(reset($ids));
   }
 
 }

--- a/lib/modules/eic_webservices/src/Utility/EicWsHelper.php
+++ b/lib/modules/eic_webservices/src/Utility/EicWsHelper.php
@@ -42,6 +42,12 @@ class EicWsHelper {
    *
    * @param int $smed_id
    *   The SME Dashboard ID.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface|null
+   *   The user entity or NULL if not found.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
   public function getUserBySmedId(int $smed_id) {
     // Get the field name that contains the SMED ID.
@@ -52,7 +58,37 @@ class EicWsHelper {
     $entity_query->condition($smed_id_field, $smed_id);
     $entity_query->range(NULL, 1);
     $uids = $entity_query->execute();
-    return $this->entityTypeManager->getStorage('user')->load(array_pop($uids));
+    return empty($uids) ? NULL : $this->entityTypeManager->getStorage('user')->load(array_pop($uids));
+  }
+
+  /**
+   * Returns a group object based on SMED ID field.
+   *
+   * In SMED each type has its own 'serial' id. We can hence have the same ID
+   * for different bundles. This is why we need to filter per bundle.
+   *
+   * @param int $smed_id
+   *   The SME Dashboard ID.
+   * @param string $group_type
+   *   The group type.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface|null
+   *   The group entity or NULL if not found.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  public function getGroupBySmedId(int $smed_id, string $group_type) {
+    // Get the field name that contains the SMED ID.
+    $smed_id_field = $this->configFactory->get('eic_webservices.settings')->get('smed_id_field');
+
+    // Find if a user account matches the given SMED ID.
+    $entity_query = $this->entityTypeManager->getStorage('group')->getQuery();
+    $entity_query->condition('type', $group_type);
+    $entity_query->condition($smed_id_field, $smed_id);
+    $entity_query->range(NULL, 1);
+    $ids = $entity_query->execute();
+    return empty($ids) ? NULL : $this->entityTypeManager->getStorage('group')->load(array_pop($ids));
   }
 
 }

--- a/lib/modules/eic_webservices/src/Utility/SmedTaxonomyHelper.php
+++ b/lib/modules/eic_webservices/src/Utility/SmedTaxonomyHelper.php
@@ -2,10 +2,167 @@
 
 namespace Drupal\eic_webservices\Utility;
 
+use Drupal\Core\Config\ConfigFactory;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeManager;
+
 /**
  * Provides helper functions for the SMED taxonomy webservice.
  */
 class SmedTaxonomyHelper {
+
+  /**
+   * The list of taxonomies imported from the SMED.
+   *
+   * @todo Replace with a dynamic way?
+   *
+   * @var string[]
+   */
+  protected const SMED_VOCABULARIES = [
+    'job_titles',
+    'languages',
+    'topics',
+  ];
+
+  /**
+   * Drupal\Core\Config\ConfigFactory definition.
+   *
+   * @var \Drupal\Core\Config\ConfigFactory
+   */
+  protected $configFactory;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManager
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The entity field manager.
+   *
+   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
+   */
+  protected $entityFieldManager;
+
+  /**
+   * Class constructor.
+   *
+   * @param \Drupal\Core\Config\ConfigFactory $config_factory
+   *   An instance of ConfigFactory.
+   * @param \Drupal\Core\Entity\EntityTypeManager $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager
+   *   The entity field manager.
+   */
+  public function __construct(
+    ConfigFactory $config_factory,
+    EntityTypeManager $entity_type_manager,
+    EntityFieldManagerInterface $entity_field_manager
+  ) {
+    $this->configFactory = $config_factory;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->entityFieldManager = $entity_field_manager;
+  }
+
+  /**
+   * Returns the term ID for the given SMED ID.
+   *
+   * @param string $smed_id
+   *   The SMED ID to look for.
+   * @param string $vocabulary_name
+   *   The taxonomy vocabulary to search for.
+   *
+   * @return int|null
+   *   The Term ID or NULL if not found.
+   */
+  public function getTaxonomyTermIdBySmedId(string $smed_id, string $vocabulary_name) {
+    // Get the field name that contains the SMED ID.
+    $smed_id_field = $this->configFactory->get('eic_webservices.settings')->get('smed_id_field');
+
+    $query = $this->entityTypeManager->getStorage('taxonomy_term')->getQuery();
+    $query->condition($smed_id_field, $smed_id);
+    $query->condition('vid', $vocabulary_name);
+    $ids = $query->execute();
+    return empty($ids) ? NULL : reset($ids);
+  }
+
+  /**
+   * Defines if a vocabulary is imported from SMED.
+   *
+   * @param string $vocabulary_name
+   *   The vocabulary machine name.
+   *
+   * @return bool
+   *   TRUE if vocabulary is being imported from SMED.
+   */
+  public function isSmedVocabulary(string $vocabulary_name) {
+    return in_array($vocabulary_name, static::SMED_VOCABULARIES);
+  }
+
+  /**
+   * Converts all SMED taxonomy fields value to Drupal Term id.
+   *
+   * Assuming that the given entity contains taxonomy field values with SMED
+   * IDs, this function will convert those values to Drupal term IDs.
+   * This function does not dive into nested entities (e.g. paragraphs). You
+   * need to provide them separately.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity to convert.
+   * @param string[] $field_names
+   *   Array of field names to convert. Leave empty to convert them all.
+   */
+  public function convertEntitySmedTaxonomyIds(EntityInterface &$entity, array $field_names = []) {
+    // Get entity field definitions.
+    $field_definitions = $this->entityFieldManager->getFieldDefinitions(
+      $entity->getEntityTypeId(),
+      $entity->bundle()
+    );
+
+    // Cycle through all entity reference fields.
+    foreach ($field_definitions as $field_definition) {
+      // We treat entity_reference fields only.
+      if ($field_definition->getType() != 'entity_reference') {
+        continue;
+      }
+
+      // Check for taxonomy term reference fields only.
+      if ($field_definition->getSetting('target_type') != 'taxonomy_term') {
+        continue;
+      }
+
+      $field_name = $field_definition->getName();
+
+      // Check if we need to handle this field.
+      if (!empty($field_names) && in_array($field_name, $field_names)) {
+        continue;
+      }
+
+      // Check if this is a SMED vocabulary.
+      $handler_settings = $field_definition->getSetting('handler_settings');
+      $vid = reset($handler_settings['target_bundles']);
+      if (!$this->isSmedVocabulary($vid)) {
+        continue;
+      }
+
+      // If field is empty, skip it.
+      if ($entity->{$field_name}->isEmpty()) {
+        continue;
+      }
+
+      // Cycle through all values to get the term IDs.
+      $target_ids = [];
+      foreach ($entity->{$field_name} as $value) {
+        $smed_id = $value->target_id;
+        $target_ids[] = $this->getTaxonomyTermIdBySmedId($smed_id, $vid);
+      }
+
+      // Replace old values with the new ones.
+      $entity->{$field_name} = $target_ids;
+    }
+  }
 
   /**
    * Returns the parent term ID for the given vocabulary and child term.
@@ -18,7 +175,7 @@ class SmedTaxonomyHelper {
    * @param string $child_id
    *   The ID of the child term for which we want to find the parent.
    *
-   * @return string|NULL
+   * @return string|null
    *   The matched parent ID or 0 if parent ID couldn't be resolved.
    */
   public static function findTermParentId(string $vocabulary_name, string $child_id) {
@@ -51,7 +208,7 @@ class SmedTaxonomyHelper {
    * @param string $child_id
    *   The ID of the child term for which we want to find the parent.
    *
-   * @return string|NULL
+   * @return string|null
    *   The matched parent ID or NULL if parent ID couldn't be resolved.
    */
   protected static function resolveThematicsTopicsParentId(string $child_id) {


### PR DESCRIPTION
### Improvements

- Added `field_smed_id` to Organisation group type
- Refined the `field_address` of Oragnisation group type: removed first/last name, made all fields optional
- Added a method to convert taxonomy term SMED IDs into Drupal term IDs with the given entity

### Tests

- [x] Create a user in Drupal with the `service_authentication` role, you should use those credentials as Basic Auth
- [x] Create one organisation, including the SMED ID, you should get the created entity in response
- [x] Try to create a new one with the same SMED ID, you should get an error (HTTP code 422 Unprocessable entity) with a message
- [x] Try to update the organisation, you should get the updated entity as a response


### Remarks

- You can find all the details about the endpoints URLs and payload examples here https://citnet.tech.ec.europa.eu/CITnet/confluence/display/EICNET/WS+-+D9+Implementation#WSD9Implementation-Organisations
