### PR TITLE
EICNET-1532: Filelist header width fix.

### DIFF
--- a/lib/themes/eic_community/sass/components/_filelist.scss
+++ b/lib/themes/eic_community/sass/components/_filelist.scss
@@ -34,6 +34,9 @@
       flex-grow: 1;
       display: flex;
       flex-direction: column;
+      @include ecl-media-breakpoint-up('sm') {
+        flex-basis: calc(100% - 140px - 1.25rem);
+      }
     }
 
     &-image-wrapper {


### PR DESCRIPTION
Fixed the issue where the header for the filelist wraps to the next line when a filename is too long.