### PR TITLE
[EICNET-1945]feat: Implement correct filter for profile activity feed + set correct datasource feed

### DIFF
--- a/config/sync/context.context.my_profile.yml
+++ b/config/sync/context.context.my_profile.yml
@@ -38,40 +38,6 @@ reactions:
         unique: 0
         context_id: my_profile
         context_mapping: {  }
-      6c509f98-b687-4e8d-a7f9-8d8f81c5bc9d:
-        id: eic_search_overview
-        label: ''
-        provider: eic_search
-        label_display: visible
-        context_mapping: {  }
-        source_type: Drupal\eic_search\Search\Sources\Profile\ActivityStreamSourceType
-        facets:
-          ss_global_content_type: ss_global_content_type
-          sm_content_field_vocab_topics_string: sm_content_field_vocab_topics_string
-        sort_options: {  }
-        enable_search: 1
-        page_options: normal
-        prefilter_group: 0
-        enable_date_filter: 0
-        add_facet_interests: 0
-        add_facet_my_groups: 1
-      ab8be712-2c43-46bb-b233-bbaf0ce733f6:
-        id: eic_search_overview
-        label: ''
-        provider: eic_search
-        label_display: visible
-        context_mapping: {  }
-        source_type: Drupal\eic_search\Search\Sources\Profile\ActivityStreamSourceType
-        facets:
-          ss_type: ss_type
-          sm_content_field_vocab_topics_string: sm_content_field_vocab_topics_string
-        sort_options: {  }
-        enable_search: 1
-        page_options: normal
-        prefilter_group: 0
-        enable_date_filter: 0
-        add_facet_interests: 0
-        add_facet_my_groups: 1
       d86d8cb2-65eb-4708-9334-4312fc5bf37b:
         uuid: d86d8cb2-65eb-4708-9334-4312fc5bf37b
         id: eic_search_overview

--- a/config/sync/context.context.my_profile.yml
+++ b/config/sync/context.context.my_profile.yml
@@ -39,7 +39,41 @@ reactions:
         context_id: my_profile
         context_mapping: {  }
       6c509f98-b687-4e8d-a7f9-8d8f81c5bc9d:
-        uuid: 6c509f98-b687-4e8d-a7f9-8d8f81c5bc9d
+        id: eic_search_overview
+        label: ''
+        provider: eic_search
+        label_display: visible
+        context_mapping: {  }
+        source_type: Drupal\eic_search\Search\Sources\Profile\ActivityStreamSourceType
+        facets:
+          ss_global_content_type: ss_global_content_type
+          sm_content_field_vocab_topics_string: sm_content_field_vocab_topics_string
+        sort_options: {  }
+        enable_search: 1
+        page_options: normal
+        prefilter_group: 0
+        enable_date_filter: 0
+        add_facet_interests: 0
+        add_facet_my_groups: 1
+      ab8be712-2c43-46bb-b233-bbaf0ce733f6:
+        id: eic_search_overview
+        label: ''
+        provider: eic_search
+        label_display: visible
+        context_mapping: {  }
+        source_type: Drupal\eic_search\Search\Sources\Profile\ActivityStreamSourceType
+        facets:
+          ss_type: ss_type
+          sm_content_field_vocab_topics_string: sm_content_field_vocab_topics_string
+        sort_options: {  }
+        enable_search: 1
+        page_options: normal
+        prefilter_group: 0
+        enable_date_filter: 0
+        add_facet_interests: 0
+        add_facet_my_groups: 1
+      d86d8cb2-65eb-4708-9334-4312fc5bf37b:
+        uuid: d86d8cb2-65eb-4708-9334-4312fc5bf37b
         id: eic_search_overview
         label: ''
         provider: eic_search
@@ -53,7 +87,7 @@ reactions:
         context_mapping: {  }
         source_type: Drupal\eic_search\Search\Sources\Profile\ActivityStreamSourceType
         facets:
-          ss_global_content_type: ss_global_content_type
+          ss_type: ss_type
           sm_content_field_vocab_topics_string: sm_content_field_vocab_topics_string
         sort_options: {  }
         enable_search: 1
@@ -61,7 +95,7 @@ reactions:
         prefilter_group: 0
         enable_date_filter: 0
         add_facet_interests: 0
-        add_facet_my_groups: 0
+        add_facet_my_groups: 1
         third_party_settings: {  }
     include_default_blocks: 0
     saved: false

--- a/lib/modules/eic_search/src/Controller/SolrSearchController.php
+++ b/lib/modules/eic_search/src/Controller/SolrSearchController.php
@@ -231,7 +231,7 @@ class SolrSearchController extends ControllerBase {
     }
 
     $this->generateQueryInterests($fq, $facets_interests);
-    $this->generateQueryUserGroupsAndContents($fq, $facets_interests);
+    $this->generateQueryUserGroupsAndContents($fq, $facets_interests, $source);
     $this->generateQueryPrivateContent($fq);
     $this->generateQueryPublishedState($fq, $source);
     $this->generateQueryPager($solariumQuery, $page, $offset, $source);
@@ -359,8 +359,10 @@ class SolrSearchController extends ControllerBase {
    *  The field query stringify to send to SOLR
    * @param array $interests
    *  Values of interests facet
+   * @param SourceTypeInterface $source
+   *  The current source.
    */
-  private function generateQueryUserGroupsAndContents(string &$fq, array $interests) {
+  private function generateQueryUserGroupsAndContents(string &$fq, array $interests, SourceTypeInterface $source) {
     if (
       empty($interests) ||
       !array_key_exists('my_groups', $interests) ||
@@ -383,8 +385,10 @@ class SolrSearchController extends ControllerBase {
     }
 
     $groups_membership_string = $groups_membership_id ? implode(' OR ', $groups_membership_id) : -1;
+    $group_field_id = $source->getPrefilteredGroupFieldId();
+    $group_field_id = reset($group_field_id);
 
-    $fq .= " AND (its_group_id_integer:($groups_membership_string) OR its_global_group_parent_id:($groups_membership_string) OR its_content_uid:($groups_membership_string))";
+    $fq .= " AND ($group_field_id:($groups_membership_string) OR its_global_group_parent_id:($groups_membership_string) OR its_content_uid:($groups_membership_string))";
   }
 
   /**

--- a/lib/modules/eic_search/src/Plugin/Block/SearchOverviewBlock.php
+++ b/lib/modules/eic_search/src/Plugin/Block/SearchOverviewBlock.php
@@ -241,6 +241,7 @@ class SearchOverviewBlock extends BlockBase implements ContainerFactoryPluginInt
         EICGroupsHelper::GROUP_OWNER_ROLE,
         $user_group_roles
       ),
+      'label_my_groups' => $source->getLabelFilterMyGroups(),
       'is_group_admin' => array_key_exists(
         EICGroupsHelper::GROUP_ADMINISTRATOR_ROLE,
         $user_group_roles

--- a/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorGlobal.php
+++ b/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorGlobal.php
@@ -139,6 +139,8 @@ class ProcessorGlobal extends DocumentProcessor {
         }
         $status = TRUE;
         $type = $fields['ss_type'];
+        $topics = $fields['sm_message_node_ref_field_vocab_topics_name'] ?? [];
+        $date = $fields['ds_created'];
         break;
       case 'entity:user':
         $user = User::load($fields['its_user_id']);

--- a/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorGroupContent.php
+++ b/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorGroupContent.php
@@ -16,9 +16,9 @@ class ProcessorGroupContent extends DocumentProcessor {
    * @inheritDoc
    */
   public function process(Document &$document, array $fields, array $items = []): void {
-    $group_parent_label = '';
-    $group_parent_url = '';
-    $group_parent_id = -1;
+    $group_parent_label = $fields['ss_global_group_parent_label'] ?? '';
+    $group_parent_url = $fields['ss_global_group_parent_url'] ?? '';
+    $group_parent_id = $fields['its_global_group_parent_id'] ?? -1;
     $group_is_published = TRUE;
 
     if (array_key_exists('its_content__group_content__entity_id_gid', $fields)) {
@@ -30,9 +30,9 @@ class ProcessorGroupContent extends DocumentProcessor {
       }
     }
 
-    $document->addField('ss_global_group_parent_label', $group_parent_label);
-    $document->addField('ss_global_group_parent_url', $group_parent_url);
-    $document->addField('its_global_group_parent_id', $group_parent_id);
+    $this->addOrUpdateDocumentField($document, 'ss_global_group_parent_label', $fields, $group_parent_label);
+    $this->addOrUpdateDocumentField($document, 'ss_global_group_parent_url', $fields, $group_parent_url);
+    $this->addOrUpdateDocumentField($document, 'its_global_group_parent_id', $fields, $group_parent_id);
     $this->addOrUpdateDocumentField($document, 'its_global_group_parent_published', $fields, (int) $group_is_published);
   }
 
@@ -40,7 +40,8 @@ class ProcessorGroupContent extends DocumentProcessor {
    * @inerhitDoc
    */
   public function supports(array $fields): bool {
-    return $fields['ss_search_api_datasource'] !== 'entity:group';
+    $datasource = $fields['ss_search_api_datasource'];
+    return $datasource !== 'entity:group' && $datasource !== 'entity:message';
   }
 
 }

--- a/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorMessage.php
+++ b/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorMessage.php
@@ -6,6 +6,8 @@ use Drupal\comment\CommentInterface;
 use Drupal\comment\Entity\Comment;
 use Drupal\eic_comments\CommentsHelper;
 use Drupal\eic_media_statistics\EntityFileDownloadCount;
+use Drupal\group\Entity\GroupContent;
+use Drupal\group\Entity\GroupInterface;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
 use Drupal\statistics\NodeStatisticsDatabaseStorage;
@@ -76,6 +78,18 @@ class ProcessorMessage extends DocumentProcessor {
       return;
     }
 
+    $group_contents = GroupContent::loadByEntity($node);
+
+    if (!empty($group_contents)) {
+      /** @var GroupContent $group_content */
+      $group_content = reset($group_contents);
+      $group_id = $group_content->getGroup() instanceof GroupInterface ?
+        $group_content->getGroup()->id() :
+        -1;
+
+      $this->addOrUpdateDocumentField($document, 'its_global_group_parent_id', $fields, $group_id);
+    }
+
     $index_views = TRUE;
     $index_comments = TRUE;
     $index_downloads = TRUE;
@@ -122,4 +136,5 @@ class ProcessorMessage extends DocumentProcessor {
   public function supports(array $fields): bool {
     return $fields['ss_search_api_datasource'] === 'entity:message';
   }
+
 }

--- a/lib/modules/eic_search/src/Search/Sources/Profile/ActivityStreamSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/Profile/ActivityStreamSourceType.php
@@ -117,7 +117,7 @@ class ActivityStreamSourceType extends SourceType {
    * @inheritDoc
    */
   public function getLabelFilterMyGroups(): string {
-    return $this->t('My groups only', [], ['context' => 'eic_search']);
+    return $this->t('Only my groups', [], ['context' => 'eic_search']);
   }
 
 }

--- a/lib/modules/eic_search/src/Search/Sources/Profile/ActivityStreamSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/Profile/ActivityStreamSourceType.php
@@ -18,9 +18,7 @@ class ActivityStreamSourceType extends SourceType {
    * @inheritDoc
    */
   public function getSourcesId(): array {
-    return [
-      'node',
-    ];
+    return ['message'];
   }
 
   /**
@@ -42,7 +40,7 @@ class ActivityStreamSourceType extends SourceType {
    */
   public function getAvailableFacets(): array {
     return [
-      'ss_global_content_type' => $this->t('Content type', [], ['context' => 'eic_search']),
+      'ss_type' => $this->t('Content type', [], ['context' => 'eic_search']),
       'sm_content_field_vocab_topics_string' => $this->t('Topics', [], ['context' => 'eic_search']),
     ];
   }
@@ -51,7 +49,7 @@ class ActivityStreamSourceType extends SourceType {
    * @inheritDoc
    */
   public function getDefaultSort(): array {
-    return ['ds_created', 'DESC'];
+    return ['ss_drupal_timestamp', 'DESC'];
   }
 
   /**
@@ -112,7 +110,14 @@ class ActivityStreamSourceType extends SourceType {
    * @inheritDoc
    */
   public function prefilterByGroupsMembership(): bool {
-    return TRUE;
+    return FALSE;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getLabelFilterMyGroups(): string {
+    return $this->t('My groups only', [], ['context' => 'eic_search']);
   }
 
 }

--- a/lib/modules/eic_search/src/Search/Sources/SourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/SourceType.php
@@ -159,4 +159,11 @@ abstract class SourceType implements SourceTypeInterface {
     return FALSE;
   }
 
+  /**
+   * @inheritDoc
+   */
+  public function getLabelFilterMyGroups(): string {
+    return $this->t('My groups & content only', [], ['context' => 'eic_search']);
+  }
+
 }

--- a/lib/modules/eic_search/src/Search/Sources/SourceTypeInterface.php
+++ b/lib/modules/eic_search/src/Search/Sources/SourceTypeInterface.php
@@ -178,4 +178,10 @@ interface SourceTypeInterface {
    */
   public function prefilterByGroupsMembership(): bool;
 
+  /**
+   * Get the label for the filter "my groups"
+   *
+   * @return string
+   */
+  public function getLabelFilterMyGroups(): string;
 }

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/Results.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/Results.js
@@ -28,7 +28,7 @@ class Results extends React.Component {
         library: LibraryResultItem,
         user_gallery: UserGalleryResultItem,
         user_list: UserListResultItem,
-        activity_stream: GlobalResultItem,
+        activity_stream: ActivityStreamResultItem,
       }
     }
   }

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/Sidebar.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/Sidebar.js
@@ -44,7 +44,7 @@ class Sidebar extends React.Component {
                                                   updateFacet={this.props.updateFacet}
                                                   value={'my_interests'}/>}
                             {parseInt(this.props.enableFacetMyGroups) !== 0 &&
-                            <CheckboxSpecialField label={'My groups & content only'}
+                            <CheckboxSpecialField label={window.drupalSettings.overview.label_my_groups}
                                                   checked={interestsValue && interestsValue.my_groups} key={'my_groups'}
                                                   facet={'interests'} updateFacet={this.props.updateFacet}
                                                   value={'my_groups'}/>}


### PR DESCRIPTION
How to test:

- [x] Re-sync search API
- [x] Go to /my-profile/activity
- [x] Verify that you have filters: "Only my groups", "Type" and "Topics"
- [x] Test different filters, especially the "only my groups"

In this one I also updated the feed results:

- [x] Now we are getting messages sources
- [x] Check if you have correct content ordered by creation date
- [x] Operation type should be there "created", "updated"