### PR TITLE
[EICNET-1907] change image style - change tag style

### DIFF
--- a/lib/themes/eic_community/sass/compositions/_organisation.scss
+++ b/lib/themes/eic_community/sass/compositions/_organisation.scss
@@ -1,5 +1,26 @@
 .ecl-organisation {
 
+  &__editorial-header {
+    & .ecl-editorial-header__image-wrapper {
+      position: relative;
+      border: 1px solid #cfcfcf;
+      border-radius: 50%;
+      overflow: hidden;
+      width: map-get($ecl-media, 'l');
+      height: map-get($ecl-media, 'l');
+      margin: 0 auto ecl-layout('gutter');
+
+      & .ecl-editorial-header__image {
+        width: 80%;
+        height: 80%;
+        object-fit: contain;
+        position: absolute;
+        left: 10%;
+        top: 10%;
+      }
+    }
+  }
+
   &__item {
     margin-bottom: $ecl-spacing-2-xl;
 
@@ -30,6 +51,13 @@
       & > ul {
         padding: 0;
         list-style: none;
+      }
+
+      & .ecl-tag {
+        text-decoration: none;
+        &:hover {
+          text-decoration: underline;
+        }
       }
     }
   }

--- a/lib/themes/eic_community/styleguide/bundles/organisation.stories.js
+++ b/lib/themes/eic_community/styleguide/bundles/organisation.stories.js
@@ -32,7 +32,7 @@ const header = {
   description: editableField(),
   title: 'The big debate about the Climate',
   image: {
-    src: 'http://picsum.photos/320/160',
+    src: 'https://upload.wikimedia.org/wikipedia/commons/thumb/5/5e/Acme_Markets_lolo.svg/1280px-Acme_Markets_lolo.svg.png',
   },
   flags: [
     {
@@ -145,7 +145,11 @@ export const Overview = () => OverviewTemplate({
 export const Detail = () => OrganisationDetailsTemplate(
   Object.assign(
     {
-      editorial_header: header,
+      editorial_header: {
+        ...header,
+        extra_classes: 'ecl-organisation__editorial-header',
+        title: 'Acme'
+      },
       subnavigation: subnavigation.organisation,
       common: common,
       site_footer: siteFooter,

--- a/lib/themes/eic_community/templates/group/group--organisation--full.html.twig
+++ b/lib/themes/eic_community/templates/group/group--organisation--full.html.twig
@@ -13,7 +13,7 @@
     {% embed "@theme/patterns/compositions/editorial-article.html.twig" with editorial_article|default({}) %}
         {% block content %}
             {% if details is not empty %}
-                <section class="ecl-organisation__details">
+                <section class="ecl-organisation__details ecl-organisation__item">
                     <h2>{{ details.title }}</h2>
                     {% for detailsItem in details.items %}
                         {% if detailsItem.type == 'stats' %}


### PR DESCRIPTION
### Tickets
https://citnet.tech.ec.europa.eu/CITnet/jira/projects/EICNET/issues/EICNET-1907?filter=myopenissues

### Figma 
https://www.figma.com/file/j583oU3vO3YfrU3SnZp4vQ/EIC---Analysis?node-id=3%3A3566

### What I did

- [ ] On the designs we show the logo of the company on the organisation detail page. The CMS now mentions "banner", which works. But is this a banner? The image is also inside a masked in a circle.
- [ ] Add some space between the topics and "announcements" title
- [ ] The labels for "target markets, Services and products offered, Topics" show underline. If you look at most other pages they never a underline. Screenshot below is from topic detail page. If this has been talked about (and we leave as is), please let me know.