### PR TITLE
EICNET-1753: Footer site name (rework)

### DIFF
--- a/config/sync/field.field.block_content.basic.body.yml
+++ b/config/sync/field.field.block_content.basic.body.yml
@@ -13,7 +13,7 @@ entity_type: block_content
 bundle: basic
 label: Body
 description: ''
-required: false
+required: true
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/config/sync/field.field.block_content.basic.field_title.yml
+++ b/config/sync/field.field.block_content.basic.field_title.yml
@@ -11,7 +11,7 @@ entity_type: block_content
 bundle: basic
 label: Title
 description: ''
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/config/sync/field.field.block_content.basic.field_title.yml
+++ b/config/sync/field.field.block_content.basic.field_title.yml
@@ -11,7 +11,7 @@ entity_type: block_content
 bundle: basic
 label: Title
 description: ''
-required: false
+required: true
 translatable: true
 default_value: {  }
 default_value_callback: ''


### PR DESCRIPTION
### Changes

- Make title and body fields as mandatory in Block type Basic.

### Tests

- [x] As SA/SCM, go to `/admin/content/block-content`
- [x] Try to edit one of the Basic blocks and make sure the body field is mandatory

### Blocker

- ~~Currently the block type that is used (Basic) is also used in other pages such as the contact form (https://qa-eic-7998fed89ac0.victhorious.com/community/contact). The problem is that in the contact form, we have the user name text in bold which means we cannot use plain text here. The only solution would be creating a new block type but I would discard that option even because the only people who can manage those blocks are content manager and site admins.~~