### PR TITLE
[EICNET-1880]feat: Add overview url prefiltered by topic

### DIFF
--- a/config/sync/search_api.index.global.yml
+++ b/config/sync/search_api.index.global.yml
@@ -3,6 +3,8 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.storage.group.field_date_range
+    - field.storage.group.field_location
     - field.storage.user.field_first_name
     - field.storage.user.field_last_name
     - field.storage.media.oe_media_image
@@ -11,8 +13,10 @@ dependencies:
     - field.storage.group.field_location_type
     - field.storage.group.field_organisation_type
     - field.storage.group.field_vocab_geo
-    - field.storage.group.field_thumbnail
+    - field.storage.group.field_vocab_services_products
+    - field.storage.group.field_vocab_target_markets
     - field.storage.group.field_image
+    - field.storage.group.field_thumbnail
     - field.storage.group.field_vocab_topics
     - field.storage.group.field_body
     - field.storage.message.field_entity_type
@@ -26,66 +30,47 @@ dependencies:
     - field.storage.message.field_source_group
     - field.storage.node.field_body
     - field.storage.node.field_comments
-    - field.storage.node.field_location
-    - field.storage.node.field_document_media
     - field.storage.node.field_document_type
+    - field.storage.media.field_media_file
+    - field.storage.node.field_document_media
+    - field.storage.node.field_location
     - field.storage.node.field_vocab_event_type
-    - field.storage.node.field_body
-    - field.storage.node.field_date_range
-    - field.storage.node.field_discussion_type
-    - field.storage.node.field_location_type
-    - field.storage.node.field_subtitle
-    - field.storage.node.field_vocab_geo
-    - field.storage.node.field_vocab_topics
-    - field.storage.media.oe_media_file
-    - field.storage.node.field_gallery_slides
-    - field.storage.paragraph.field_gallery_slide_media
-    - field.storage.paragraph.field_gallery_slide_legend
     - field.storage.node.field_image
     - field.storage.node.field_language
-    - field.storage.message.field_referenced_node
-    - field.storage.message.field_share_message
-    - field.storage.media.field_media_file
-    - field.storage.group.field_location
-    - field.storage.group.field_image
-    - field.storage.group.field_body
-    - field.storage.group.field_date_range
-    - field.storage.group.field_location_type
-    - field.storage.group.field_organisation_type
-    - field.storage.group.field_vocab_geo
-    - field.storage.group.field_vocab_topics
-    - field.storage.message.field_group_ref
-    - field.storage.group.field_thumbnail
-    - field.storage.message.field_referenced_comment
-    - field.storage.message.field_operation_type
-    - field.storage.message.field_source_group
-    - field.storage.message.field_entity_type
-    - field.storage.profile.field_location_address
+    - field.storage.node.field_location_type
+    - field.storage.node.field_vocab_geo
+    - field.storage.node.field_gallery_slides
+    - field.storage.paragraph.field_gallery_slide_legend
+    - field.storage.media.oe_media_file
+    - field.storage.paragraph.field_gallery_slide_media
+    - field.storage.node.field_date_range
+    - field.storage.node.field_subtitle
     - field.storage.profile.field_body
+    - field.storage.profile.field_location_address
+    - field.storage.profile.field_vocab_job_title
     - field.storage.profile.field_vocab_language
+    - field.storage.profile.field_social_links
+    - field.storage.profile.field_vocab_geo
     - field.storage.profile.field_vocab_topic_expertise
     - field.storage.profile.field_vocab_topic_interest
-    - field.storage.profile.field_vocab_geo
-    - field.storage.profile.field_vocab_job_title
-    - field.storage.profile.field_social_links
     - search_api.server.global
     - core.entity_view_mode.group.no_html
     - core.entity_view_mode.node.no_html
   module:
     - search_api_solr
-    - message
+    - flag
+    - group
     - user
     - file
     - media
-    - node
     - taxonomy
-    - paragraphs
-    - eic_private_content
-    - flag
-    - group
     - content_moderation
+    - message
     - comment
+    - node
+    - eic_private_content
     - path
+    - paragraphs
     - profile
     - search_api
     - address
@@ -1012,6 +997,26 @@ field_settings:
     dependencies:
       config:
         - field.storage.message.field_operation_type
+  organisation_services_products:
+    label: 'Services and products » Taxonomy term » Name'
+    datasource_id: 'entity:group'
+    property_path: 'field_vocab_services_products:entity:name'
+    type: string
+    dependencies:
+      config:
+        - field.storage.group.field_vocab_services_products
+      module:
+        - taxonomy
+  organisation_target_market_name:
+    label: 'Target markets » Taxonomy term » Name'
+    datasource_id: 'entity:group'
+    property_path: 'field_vocab_target_markets:entity:name'
+    type: string
+    dependencies:
+      config:
+        - field.storage.group.field_vocab_target_markets
+      module:
+        - taxonomy
   path:
     label: 'Referenced node » Content » URL alias'
     datasource_id: 'entity:message'
@@ -1443,6 +1448,7 @@ processor_settings:
     fields: {  }
     all_fields: false
   aggregated_field: {  }
+  entity_type: {  }
   file_attachments:
     excluded_extensions: 'aif art avi bmp gif ico mov oga ogv png psd ra ram rgb flv'
     number_indexed: 0

--- a/lib/modules/eic_overviews/src/GlobalOverviewPages.php
+++ b/lib/modules/eic_overviews/src/GlobalOverviewPages.php
@@ -75,14 +75,14 @@ class GlobalOverviewPages {
    *
    * @throws \Drupal\Core\Entity\EntityMalformedException
    */
-  public static function getGlobalOverviewPageLink(int $page): Link {
+  public static function getGlobalOverviewPageLink(int $page, $params = []): Link {
     $overview_entities = \Drupal::entityQuery('overview_page')
       ->condition('field_overview_id', $page)
       ->execute();
 
     $default_link = Link::fromTextAndUrl(
       t('Overview', [], ['context' => 'eic_overviews']),
-      Url::fromRoute('<current>')
+      Url::fromRoute('<current>', [], $params)
     );
 
     if (empty($overview_entities)) {
@@ -98,7 +98,7 @@ class GlobalOverviewPages {
 
     return Link::fromTextAndUrl(
       $overview_entity->label(),
-      $overview_entity->toUrl()
+      $overview_entity->toUrl()->setOptions($params)
     );
   }
 

--- a/lib/modules/eic_search/src/Search/Sources/OrganisationSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/OrganisationSourceType.php
@@ -44,6 +44,8 @@ class OrganisationSourceType extends SourceType {
       'sm_group_organisation_type_string' => $this->t('Organisation type', [], ['context' => 'eic_search']),
       'sm_content_field_vocab_topics_string' => $this->t('Topic', [], ['context' => 'eic_search']),
       'sm_group_field_locations_string' => $this->t('Locations', [], ['context' => 'eic_search']),
+      'sm_organisation_services_products' => $this->t('Activity sectors', [], ['context' => 'eic_search']),
+      'sm_organisation_target_market_name' => $this->t('Target sectors', [], ['context' => 'eic_search']),
     ];
   }
 

--- a/lib/themes/eic_community/includes/preprocess/groups/organisation.inc
+++ b/lib/themes/eic_community/includes/preprocess/groups/organisation.inc
@@ -5,11 +5,12 @@
  * Prepares variables for group type organisation templates.
  */
 
+use Drupal\eic_search\SearchHelper;
+use Drupal\eic_topics\Constants\Topics;
 use Drupal\file\Entity\File;
 use Drupal\taxonomy\TermInterface;
 use Drupal\Core\Url;
-use Drupal\address\FieldHelper;
-use CommerceGuys\Addressing\AddressFormat\AddressField;
+use \Drupal\eic_overviews\GlobalOverviewPages;
 use Drupal\paragraphs\ParagraphInterface;
 use Drupal\group\Entity\GroupInterface;
 use Drupal\eic_overviews\GroupOverviewPages;
@@ -325,7 +326,10 @@ function _eic_community_render_organisation_detail_page(&$variables, $group) {
             [
               'tag' => [
                 'type' => 'link',
-                'path' => $term->toUrl()->toString(),
+                'path' => _generate_overview_prefilter_url(
+                  'sm_organisation_services_products',
+                  $term->label()
+                ),
                 'label' => $term->getName(),
               ],
             ];
@@ -345,7 +349,10 @@ function _eic_community_render_organisation_detail_page(&$variables, $group) {
             [
               'tag' => [
                 'type' => 'link',
-                'path' => $term->toUrl()->toString(),
+                'path' => _generate_overview_prefilter_url(
+                  'sm_organisation_target_market_name',
+                  $term->label()
+                ),
                 'label' => $term->getName(),
               ],
             ];
@@ -365,7 +372,10 @@ function _eic_community_render_organisation_detail_page(&$variables, $group) {
             [
               'tag' => [
                 'type' => 'link',
-                'path' => $term->toUrl()->toString(),
+                'path' => _generate_overview_prefilter_url(
+                  Topics::TERM_TOPICS_ID_FIELD_CONTENT_SOLR,
+                  $term->label()
+                ),
                 'label' => $term->getName(),
               ],
             ];
@@ -455,4 +465,26 @@ function eic_community_preprocess_paragraph__organisation_member(&$variables) {
       ],
     ],
   ];
+}
+
+/**
+ * @param string $filter
+ * @param string $value
+ *
+ * @return string
+ * @throws \Drupal\Core\Entity\EntityMalformedException
+ */
+function _generate_overview_prefilter_url(string $filter, string $value): string {
+  $filters = [
+    $filter => $value,
+  ];
+
+  $query_options = [
+    'query' => SearchHelper::buildSolrQueryParams($filters),
+  ];
+
+  return GlobalOverviewPages::getGlobalOverviewPageLink(
+    GlobalOverviewPages::ORGANISATIONS,
+    $query_options
+  )->getUrl()->toString();
 }


### PR DESCRIPTION
How to test it:

- [x] Go to organisation detail
- [x] Click on different term value from: topics, markets, services
- [x] You are redirected to organisations overview prefiltered by the selected term

PS: be sure you enabled the facets on the overview page (Topics, activity sector, target sector)