### PR TITLE
EICNET-2076: Disable like action and statistics in comments (GM/GO/GA)

### DIFF
--- a/lib/modules/eic_comments/eic_comments.module
+++ b/lib/modules/eic_comments/eic_comments.module
@@ -145,7 +145,8 @@ function eic_comments_flag_action_access($action, FlagInterface $flag, AccountIn
   switch ($flaggable->getEntityTypeId()) {
     case 'comment':
       // Deny access to flag/unflag the comment if the comment has been soft
-      // deleted or archived.
+      // deleted, archived or if the user doesn't have permission to view
+      // comments.
       if (
         (
           !$flaggable->get('field_comment_is_soft_deleted')->isEmpty() &&
@@ -154,7 +155,8 @@ function eic_comments_flag_action_access($action, FlagInterface $flag, AccountIn
         (
           !$flaggable->get('field_comment_is_archived')->isEmpty() &&
           $flaggable->get('field_comment_is_archived')->value
-        )
+        ) ||
+        !$account->hasPermission('access comments')
       ) {
         $access = AccessResult::forbidden()
           ->addCacheableDependency($flaggable);
@@ -165,11 +167,30 @@ function eic_comments_flag_action_access($action, FlagInterface $flag, AccountIn
       $commented_entity = $flaggable->getCommentedEntity();
 
       // If node is published, the access to flag/unflag the comment will be
-      // neutral and might be allowed or denied by other modules.
+      // neutral and might be allowed or denied by other modules. Exception for
+      // request flags which also depends on extra permissions.
       if (
         $commented_entity->isPublished() &&
         $commented_entity->access('view')
       ) {
+
+        // Deny access to create archival or delete requests if the user
+        // doesn't have permission to do so.
+        if (
+          (
+            $flag->id() === 'request_archive_comment' &&
+            $account->hasPermission('make archive request')
+          ) ||
+          (
+            $flag->id() === 'request_delete_comment' &&
+            $account->hasPermission('make delete request')
+          )
+        ) {
+          $access = AccessResult::allowed()
+            ->addCacheableDependency($account)
+            ->addCacheableDependency($flaggable)
+            ->addCacheableDependency($commented_entity);
+        }
         break;
       }
 

--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -745,8 +745,12 @@ function eic_groups_flag_action_access($action, FlagInterface $flag, AccountInte
       // Load the group.
       $group = $group_content->getGroup();
 
-      // Deny access to flag if the group is not flaggable.
-      if (!EICGroupsHelper::groupIsFlaggable($group)) {
+      // Deny access to flag if the group is not flaggable or the user doesn't
+      // have permission to view comments in the group.
+      if (
+        !EICGroupsHelper::groupIsFlaggable($group) ||
+        !$group->hasPermission('view comments', $account)
+      ) {
         $access = AccessResult::forbidden()
           ->addCacheableDependency($group)
           ->addCacheableDependency($flaggable);

--- a/lib/themes/eic_community/react/components/Block/CommentsDiscussion/Partials/Answer.js
+++ b/lib/themes/eic_community/react/components/Block/CommentsDiscussion/Partials/Answer.js
@@ -117,8 +117,8 @@ class Answer extends React.Component {
             </footer>
           }
 
-
-          {this.props.activeAnswerForm === child.comment_id &&
+          { !isCommentHidden(child) &&
+            this.props.activeAnswerForm === child.comment_id &&
           <CommentForm
             addComment={this.props.addComment}
             parentComment={child.comment_id}

--- a/lib/themes/eic_community/react/components/Block/CommentsDiscussion/Partials/TopAnswer.js
+++ b/lib/themes/eic_community/react/components/Block/CommentsDiscussion/Partials/TopAnswer.js
@@ -106,7 +106,8 @@ class TopAnswer extends React.Component {
               </footer>
             }
 
-            {this.props.activeAnswerForm === this.props.comment.comment_id &&
+            {!isCommentHidden(this.props.comment) &&
+              this.props.activeAnswerForm === this.props.comment.comment_id &&
             <CommentForm addComment={this.props.addComment}
                          parentComment={this.props.comment.comment_id}
                          commentTextReply={this.props.commentTextReply}

--- a/lib/themes/eic_community/react/components/Block/CommentsDiscussion/Services/Permissions.js
+++ b/lib/themes/eic_community/react/components/Block/CommentsDiscussion/Services/Permissions.js
@@ -14,7 +14,7 @@ function canShowActions(comment) {
 }
 
 function isCommentHidden(comment) {
-  return comment.archived_flag_time !== null || comment.deleted_flag_time !== null || parseInt(comment.is_soft_delete) !== 0;
+  return comment.archived_flag_time !== null || comment.deleted_flag_time !== null || parseInt(comment.is_soft_delete) !== 0 || parseInt(comment.is_archived) !== 0;
 }
 
 function hasPermissionApi(comment, flag) {


### PR DESCRIPTION
### Fixes

- Fix issue where GM/GO/GA could still reply and view statistics of archived comments;
- Improve access to flag comments so that it includes check on the view comments permission (globally and in the group context).

### Tests

- [x] As SA/SCM, create a comment in a discussion
- [x] As GM/GO/GA, make sure you can request archival + request deletion + like + reply
- [x] As GM/GO/GA, make an archival request
- [x] As SA/SCM, accept the archival request
- [x] As GM/GO/GA, go to the discussion and make sure the comment shows as archived message and you can't do any action such as  request archival + request deletion + like + reply
- [x] As SA/SCM, create a new comment
- [x] As GM/GO/GA, make a deletion request
- [x] As GM/GO/GA, go to the discussion and make sure the comment shows as deleted message and you can't do any action such as  request archival + request deletion + like + reply