### PR TITLE
[EICNET-1847] cancel the jump when we use a filter on mobile

### DIFF
--- a/lib/themes/eic_community/react/components/Block/Overview/Search/Field/CheckboxField.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/Field/CheckboxField.js
@@ -15,9 +15,9 @@ class CheckboxField extends React.Component {
     if (this.props.value[1] === 0) {
       return
     }
-
     const checked = !this.props.checked;
     this.props.updateFacet(value, checked, this.props.facet);
+    this.props.onChange(e)
   }
 
   render() {

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/Field/CollapsedOptions.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/Field/CollapsedOptions.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 import CheckboxField from "./CheckboxField";
 import svg from "../../../../../svg/svg"
 
@@ -10,6 +10,7 @@ const CollapsedOptions = ({values, facetsValue, bundle, updateFacet, translation
   const [collapsed, setCollapsed] = useState(false)
   const [index, setIndex] = useState(minItems)
   const [isHide, setIsHide] = useState(true)
+  const currentGroup = useRef()
   const facets = values.length >= 1 && values[1].filter(option => {
     return (option[0] || option[1] !== 0) && (values[0] !== 'ss_global_content_type' || bundle !== 'library' || ['video', 'document', 'gallery'].includes(option[0]))
   })
@@ -19,6 +20,14 @@ const CollapsedOptions = ({values, facetsValue, bundle, updateFacet, translation
     setIsHide(true)
   }, [collapsed])
 
+  const hanldeFilterChecked = useCallback(() => {
+    if(window.innerWidth > 768) {
+      return
+    }
+    const el = currentGroup.current
+    el.parentElement.scrollIntoView()
+  }, [])
+
   const action = '<span class="ecl-button__label" data-ecl-label="true">'+ (isHide ? translations.show_more : translations.collapse) +'</span>' + svg('arrow-down', `ecl-icon ecl-icon--xs ${isHide && 'ecl-icon--rotate-180'} ecl-button__icon ecl-button__icon--after`)
   const showmoreHandleClick = () => {
     const newIndex = index !== minItems ? minItems : facets.length
@@ -26,7 +35,7 @@ const CollapsedOptions = ({values, facetsValue, bundle, updateFacet, translation
     setIsHide(!isHide)
   }
   return (
-    <div className="ecl-filter-sidebar__item" aria-expanded={!collapsed}>
+    <div ref={currentGroup} className="ecl-filter-sidebar__item" aria-expanded={!collapsed}>
 
       <div onClick={() => setCollapsed(!collapsed)} className="ecl-filter-sidebar__item-label ecl-filter-sidebar__item-label--facets" tabIndex="0">
         {sourceTranslations.sources[sourceBundle].facet[values[0]]}
@@ -39,7 +48,7 @@ const CollapsedOptions = ({values, facetsValue, bundle, updateFacet, translation
             const facetValue = facetsValue[values[0]];
             const checked = facetValue ? facetValue[option[0]] : false;
 
-            return <CheckboxField checked={checked} key={option[0]} facet={values[0]} updateFacet={updateFacet} value={option}/>
+            return <CheckboxField onChange={hanldeFilterChecked} checked={checked} key={option[0]} facet={values[0]} updateFacet={updateFacet} value={option}/>
           })}
         </div>
         {facets.length > minItems && (

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/TopOptions/ActiveFacet.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/TopOptions/ActiveFacet.js
@@ -5,25 +5,31 @@ class SortOption extends React.Component {
   constructor(props) {
     super(props);
 
+    this.el = React.createRef()
+
     this.onClick = this.onClick.bind(this);
+    this.resetScroll = this.resetScroll.bind(this);
   }
 
-  onClick(e) {
+  onClick() {
+    this.resetScroll()
     this.props.updateFacet(this.props.value, false, this.props.facet);
+  }
+
+  resetScroll() {
+    if(window.innerWidth > 768) {
+      return
+    }
+    this.el.current.parentElement.scrollIntoView()
   }
 
   render() {
     return (
-      <button onClick={this.onClick} type="button" aria-label="Dismiss" className="ecl-tag ecl-tag--removable ecl-teaser-overview__active-filters-item">
+      <button ref={this.el} onClick={this.onClick} type="button" aria-label="Dismiss" className="ecl-tag ecl-tag--removable ecl-teaser-overview__active-filters-item">
         {this.props.value[0].toUpperCase() + this.props.value.slice(1).replace(/_/g, " ")}
         <span className="ecl-tag__icon" dangerouslySetInnerHTML={{__html: svg('clear')}}/>
       </button>
     )
-    // return <div onClick={this.onClick} className="ecl-teaser-overview__active-filters-item">
-    //           <div className="ecl-tag ecl-tag--removable ecl-teaser-overview__active-filters-tag">{this.props.value[0].toUpperCase() + this.props.value.slice(1).replace(/_/g, " ")}
-    //             <button type="button" data-value="content-type=news" className="ecl-tag__icon"  />
-    //           </div>
-    // </div>
   }
 }
 


### PR DESCRIPTION
### Ticket
https://citnet.tech.ec.europa.eu/CITnet/jira/browse/EICNET-1847

### What I did

- [ ] On a small screen, when you click on the filter elements, you move to the scroll position of the parent element.
- [ ] same thing when you click on the tags to cancel the filter 