### PR TITLE
EICNET-1896: Color group states on homepage (Custom restricted groups)

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/groups/group.inc
+++ b/lib/themes/eic_community/includes/preprocess/groups/group.inc
@@ -55,6 +55,13 @@ function eic_community_preprocess_group__group(array &$variables) {
 
       // Get group visibility.
       if ($group_visibility_label = \Drupal::service('oec_group_flex.helper')->getGroupVisibilityTagLabel($group)) {
+
+        // Exception for the custom visibility. We need to show the label
+        // "Restricted" instead.
+        if (strtolower($group_visibility_label) === 'custom') {
+          $group_visibility_label = t('Restricted');
+        }
+
         $item['type']['label'] = $group_visibility_label;
         $item['type']['extra_classes'] = 'ecl-tag--is-' . strtolower($group_visibility_label);
       }


### PR DESCRIPTION
### Improvements

- Change group visibility label for custom restricted groups to "Restricted"

### Tests

- [ ] As SA/SCM/GM/GO/GA when I view custom restricted groups in lists or detail pages, I should always see the label "Restricted" instead of "Custom" and also in orange.