### PR TITLE
EICNET-1940: Email notification for user tagging in comments

### DIFF
--- a/config/sync/core.entity_form_display.message.notify_user_tagged_on_comment.default.yml
+++ b/config/sync/core.entity_form_display.message.notify_user_tagged_on_comment.default.yml
@@ -1,0 +1,45 @@
+uuid: c40ac14d-5192-44a6-9373-2912307d943f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.message.notify_user_tagged_on_comment.field_event_executing_user
+    - field.field.message.notify_user_tagged_on_comment.field_referenced_comment
+    - field.field.message.notify_user_tagged_on_comment.field_rendered_content
+    - message.template.notify_user_tagged_on_comment
+  module:
+    - text
+id: message.notify_user_tagged_on_comment.default
+targetEntityType: message
+bundle: notify_user_tagged_on_comment
+mode: default
+content:
+  field_event_executing_user:
+    type: entity_reference_autocomplete
+    weight: 0
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_referenced_comment:
+    type: entity_reference_autocomplete
+    weight: 1
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_rendered_content:
+    type: text_textarea
+    weight: 2
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/config/sync/core.entity_view_display.comment.node_comment.notification_teaser.yml
+++ b/config/sync/core.entity_view_display.comment.node_comment.notification_teaser.yml
@@ -1,0 +1,42 @@
+uuid: 4b53fb56-3432-40c3-81e1-3cd5ee2019da
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.node_comment
+    - core.entity_view_mode.comment.notification_teaser
+    - field.field.comment.node_comment.comment_body
+    - field.field.comment.node_comment.field_comment_attachment
+    - field.field.comment.node_comment.field_comment_deletion_date
+    - field.field.comment.node_comment.field_comment_is_soft_deleted
+    - field.field.comment.node_comment.field_tagged_users
+  module:
+    - text
+id: comment.node_comment.notification_teaser
+targetEntityType: comment
+bundle: node_comment
+mode: notification_teaser
+content:
+  comment_body:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_tagged_users:
+    type: entity_reference_label
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  field_comment_attachment: true
+  field_comment_deletion_date: true
+  field_comment_is_soft_deleted: true
+  flag_like_comment: true
+  langcode: true
+  links: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.notify_user_tagged_on_comment.default.yml
+++ b/config/sync/core.entity_view_display.message.notify_user_tagged_on_comment.default.yml
@@ -1,0 +1,51 @@
+uuid: e4e79df8-5b09-47c8-8203-f18b6a6f197c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.message.notify_user_tagged_on_comment.field_event_executing_user
+    - field.field.message.notify_user_tagged_on_comment.field_referenced_comment
+    - field.field.message.notify_user_tagged_on_comment.field_rendered_content
+    - message.template.notify_user_tagged_on_comment
+  module:
+    - text
+id: message.notify_user_tagged_on_comment.default
+targetEntityType: message
+bundle: notify_user_tagged_on_comment
+mode: default
+content:
+  field_event_executing_user:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_referenced_comment:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_rendered_content:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  partial_0:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  partial_1:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.notify_user_tagged_on_comment.mail_body.yml
+++ b/config/sync/core.entity_view_display.message.notify_user_tagged_on_comment.mail_body.yml
@@ -1,0 +1,24 @@
+uuid: 82e92d36-95a2-4837-8f74-e2cefb2fa796
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.message.mail_body
+    - field.field.message.notify_user_tagged_on_comment.field_event_executing_user
+    - field.field.message.notify_user_tagged_on_comment.field_referenced_comment
+    - field.field.message.notify_user_tagged_on_comment.field_rendered_content
+    - message.template.notify_user_tagged_on_comment
+id: message.notify_user_tagged_on_comment.mail_body
+targetEntityType: message
+bundle: notify_user_tagged_on_comment
+mode: mail_body
+content:
+  partial_1:
+    weight: 0
+    region: content
+hidden:
+  field_event_executing_user: true
+  field_referenced_comment: true
+  field_rendered_content: true
+  partial_0: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.notify_user_tagged_on_comment.mail_subject.yml
+++ b/config/sync/core.entity_view_display.message.notify_user_tagged_on_comment.mail_subject.yml
@@ -1,0 +1,24 @@
+uuid: 47d2ec9e-93a2-4ea5-b5cd-91b420aa4ddb
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.message.mail_subject
+    - field.field.message.notify_user_tagged_on_comment.field_event_executing_user
+    - field.field.message.notify_user_tagged_on_comment.field_referenced_comment
+    - field.field.message.notify_user_tagged_on_comment.field_rendered_content
+    - message.template.notify_user_tagged_on_comment
+id: message.notify_user_tagged_on_comment.mail_subject
+targetEntityType: message
+bundle: notify_user_tagged_on_comment
+mode: mail_subject
+content:
+  partial_0:
+    weight: 0
+    region: content
+hidden:
+  field_event_executing_user: true
+  field_referenced_comment: true
+  field_rendered_content: true
+  partial_1: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_mode.comment.notification_teaser.yml
+++ b/config/sync/core.entity_view_mode.comment.notification_teaser.yml
@@ -1,0 +1,10 @@
+uuid: 8e437149-9ed9-44bf-92f1-8f9c405cadc1
+langcode: en
+status: true
+dependencies:
+  module:
+    - comment
+id: comment.notification_teaser
+label: 'Notification teaser'
+targetEntityType: comment
+cache: true

--- a/config/sync/field.field.message.notify_user_tagged_on_comment.field_event_executing_user.yml
+++ b/config/sync/field.field.message.notify_user_tagged_on_comment.field_event_executing_user.yml
@@ -1,0 +1,29 @@
+uuid: f8d0dab9-a609-4a86-b538-b2c301e24b87
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_event_executing_user
+    - message.template.notify_user_tagged_on_comment
+id: message.notify_user_tagged_on_comment.field_event_executing_user
+field_name: field_event_executing_user
+entity_type: message
+bundle: notify_user_tagged_on_comment
+label: 'Event executing user'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:user'
+  handler_settings:
+    target_bundles: null
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    filter:
+      type: _none
+    include_anonymous: false
+field_type: entity_reference

--- a/config/sync/field.field.message.notify_user_tagged_on_comment.field_referenced_comment.yml
+++ b/config/sync/field.field.message.notify_user_tagged_on_comment.field_referenced_comment.yml
@@ -1,0 +1,29 @@
+uuid: de9ea4db-da3d-48a1-967d-8a84c36ff8db
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.node_comment
+    - field.storage.message.field_referenced_comment
+    - message.template.notify_user_tagged_on_comment
+id: message.notify_user_tagged_on_comment.field_referenced_comment
+field_name: field_referenced_comment
+entity_type: message
+bundle: notify_user_tagged_on_comment
+label: 'Referenced comment'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:comment'
+  handler_settings:
+    target_bundles:
+      node_comment: node_comment
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.message.notify_user_tagged_on_comment.field_rendered_content.yml
+++ b/config/sync/field.field.message.notify_user_tagged_on_comment.field_rendered_content.yml
@@ -1,0 +1,21 @@
+uuid: ff88163b-8402-486f-aa75-d183db013c93
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_rendered_content
+    - message.template.notify_user_tagged_on_comment
+  module:
+    - text
+id: message.notify_user_tagged_on_comment.field_rendered_content
+field_name: field_rendered_content
+entity_type: message
+bundle: notify_user_tagged_on_comment
+label: 'Rendered content'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/config/sync/language/en/message.template.notify_user_tagged_on_comment.yml
+++ b/config/sync/language/en/message.template.notify_user_tagged_on_comment.yml
@@ -1,0 +1,7 @@
+text:
+  -
+    value: "<p>[message:field_event_executing_user:entity:field_first_name]&nbsp;[message:field_event_executing_user:entity:field_last_name]&nbsp;tagged you in a comment</p>\r\n"
+    format: full_html
+  -
+    value: "<p><a href=\"[message:field_event_executing_user:entity:url]\">[message:field_event_executing_user:entity:field_first_name]&nbsp;[message:field_event_executing_user:entity:field_last_name]</a> tagged you in a comment:</p>\r\n\r\n<div>[message:raw-value:field_rendered_content]</div>\r\n\r\n<p><a href=\"[message:field_referenced_comment:entity:url]\">View comment</a></p>\r\n"
+    format: full_html

--- a/config/sync/message.template.notify_user_tagged_on_comment.yml
+++ b/config/sync/message.template.notify_user_tagged_on_comment.yml
@@ -1,0 +1,27 @@
+uuid: d2cbf7c2-772a-4a2c-9c42-f36f1842991a
+langcode: en
+status: true
+dependencies:
+  config:
+    - filter.format.full_html
+  module:
+    - eic_messages
+third_party_settings:
+  eic_messages:
+    message_template_type: notification
+template: notify_user_tagged_on_comment
+label: 'NOTIFY :: MT:: User tagged on comment'
+description: 'Notifies a user when tagged on a comment by another user'
+text:
+  -
+    value: "<p>[message:field_event_executing_user:entity:field_first_name]&nbsp;[message:field_event_executing_user:entity:field_last_name]&nbsp;tagged you in a comment</p>\r\n"
+    format: full_html
+  -
+    value: "<p><a href=\"[message:field_event_executing_user:entity:url]\">[message:field_event_executing_user:entity:field_first_name]&nbsp;[message:field_event_executing_user:entity:field_last_name]</a> tagged you in a comment:</p>\r\n\r\n<div>[message:raw-value:field_rendered_content]</div>\r\n\r\n<p><a href=\"[message:field_referenced_comment:entity:url]\">View comment</a></p>\r\n"
+    format: full_html
+settings:
+  'token options':
+    clear: false
+    'token replace': true
+  purge_override: false
+  purge_methods: {  }

--- a/lib/modules/eic_messages/eic_messages.module
+++ b/lib/modules/eic_messages/eic_messages.module
@@ -45,13 +45,12 @@ function eic_messages_group_update(EntityInterface $entity) {
 
 /**
  * Implements hook_ENTITY_TYPE_update().
- *
- * @param \Drupal\comment\CommentInterface $entity
  */
 function eic_messages_comment_insert(EntityInterface $entity) {
   /** @var \Drupal\eic_messages\Service\CommentMessageCreator $group_message_create */
   $group_message_create = \Drupal::classResolver(CommentMessageCreator::class);
   $group_message_create->createCommentActivity($entity, ActivityStreamOperationTypes::NEW_ENTITY);
+  $group_message_create->createCommentTaggedUsersNotification($entity);
 }
 
 /**

--- a/lib/modules/eic_messages/src/Service/CommentMessageCreator.php
+++ b/lib/modules/eic_messages/src/Service/CommentMessageCreator.php
@@ -4,9 +4,13 @@ namespace Drupal\eic_messages\Service;
 
 use Drupal\comment\CommentInterface;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\eic_content\EICContentHelperInterface;
+use Drupal\eic_messages\Hooks\MessageTokens;
 use Drupal\eic_messages\Util\ActivityStreamMessageTemplates;
+use Drupal\eic_messages\Util\NotificationMessageTemplates;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -17,35 +21,66 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class CommentMessageCreator implements ContainerInjectionInterface {
 
   /**
+   * The current route.
+   *
    * @var \Drupal\Core\Routing\RouteMatchInterface
    */
   private $routeMatch;
 
   /**
-   * The EIC Content helper service.
+   * The EIC content helper service.
    *
    * @var \Drupal\eic_content\EICContentHelperInterface
    */
   private $contentHelper;
 
   /**
+   * The message bus service.
+   *
    * @var \Drupal\eic_messages\Service\MessageBusInterface
    */
   private $messageBus;
 
   /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  private $entityTypeManager;
+
+  /**
+   * The renderer service.
+   *
+   * @var \Drupal\Core\Render\RendererInterface
+   */
+  private $renderer;
+
+  /**
+   * Constructs a new CommentMessageCreator object.
+   *
    * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The current route.
    * @param \Drupal\eic_content\EICContentHelperInterface $content_helper
+   *   The EIC content helper service.
    * @param \Drupal\eic_messages\Service\MessageBusInterface $message_bus
+   *   The message bus service.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Render\RendererInterface $renderer
+   *   The renderer service.
    */
   public function __construct(
     RouteMatchInterface $route_match,
     EICContentHelperInterface $content_helper,
-    MessageBusInterface $message_bus
+    MessageBusInterface $message_bus,
+    EntityTypeManagerInterface $entity_type_manager,
+    RendererInterface $renderer
   ) {
     $this->routeMatch = $route_match;
     $this->contentHelper = $content_helper;
     $this->messageBus = $message_bus;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->renderer = $renderer;
   }
 
   /**
@@ -55,7 +90,9 @@ class CommentMessageCreator implements ContainerInjectionInterface {
     return new static(
       $container->get('current_route_match'),
       $container->get('eic_content.helper'),
-      $container->get('eic_messages.message_bus')
+      $container->get('eic_messages.message_bus'),
+      $container->get('entity_type.manager'),
+      $container->get('renderer')
     );
   }
 
@@ -92,6 +129,39 @@ class CommentMessageCreator implements ContainerInjectionInterface {
       'field_operation_type' => $operation,
       'field_group_ref' => $group_content->getGroup(),
     ]);
+  }
+
+  /**
+   * Creates a notification message for tagged users in a comment.
+   *
+   * @param \Drupal\comment\CommentInterface $entity
+   *   The group having this content.
+   */
+  public function createCommentTaggedUsersNotification(
+    CommentInterface $entity
+  ) {
+    // If there are no tagged users, we do nothing.
+    if ($entity->get('field_tagged_users')->isEmpty()) {
+      return;
+    }
+
+    // Get the comment notification teaser renderable array.
+    $comment_teaser = $this->entityTypeManager->getViewBuilder('comment')
+      ->view($entity, 'notification_teaser');
+    // Get the rendered HTML markup of comment notification teaser.
+    $rendered_comment_teaser = $this->renderer->render($comment_teaser);
+    /** @var \Drupal\user\UserInterface[] $tagged_users */
+    $tagged_users = $entity->get('field_tagged_users')->referencedEntities();
+    // Creates a notification message for each tagged user.
+    foreach ($tagged_users as $user) {
+      $this->messageBus->dispatch([
+        'template' => NotificationMessageTemplates::USER_TAGGED_ON_COMMENT,
+        'uid' => $user->id(),
+        'field_referenced_comment' => $entity,
+        'field_event_executing_user' => $entity->getOwner(),
+        MessageTokens::RENDERED_CONTENT_FIELD => $rendered_comment_teaser,
+      ]);
+    }
   }
 
 }

--- a/lib/modules/eic_messages/src/Util/NotificationMessageTemplates.php
+++ b/lib/modules/eic_messages/src/Util/NotificationMessageTemplates.php
@@ -17,6 +17,11 @@ final class NotificationMessageTemplates implements MessageIdentifierInterface {
   const TRANSFER_GROUP_OWNERSHIP = 'notify_transfer_group_ownership';
 
   /**
+   * Message template for notifying user when tagged on a comment.
+   */
+  const USER_TAGGED_ON_COMMENT = 'notify_user_tagged_on_comment';
+
+  /**
    * {@inheritdoc}
    */
   public static function getMessageTemplatePrimaryKeys(MessageTemplateInterface $message_template) {

--- a/lib/themes/eic_community/includes/preprocess/comments/comment.inc
+++ b/lib/themes/eic_community/includes/preprocess/comments/comment.inc
@@ -107,6 +107,18 @@ function eic_community_preprocess_comment(&$variables) {
   $link = $flag_link_builder->build('comment', $comment->id(), 'like_comment');
 
   $variables['comment']['flag_link'] = $link;
+
+  $view_mode = $variables['elements']['#view_mode'];
+
+  switch ($view_mode) {
+    case 'notification_teaser':
+      // Removes unneeded variables from notification teaser.
+      unset($variables['comment']['is_owner']);
+      unset($variables['comment']['user']);
+      break;
+
+  }
+
 }
 
 /**

--- a/lib/themes/eic_community/templates/content/comment--notification-teaser.html.twig
+++ b/lib/themes/eic_community/templates/content/comment--notification-teaser.html.twig
@@ -1,0 +1,6 @@
+{# Todo: we need to change this template that will be used in the notifications. #}
+<div class="ecl-comment-overview__item">
+  <div class="ecl-comment-thread">
+  {% include "@theme/patterns/compositions/comment/comment-base.html.twig" with comment|default({}) only %}
+  </div>
+</div>


### PR DESCRIPTION
### Features

- Create new message type notification for tagged users in comments;
- Create logic to send message notification to tagged users;
- Create new view mode notification teaser to use when rendering a comment in the notification message;
- Provide example template for the comment notification teaser view mode.

### Tests

