### PR TITLE
EICNET-2003: Group creation status draft banner improvements 

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/blocks/block--eic-group-moderated-message-box.inc
+++ b/lib/themes/eic_community/includes/preprocess/blocks/block--eic-group-moderated-message-box.inc
@@ -1,8 +1,12 @@
 <?php
 
 /**
- * Implements hook_preprocess_eic_group_overview_message_block() for eic_group_overview_message
- * block.
+ * @file
+ * Contains implementation of hook_preprocess_eic_group_moderated_message_box().
+ */
+
+/**
+ * Implements hook_preprocess_eic_group_overview_message_block().
  */
 function eic_community_preprocess_eic_group_moderated_message_box(array &$variables) {
   $actions = [];
@@ -28,6 +32,10 @@ function eic_community_preprocess_eic_group_moderated_message_box(array &$variab
       $actions[] = [
         'label' => $link['label'],
         'items' => $items,
+        'icon' => [
+          'name' => 'plus',
+          'type' => 'ui',
+        ],
       ];
     }
     else {

--- a/lib/themes/eic_community/templates/blocks/eic-group-moderated-message-box.html.twig
+++ b/lib/themes/eic_community/templates/blocks/eic-group-moderated-message-box.html.twig
@@ -59,7 +59,8 @@
 
 {% if actions is not empty and (moderation_state == 'draft' or moderation_state == 'published') and has_content == false %}
   {% embed "@theme/patterns/compositions/simple-banner.html.twig" with {
-    "title": "Get the conversation started"|t
+    "title": "Get the conversation started"|t,
+    "icon_file_path": eic_icon_path
   } %}
     {% block description %}
       <p>{{ 'Start discussions with other members.'|t }}</p>


### PR DESCRIPTION
### Improvements

- Add missing icon to operations dropdown in group draft message banner.

### Test

- [x] As Tu, create a new group
- [x] As SA/SCM, send the group to draft status
- [x] As GO, go to the group overview page and check if the dropdown operations in the message banner have the "plus" icon