### PR TITLE
EICNET-2102: Create-a-new-group CTA not working and wrong color

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/overview_pages/overview-page.inc
+++ b/lib/themes/eic_community/includes/preprocess/overview_pages/overview-page.inc
@@ -5,15 +5,13 @@
  * Prepares variables for overview_page templates.
  */
 
-use Drupal\eic_overviews\GlobalOverviewPages;
-
 /**
  * Implements hook_preprocess_overview_page().
  */
 function eic_community_preprocess_overview_page(array &$variables) {
   // Adds breadcrumbs block to the theme variables.
   $variables['eic_community_breadcrumbs'] = _eic_community_load_breadcrumb_block();
-  /** @var GlobalOverviewPages $overview_helper */
+  /** @var \Drupal\eic_overviews\GlobalOverviewPages $overview_helper */
   $overview_helper = \Drupal::service('eic_overviews.global_overview_pages');
   // Adds overview page operations.
   $overview_id = $overview_helper->getCurrentOverviewPageId();
@@ -26,8 +24,11 @@ function eic_community_preprocess_overview_page(array &$variables) {
   if (!empty($operations)) {
     foreach ($operations as $operation) {
       $variables['overview_page_actions'][] = [
-        'label' => $operation['title'],
-        'path' => $operation['url'],
+        'link' => [
+          'label' => $operation['title'],
+          'path' => $operation['url'],
+        ],
+        'type' => 'cta',
       ];
     }
   }


### PR DESCRIPTION
### Fixes

- Fix regression in create new group CTA button in groups overview page;
- Fix coding standards.

### Tests

- [x] As authenticated users (TU/SA/SCM), go to the groups overview page `/groups`
- [x] Make sure you see the link "Create a new group" in yellow and when you click you get redirected to the group creation form.