### PR TITLE
EICNET-2064: As a non logged in (anonymous user) I cannot access wiki pages on the upper level

### DIFF
--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -187,6 +187,42 @@ function eic_groups_group_content_insert(EntityInterface $entity) {
     // Re-create entity alias.
     \Drupal::service('pathauto.generator')->createEntityAlias($related_entity, 'insert');
   }
+
+  switch ($entity->bundle()) {
+    case 'wiki_page':
+      // We need to clear the wiki parent book cache in order to redirect the
+      // user to the right wiki page when accessing the book page. Otherwise
+      // the redirect response might point to the wrong wiki page.
+      \Drupal::classResolver(EntityOperations::class)
+        ->clearWikiPageBookCache($entity);
+      break;
+
+  }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_update().
+ */
+function eic_groups_node_update(EntityInterface $entity) {
+  /** @var \Drupal\group\Entity\GroupContentInterface[] $group_contents */
+  $group_contents = \Drupal::entityTypeManager()->getStorage('group_content')
+    ->loadByEntity($entity);
+
+  if (empty($group_contents)) {
+    return;
+  }
+
+  switch ($entity->bundle()) {
+    case 'wiki_page':
+      // We need to clear the wiki parent book cache in order to redirect the
+      // user to the right wiki page when accessing the book page. Otherwise
+      // the redirect response might point to the wrong wiki page.
+      \Drupal::classResolver(EntityOperations::class)
+        ->clearWikiPageBookCache($entity);
+      break;
+
+  }
+
 }
 
 /**

--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -205,8 +205,7 @@ function eic_groups_group_content_insert(EntityInterface $entity) {
  */
 function eic_groups_node_update(EntityInterface $entity) {
   /** @var \Drupal\group\Entity\GroupContentInterface[] $group_contents */
-  $group_contents = \Drupal::entityTypeManager()->getStorage('group_content')
-    ->loadByEntity($entity);
+  $group_contents = \Drupal::service('eic_content.helper')->getGroupContentByEntity($entity);
 
   if (empty($group_contents)) {
     return;

--- a/lib/modules/eic_groups/src/EventSubscriber/BookPageRedirectSubscriber.php
+++ b/lib/modules/eic_groups/src/EventSubscriber/BookPageRedirectSubscriber.php
@@ -90,9 +90,10 @@ class BookPageRedirectSubscriber implements EventSubscriberInterface {
     if (!empty($book_data['below'])) {
       $wiki_page_nid = reset($book_data['below'])['link']['nid'];
       $wiki_page = $this->entityTypeManager->getStorage('node')->load($wiki_page_nid);
-      $redirect_response = new CacheableRedirectResponse($wiki_page->toUrl()->toString());
+      $redirect_response = new CacheableRedirectResponse($wiki_page->toUrl()->toString(), 301);
       $redirect_response->addCacheableDependency($wiki_page);
-      $redirect_response->send();
+      $redirect_response->addCacheableDependency($node);
+      $event->setResponse($redirect_response);
     }
   }
 


### PR DESCRIPTION
### Fixes

- Fix redirect issue when accessing wiki section as anonymous user;
- Update wiki redirection when changing wiki page weights;
- Fix coding standards.

### Tests

- [x] As anonymous user, navigate to a group wiki section (`/groups/<group-name>/wiki`) which contains at least 2 wiki pages in the first level
- [x] Make sure you get redirected to the first wiki page of the section
- [x] As SA/SCM, edit the first wiki page and change the book outline order to the end
- [x] As anonymous user, try to access the wiki section `/groups/<group-name>/wiki` and make sure you get redirected to the first wiki page of the section (it should be the wiki page that was in the second position before changing the orders)
- [x] Try to access the wiki section again `/groups/<group-name>/wiki` and make sure you still get redirected to the wiki page