### PR TITLE
EICNET-1896: Color group states on homepage

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/groups/group.inc
+++ b/lib/themes/eic_community/includes/preprocess/groups/group.inc
@@ -54,7 +54,7 @@ function eic_community_preprocess_group__group(array &$variables) {
       }
 
       // Get group visibility.
-      if (!empty($group_visibility_label = \Drupal::service('eic_groups.helper')->getGroupVisibilityLabel($group, 'short'))) {
+      if ($group_visibility_label = \Drupal::service('oec_group_flex.helper')->getGroupVisibilityTagLabel($group)) {
         $item['type']['label'] = $group_visibility_label;
         $item['type']['extra_classes'] = 'ecl-tag--is-' . strtolower($group_visibility_label);
       }


### PR DESCRIPTION
### Fixes

- Fix label and color of group visibility in homepage lists.

### Tests

- [x] As SA/SCM, go to the homepage
- [x] Make sure you have at least 1 group in the list of Most active groups with visibility set to "Community members only"
- [x] Make sure the visibility label of the group is showing "Restricted" in orange.