### PR TITLE
EICNET-1573: Add missing fields to gallery and video activity stream messages.

### DIFF
--- a/config/sync/core.entity_form_display.message.stream_gallery_insert_update.default.yml
+++ b/config/sync/core.entity_form_display.message.stream_gallery_insert_update.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.message.stream_gallery_insert_update.field_entity_type
     - field.field.message.stream_gallery_insert_update.field_group_ref
     - field.field.message.stream_gallery_insert_update.field_operation_type
     - field.field.message.stream_gallery_insert_update.field_referenced_node
@@ -12,6 +13,14 @@ targetEntityType: message
 bundle: stream_gallery_insert_update
 mode: default
 content:
+  field_entity_type:
+    type: string_textfield
+    weight: 3
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_group_ref:
     type: entity_reference_autocomplete
     weight: 0

--- a/config/sync/core.entity_form_display.message.stream_video_insert_update.default.yml
+++ b/config/sync/core.entity_form_display.message.stream_video_insert_update.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.message.stream_video_insert_update.field_entity_type
     - field.field.message.stream_video_insert_update.field_group_ref
     - field.field.message.stream_video_insert_update.field_operation_type
     - field.field.message.stream_video_insert_update.field_referenced_node
@@ -12,6 +13,14 @@ targetEntityType: message
 bundle: stream_video_insert_update
 mode: default
 content:
+  field_entity_type:
+    type: string_textfield
+    weight: 3
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_group_ref:
     type: entity_reference_autocomplete
     weight: 0

--- a/config/sync/core.entity_view_display.message.stream_gallery_insert_update.default.yml
+++ b/config/sync/core.entity_view_display.message.stream_gallery_insert_update.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.message.stream_gallery_insert_update.field_entity_type
     - field.field.message.stream_gallery_insert_update.field_group_ref
     - field.field.message.stream_gallery_insert_update.field_operation_type
     - field.field.message.stream_gallery_insert_update.field_referenced_node
@@ -12,6 +13,14 @@ targetEntityType: message
 bundle: stream_gallery_insert_update
 mode: default
 content:
+  field_entity_type:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 4
+    region: content
   field_group_ref:
     type: entity_reference_label
     label: above

--- a/config/sync/core.entity_view_display.message.stream_video_insert_update.default.yml
+++ b/config/sync/core.entity_view_display.message.stream_video_insert_update.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.message.stream_video_insert_update.field_entity_type
     - field.field.message.stream_video_insert_update.field_group_ref
     - field.field.message.stream_video_insert_update.field_operation_type
     - field.field.message.stream_video_insert_update.field_referenced_node
@@ -12,6 +13,14 @@ targetEntityType: message
 bundle: stream_video_insert_update
 mode: default
 content:
+  field_entity_type:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 4
+    region: content
   field_group_ref:
     type: entity_reference_label
     label: above

--- a/config/sync/field.field.message.stream_gallery_insert_update.field_entity_type.yml
+++ b/config/sync/field.field.message.stream_gallery_insert_update.field_entity_type.yml
@@ -1,0 +1,19 @@
+uuid: 4d379e80-69f1-4f63-9885-568bd8a393c3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_entity_type
+    - message.template.stream_gallery_insert_update
+id: message.stream_gallery_insert_update.field_entity_type
+field_name: field_entity_type
+entity_type: message
+bundle: stream_gallery_insert_update
+label: 'Entity type'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.message.stream_video_insert_update.field_entity_type.yml
+++ b/config/sync/field.field.message.stream_video_insert_update.field_entity_type.yml
@@ -1,0 +1,19 @@
+uuid: 8f7e1c7e-1ea1-423b-b359-0268abae72e7
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_entity_type
+    - message.template.stream_video_insert_update
+id: message.stream_video_insert_update.field_entity_type
+field_name: field_entity_type
+entity_type: message
+bundle: stream_video_insert_update
+label: 'Entity type'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string


### PR DESCRIPTION
### Tests

- [x] Add a Video and a Gallery in a group and tag them with a specific topic
- [x] Check the "Post activity" option
- [x] Go to the topic detail page and check that you have one activity messages for each content in the acivitiy stream

### Remarks

- If you have previous actvity messages of types Gallery or Video, this might break the atcivity stream. Either delete them or start on new install