### PR TITLE
EICNET-873: Regression issues in group about page

### DIFF
--- a/lib/themes/eic_community/templates/group/group--group--about-page.html.twig
+++ b/lib/themes/eic_community/templates/group/group--group--about-page.html.twig
@@ -1,0 +1,2 @@
+{% extends "@eic_community/group/group--about-page.html.twig" %}
+


### PR DESCRIPTION
### Fix regressions

- Override group--group--about-page template (for some reason group--about-page is not picked).

### Needs investigation

- [ ] Investigate why `group--about-page` template is not being picked in the first place.

### Test

- [x] Go to a group about page
- [x] Make sure the tabs **About This Group** & **Permission and Visibility** are shown