### PR TITLE
EICNET-2085: Anonymous user sees Group management button

### DIFF
--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
@@ -260,7 +260,7 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
       return in_array(
         $key,
         ['edit', 'delete', 'publish', 'request_block', 'bulk_invite']
-      );
+      ) && $item['url']->access();
     }, ARRAY_FILTER_USE_BOTH);
 
     // Sorts group operation links by key. "Delete" operation needs to show
@@ -374,7 +374,7 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
 
       // If user has access to view the flag we add it to the results so that
       // it can be shown in the group header.
-      if ($flag->actionAccess($action)) {
+      if ($flag->actionAccess($action, NULL, $group)) {
         $group_flags[$flag_id] = [
           '#lazy_builder' => [
             'flag.link_builder:build',

--- a/lib/themes/eic_community/includes/preprocess/common.inc
+++ b/lib/themes/eic_community/includes/preprocess/common.inc
@@ -138,7 +138,7 @@ function _eic_community_get_flag_access($flag_id, EntityInterface $entity) {
   $user_flag = $flag_service->getFlagging($flag, $entity);
   $action = $user_flag ? 'unflag' : 'flag';
 
-  return $flag->actionAccess($action);
+  return $flag->actionAccess($action, NULL, $entity);
 }
 
 /**


### PR DESCRIPTION
### Improvements

- Hide group management dropdown for anonymous users;
- Improvements in logic to check access to a flag in the theme.

### Tests

- [x] As anonymous user, navigate to a group detail page
- [x] Make sure you can't view the group management dropdown