### PR TITLE
[EICNET-1569] restyle correctly related discussion in topics

### DIFF
--- a/lib/themes/eic_community/data/featured-content-collection/discussion.data.js
+++ b/lib/themes/eic_community/data/featured-content-collection/discussion.data.js
@@ -12,7 +12,7 @@ export default {
       content: DiscussionThreadTemplate(
         Object.assign(
           {
-            extra_classes: 'ecl-discussion-thread--has-compact-layout',
+            extra_classes: '',
             highlight: true,
             type: {
               icon: {
@@ -34,7 +34,7 @@ export default {
             highlight: {
               is_active: true,
             },
-            extra_classes: 'ecl-discussion-thread--has-compact-layout',
+            extra_classes: '',
             type: {
               icon: {
                 name: 'idea',

--- a/lib/themes/eic_community/sass/compositions/_discussion-thread.scss
+++ b/lib/themes/eic_community/sass/compositions/_discussion-thread.scss
@@ -141,7 +141,7 @@
   &__meta,
   &__featured-items {
     @include ecl-media-breakpoint-up('md') {
-      padding-left: calc(#{map-get($ecl-media, 'xs')} + #{ecl-box-model('padding', 'controls')});
+      padding-left: calc(#{map-get($ecl-media, 'xs')} + 1.25rem);
     }
   }
 
@@ -161,7 +161,6 @@
     position: relative;
     flex-wrap: wrap;
     gap: ecl-box-model('margin', 'controls');
-    flex-direction: column;
     @include ecl-media-breakpoint-up('md') {
       align-items: center;
       flex-direction: row;

--- a/lib/themes/eic_community/sass/compositions/_discussion-thread.scss
+++ b/lib/themes/eic_community/sass/compositions/_discussion-thread.scss
@@ -141,10 +141,7 @@
   &__meta,
   &__featured-items {
     @include ecl-media-breakpoint-up('md') {
-
-      #{$node}--has-compact-layout & {
-        padding-left: calc(#{map-get($ecl-media, '2xs')} + #{ecl-box-model('padding', 'controls')});
-      }
+      padding-left: calc(#{map-get($ecl-media, 'xs')} + #{ecl-box-model('padding', 'controls')});
     }
   }
 
@@ -182,8 +179,7 @@
   }
 
   &__timestamp {
-    @include ecl-responsive-font('meta');
-    @include ecl-responsive-font('meta');
+    @include ecl-responsive-font('label');
   }
 
   &__author {
@@ -227,7 +223,7 @@
   &__stats-item {
     align-items: center;
     color: ecl-typography('color', 'meta');
-    @include ecl-responsive-font('meta');
+    @include ecl-responsive-font('label');
   }
 
   &__stats-item-label {
@@ -235,12 +231,12 @@
   }
 
   &__stats-item-icon {
-    margin-right: ecl-box-model('padding', 'controls');
+    margin-right: $ecl-spacing-2-xs;
   }
 
-  &__tag {
+  & &__tag {
     @include ecl-responsive-font('meta');
-    background-color: map-get($ecl-colors, 'white');
+    background: map-get($ecl-colors, 'white');
     text-decoration: none;
     color: ecl-typography('color', 'title');
     padding: map-get($ecl-spacing, '2xs') map-get($ecl-spacing, 'xs');


### PR DESCRIPTION
### Ticket 
https://citnet.tech.ec.europa.eu/CITnet/jira/browse/EICNET-1569?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel

### Stoybook
http://localhost:9000/?path=/story/bundles-topic--topic-details

### Figma 
https://www.figma.com/file/WZH3qhNynnmm0H6FKmD3hi/EASME_v1?node-id=9625%3A46422

### What I did

- [ ] Topics have a wrong design: Grey background but should be white
- [ ] Author name and last comment are vertically aligned fully to the left. They should be aligned with the other text: the title, body text, topics
- [ ] There is too much space between the statistics icons and the numbers.
- [ ] Font size of the last activity is too small (when compared to the design and to other types of teasers)

