### PR TITLE
EICNET-1896: Color group states (sitewide)

### DIFF
--- a/lib/modules/oec_group_flex/src/OECGroupFlexHelper.php
+++ b/lib/modules/oec_group_flex/src/OECGroupFlexHelper.php
@@ -120,6 +120,12 @@ class OECGroupFlexHelper {
     $group_visibility = $this->getGroupVisibilitySettings($group);
     $tag = strpos($group_visibility['plugin_id'], '_') !== FALSE ? strstr($group_visibility['plugin_id'], '_', TRUE) : $group_visibility['plugin_id'];
 
+    // Exception for the custom visibility. We need to show the label
+    // "Restricted" instead.
+    if ($group_visibility['plugin_id'] === 'custom_restricted') {
+      $tag = 'restricted';
+    }
+
     return ucfirst($tag);
   }
 

--- a/lib/themes/eic_community/includes/preprocess/groups/group.inc
+++ b/lib/themes/eic_community/includes/preprocess/groups/group.inc
@@ -55,13 +55,6 @@ function eic_community_preprocess_group__group(array &$variables) {
 
       // Get group visibility.
       if ($group_visibility_label = \Drupal::service('oec_group_flex.helper')->getGroupVisibilityTagLabel($group)) {
-
-        // Exception for the custom visibility. We need to show the label
-        // "Restricted" instead.
-        if (strtolower($group_visibility_label) === 'custom') {
-          $group_visibility_label = t('Restricted');
-        }
-
         $item['type']['label'] = $group_visibility_label;
         $item['type']['extra_classes'] = 'ecl-tag--is-' . strtolower($group_visibility_label);
       }


### PR DESCRIPTION
### Improvements

- Change group visibility label for custom restricted groups sitewide.

### Tests

- [x] As SA/SCM/GM/GO/GA when I view custom restricted groups in lists, overview pages or detail pages, I should always see the label "Restricted" instead of "Custom" and also in orange.