### PR TITLE
[EICNET-1908]feat: Create new endpoint for organisation "/team" overview

### DIFF
--- a/config/sync/context.context.group_members_overviews.yml
+++ b/config/sync/context.context.group_members_overviews.yml
@@ -17,7 +17,7 @@ conditions:
     negate: false
     uuid: f43d7d69-4d35-4f45-adc7-347224f302b5
     context_mapping: {  }
-    routes: eic_overviews.groups.overview_page.members
+    routes: "eic_overviews.groups.overview_page.members\r\neic_overviews.groups.overview_page.team"
 reactions:
   blocks:
     id: blocks

--- a/lib/modules/eic_groups/eic_groups.install
+++ b/lib/modules/eic_groups/eic_groups.install
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\eic_groups\Constants\NodeProperty;
+use Drupal\group_content_menu\GroupContentMenuInterface;
 use Drupal\group_permissions\Entity\GroupPermission;
 
 /**
@@ -25,7 +26,12 @@ function eic_groups_install() {
     ->setDisplayConfigurable('view', TRUE);
 
   \Drupal::entityDefinitionUpdateManager()
-    ->installFieldStorageDefinition(NodeProperty::MEMBER_CONTENT_EDIT_ACCESS, 'node', 'node', $field_storage_definition);
+    ->installFieldStorageDefinition(
+      NodeProperty::MEMBER_CONTENT_EDIT_ACCESS,
+      'node',
+      'node',
+      $field_storage_definition
+    );
 }
 
 /**
@@ -124,7 +130,11 @@ function eic_groups_update_9002(&$sandbox) {
     }
 
     foreach ($roles as $role) {
-      \Drupal::service('eic_groups.helper')->removeRolePermissionsFromGroup($group_permission, $role, ['view comments']);
+      \Drupal::service('eic_groups.helper')->removeRolePermissionsFromGroup(
+        $group_permission,
+        $role,
+        ['view comments']
+      );
     }
 
     $group_permission->setNewRevision();
@@ -142,3 +152,38 @@ function eic_groups_update_9002(&$sandbox) {
     $group->save();
   }
 }
+
+/**
+ * Remove old menu link "/members" link from the Organisation.
+ */
+function eic_groups_update_9003(&$sandbox) {
+  /** @var \Drupal\Core\Entity\EntityTypeManagerInterface $em */
+  $em = \Drupal::service('entity_type.manager');
+  $organisations = $em->getStorage('group')->loadByProperties([
+    'type' => 'organisation',
+  ]);
+  $menu_name = 'group_main_menu';
+
+  foreach ($organisations as $organisation) {
+    foreach (group_content_menu_get_menus_per_group($organisation) as $group_menu) {
+      if (
+        $group_menu->getGroupContentType()->getContentPlugin()->getPluginId() ==
+        "group_content_menu:$menu_name"
+      ) {
+        $items = $em->getStorage('menu_link_content')->loadByProperties([
+          'menu_name' => GroupContentMenuInterface::MENU_PREFIX . $group_menu->getEntity()->id(),
+          'title' => 'Team',
+        ]);
+
+        if (empty($items)) {
+          continue;
+        }
+
+        /** @var \Drupal\menu_link_content\Entity\MenuLinkContent $menu_item_people */
+        $menu_item_people = reset($items);
+        $menu_item_people->delete();
+      }
+    }
+  }
+}
+

--- a/lib/modules/eic_groups/src/Plugin/GroupFeature/GroupAnchorFeature/GroupAnchorMembers.php
+++ b/lib/modules/eic_groups/src/Plugin/GroupFeature/GroupAnchorFeature/GroupAnchorMembers.php
@@ -16,6 +16,13 @@ use Drupal\eic_groups\Plugin\GroupFeature\GroupMembers;
 class GroupAnchorMembers extends GroupMembers {
 
   /**
+   * Route of the members overview.
+   *
+   * @var string
+   */
+  const PRIMARY_OVERVIEW_ROUTE = 'eic_overviews.groups.overview_page.team';
+
+  /**
    * {@inheritdoc}
    */
   const ANCHOR_ID = 'members';

--- a/lib/modules/eic_overviews/eic_overviews.routing.yml
+++ b/lib/modules/eic_overviews/eic_overviews.routing.yml
@@ -43,6 +43,13 @@ eic_overviews.groups.overview_page.members:
     _title: 'Members'
   requirements:
     _custom_access: '\Drupal\eic_overviews\Controller\GroupOverviewsController::access'
+eic_overviews.groups.overview_page.team:
+  path: '/group/{group}/team'
+  defaults:
+    _controller: '\Drupal\eic_overviews\Controller\GroupOverviewsController::buildGenericPage'
+    _title: 'Team'
+  requirements:
+    _custom_access: '\Drupal\eic_overviews\Controller\GroupOverviewsController::access'
 eic_overviews.groups.overview_page.latest_activity_stream:
   path: '/group/{group}/latest-activity'
   defaults:

--- a/lib/modules/eic_overviews/src/Controller/GroupOverviewsController.php
+++ b/lib/modules/eic_overviews/src/Controller/GroupOverviewsController.php
@@ -59,6 +59,7 @@ class GroupOverviewsController extends ControllerBase {
         break;
 
       case GroupOverviewPages::MEMBERS:
+      case GroupOverviewPages::ORGANISATIONS_TEAM:
         $overview_perm = 'access members overview';
         break;
 

--- a/lib/modules/eic_overviews/src/GroupOverviewPages.php
+++ b/lib/modules/eic_overviews/src/GroupOverviewPages.php
@@ -38,6 +38,11 @@ class GroupOverviewPages {
   const MEMBERS = 'eic_overviews.groups.overview_page.members';
 
   /**
+   * Route to the group team from organisation overview.
+   */
+  const ORGANISATIONS_TEAM = 'eic_overviews.groups.overview_page.team';
+
+  /**
    * Route to the group news overview.
    */
   const NEWS = 'eic_overviews.groups.overview_page.news';

--- a/lib/themes/eic_community/includes/preprocess/groups/organisation.inc
+++ b/lib/themes/eic_community/includes/preprocess/groups/organisation.inc
@@ -296,7 +296,7 @@ function _eic_community_render_organisation_detail_page(&$variables, $group) {
       'link' => [
         'label' => t('See all members', [], ['context' => 'eic_community']),
         'path' => Url::fromRoute(
-          GroupOverviewPages::MEMBERS,
+          GroupOverviewPages::ORGANISATIONS_TEAM,
           ['group' => $group instanceof GroupInterface ? $group->id() : 0]
         ),
       ],


### PR DESCRIPTION
How to test:

- [x] Be sure the "drush updb" has been done.
- [x] Go to an organisation, edit it, and check the feature "Team".
- [x] Go to the detail page of organisation, verify that the Team tab is enabled and the see all members in the block redirect to /team overview
- [x] Verify that the Team tab is active