### PR TITLE
EICNET-1987: Cache issues in account header

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/layout/page.inc
+++ b/lib/themes/eic_community/includes/preprocess/layout/page.inc
@@ -69,6 +69,10 @@ function eic_community_preprocess_page(array &$variables): void {
     ];
 
     $variables['site_header']['user'] = $user;
+    // We need to add the session cache context otherwise the header doesn't
+    // update when log in with another account with the same permissions.
+    // @todo In the future we should consider creating a block a load it here.
+    $variables['#cache']['contexts'][] = 'session';
   }
 
   $footer_sections = [];


### PR DESCRIPTION
### Fixes

- Add cache context "session" in hook_preprocess_page() so that the account header shows the updated user information and links according to the current logged in user.

### Tests

- [x] Login as TU
- [x] Go to the groups overview page and members overview page
- [x] Make sure your account info is shown in the site header
- [x] Log out and Log in with another TU
- [x] Go to the groups overview page and members overview page
- [x] Make sure your account info is shown correctly in the site header and not the previous logged in account