### PR TITLE
EICNET-1940: Email notification for user tagging in comments (Improvements)

### DIFF
--- a/config/sync/core.entity_view_display.comment.node_comment.notification_teaser.yml
+++ b/config/sync/core.entity_view_display.comment.node_comment.notification_teaser.yml
@@ -35,7 +35,6 @@ content:
 hidden:
   field_comment_attachment: true
   field_comment_deletion_date: true
-  field_comment_is_archived: true
   field_comment_is_soft_deleted: true
   flag_like_comment: true
   langcode: true

--- a/config/sync/core.entity_view_display.comment.node_comment.notification_teaser.yml
+++ b/config/sync/core.entity_view_display.comment.node_comment.notification_teaser.yml
@@ -35,6 +35,7 @@ content:
 hidden:
   field_comment_attachment: true
   field_comment_deletion_date: true
+  field_comment_is_archived: true
   field_comment_is_soft_deleted: true
   flag_like_comment: true
   langcode: true

--- a/lib/themes/eic_community/templates/content/comment--notification-teaser.html.twig
+++ b/lib/themes/eic_community/templates/content/comment--notification-teaser.html.twig
@@ -72,10 +72,7 @@
                                                     {% if comment.tagged_users is defined %}
                                                       <br><br>With:
                                                       {% for user in comment.tagged_users %}
-                                                        <a style="font-weight: bold; text-decoration: none; color: #004494" href="{{ user.path }}" target="_blank">{{ user.name }}</a>
-                                                        {% if loop.last == false %}
-                                                          ,
-                                                        {% endif %}
+                                                        <a style="font-weight: bold; text-decoration: none; color: #004494" href="{{ user.path }}" target="_blank">{{ user.name }}</a>{% if loop.last == false %}, {% endif %}
                                                       {% endfor %}
                                                     {% endif %}
                                                   </div>


### PR DESCRIPTION
### Improvements

- Remove extra comma from rendered output of tagged users in comments.

### Tests

- [x] As SA/SCM, create a comment in a discussion and tag one or multiple user
- [x] Run cron
- [x] Check if the email notification shows the tagged users and each one is separated with "**,** " and not " **,** "