### PR TITLE
Feature/eicnet 1924 share group content rework

### DIFF
--- a/config/sync/group.content_type.event-group_shared_content.yml
+++ b/config/sync/group.content_type.event-group_shared_content.yml
@@ -1,0 +1,18 @@
+uuid: 3e678500-41a5-4839-8dad-51b5bc60e31d
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.event
+  module:
+    - eic_share_content
+    - node
+id: event-group_shared_content
+label: 'Event: Group Shared content'
+description: 'Adds shared content to groups.'
+group_type: event
+content_plugin: group_shared_content
+plugin_config:
+  group_cardinality: 0
+  entity_cardinality: 1
+  use_creation_wizard: false

--- a/config/sync/group.content_type.group-group_shared_content.yml
+++ b/config/sync/group.content_type.group-group_shared_content.yml
@@ -1,0 +1,18 @@
+uuid: b12db388-963a-4058-b3cb-0609eca598a6
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.group
+  module:
+    - eic_share_content
+    - node
+id: group-group_shared_content
+label: 'Group: Group Shared content'
+description: 'Adds shared content to groups.'
+group_type: group
+content_plugin: group_shared_content
+plugin_config:
+  group_cardinality: 0
+  entity_cardinality: 1
+  use_creation_wizard: false

--- a/config/sync/group.content_type.group_content_type_4a2cdf9ed8847.yml
+++ b/config/sync/group.content_type.group_content_type_4a2cdf9ed8847.yml
@@ -1,0 +1,18 @@
+uuid: 04e6130e-d1e3-4a4a-948d-754b2989cd8f
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.organisation
+  module:
+    - eic_share_content
+    - node
+id: group_content_type_4a2cdf9ed8847
+label: 'Organisation: Group Shared content'
+description: 'Adds shared content to groups.'
+group_type: organisation
+content_plugin: group_shared_content
+plugin_config:
+  group_cardinality: 0
+  entity_cardinality: 1
+  use_creation_wizard: false

--- a/lib/modules/eic_content/src/EICContentHelper.php
+++ b/lib/modules/eic_content/src/EICContentHelper.php
@@ -4,11 +4,8 @@ namespace Drupal\eic_content;
 
 use Drupal\Component\Plugin\Exception\PluginException;
 use Drupal\Core\Entity\ContentEntityInterface;
-use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
-use Drupal\group\Entity\GroupInterface;
-use Drupal\node\NodeInterface;
 
 /**
  * EICContentHelper service that provides helper functions for content.
@@ -58,39 +55,6 @@ class EICContentHelper implements EICContentHelperInterface {
     }
     catch (PluginException $e) {
       return FALSE;
-    }
-  }
-
-  /**
-   * @param \Drupal\group\Entity\GroupInterface $group
-   * @param \Drupal\node\NodeInterface $node
-   *
-   * @return \Drupal\Core\Entity\EntityInterface|null
-   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
-   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
-   */
-  public function getGroupContent(
-    GroupInterface $group,
-    NodeInterface $node
-  ): ?EntityInterface {
-    if (!$this->moduleHandler->moduleExists('group')) {
-      return NULL;
-    }
-
-    $storage = $this->entityTypeManager->getStorage('group_content');
-    try {
-      $group_contents = $storage->loadByProperties([
-        'gid' => $group->id(),
-        'entity_id' => $node->id(),
-      ]);
-
-      if (empty($group_contents)) {
-        return NULL;
-      }
-
-      return reset($group_contents);
-    } catch (\Exception $e) {
-      return NULL;
     }
   }
 

--- a/lib/modules/eic_groups/modules/eic_share_content/eic_share_content.services.yml
+++ b/lib/modules/eic_groups/modules/eic_share_content/eic_share_content.services.yml
@@ -1,4 +1,4 @@
 services:
   eic_share_content.share_manager:
     class: 'Drupal\eic_share_content\Service\ShareManager'
-    arguments: [ '@eic_content.helper', '@entity_type.manager', '@plugin.manager.group_content_enabler', '@eic_messages.message_bus', '@eic_search.solr_document_processor' ]
+    arguments: [ '@eic_groups.helper', '@entity_type.manager', '@plugin.manager.group_content_enabler', '@eic_messages.message_bus', '@eic_search.solr_document_processor' ]

--- a/lib/modules/eic_groups/modules/eic_share_content/src/Hooks/SolrDocumentDecorator.php
+++ b/lib/modules/eic_groups/modules/eic_share_content/src/Hooks/SolrDocumentDecorator.php
@@ -10,21 +10,32 @@ use Drupal\node\NodeInterface;
 use Solarium\Core\Query\DocumentInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
+/**
+ * Class that decorates Solr documents for sharing feature.
+ */
 class SolrDocumentDecorator implements ContainerInjectionInterface {
 
   /**
+   * The share manager.
+   *
    * @var \Drupal\eic_share_content\Service\ShareManager
    */
   private $shareManager;
 
   /**
+   * The entity type manager.
+   *
    * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   private $entityTypeManager;
 
   /**
+   * Constructs a new SolrDocumentDecorator object.
+   *
    * @param \Drupal\eic_share_content\Service\ShareManager $manager
+   *   The share manager.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
    */
   public function __construct(
     ShareManager $manager,
@@ -38,14 +49,21 @@ class SolrDocumentDecorator implements ContainerInjectionInterface {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
-    return new static($container->get('eic_share_content.share_manager'),
-      $container->get('entity_type.manager'));
+    return new static(
+      $container->get('eic_share_content.share_manager'),
+      $container->get('entity_type.manager')
+    );
   }
 
   /**
+   * Alters the search api documents to include sharing information.
+   *
    * @param \Solarium\Core\Query\DocumentInterface $document
+   *   The Search API document.
    *
    * @return \Solarium\Core\Query\DocumentInterface
+   *   The altered Search API document.
+   *
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
@@ -61,13 +79,13 @@ class SolrDocumentDecorator implements ContainerInjectionInterface {
       return $document;
     }
 
-    if (!$shares = $this->shareManager->getShares($entity)) {
+    if (!$shares = $this->shareManager->getSharedEntities($entity)) {
       return $document;
     }
 
     $shared_groups = [];
     foreach ($shares as $share) {
-      $group = $share->get('field_group_ref')->entity;
+      $group = $share->get('gid')->entity;
       if (!$group instanceof GroupInterface) {
         continue;
       }

--- a/lib/modules/eic_groups/modules/eic_share_content/src/Plugin/GroupContentEnabler/SharedContent.php
+++ b/lib/modules/eic_groups/modules/eic_share_content/src/Plugin/GroupContentEnabler/SharedContent.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Drupal\eic_share_content\Plugin\GroupContentEnabler;
+
+use Drupal\group\Plugin\GroupContentEnablerBase;
+
+/**
+ * Provides a content enabler to request the archival of the group.
+ *
+ * @GroupContentEnabler(
+ *   id = "group_shared_content",
+ *   label = @Translation("Group Shared content"),
+ *   description = @Translation("Adds shared content to groups."),
+ *   entity_type_id = "node",
+ *   pretty_path_key = "shared_content",
+ *   reference_label = @Translation("Shared content"),
+ *   reference_description = @Translation("Shared content."),
+ * )
+ */
+class SharedContent extends GroupContentEnablerBase {
+
+}

--- a/lib/modules/eic_groups/modules/eic_share_content/src/Service/ShareManager.php
+++ b/lib/modules/eic_groups/modules/eic_share_content/src/Service/ShareManager.php
@@ -15,7 +15,7 @@ use Drupal\node\NodeInterface;
 use Drupal\search_api\Plugin\search_api\datasource\ContentEntity;
 
 /**
- * Class ShareManager
+ * Class that manages functions for the sharing feature.
  *
  * @package Drupal\eic_share_content\Service
  */
@@ -31,30 +31,44 @@ class ShareManager {
   const GROUP_CONTENT_SHARED_PLUGIN_ID = 'group_shared_content';
 
   /**
+   * The EIC Groups helper.
+   *
    * @var \Drupal\eic_groups\EICGroupsHelperInterface
    */
   private $groupsHelper;
 
   /**
+   * The entity type manager.
+   *
    * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   private $entityTypeManager;
 
   /**
+   * The group content enabler manager.
+   *
    * @var \Drupal\group\Plugin\GroupContentEnablerManagerInterface
    */
   private $groupContentPluginManager;
 
   /**
+   * The EIC message bus.
+   *
    * @var \Drupal\eic_messages\Service\MessageBusInterface
    */
   private $messageBus;
 
   /**
+   * Constructs a new ShareManager object.
+   *
    * @param \Drupal\eic_groups\EICGroupsHelperInterface $groups_helper
+   *   The EIC Groups helper.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
    * @param \Drupal\group\Plugin\GroupContentEnablerManagerInterface $plugin_manager
+   *   The group content enabler manager.
    * @param \Drupal\eic_messages\Service\MessageBusInterface $message_bus
+   *   The EIC message bus.
    */
   public function __construct(
     EICGroupsHelperInterface $groups_helper,
@@ -69,9 +83,13 @@ class ShareManager {
   }
 
   /**
+   * Checks if a node bundle is eligible for group sharing.
+   *
    * @param string $node_bundle
+   *   The node bundle machine name.
    *
    * @return bool
+   *   TRUE if node bundle is supported.
    */
   public function isSupported(string $node_bundle): bool {
     static $shareableNodeBundles = [
@@ -88,10 +106,16 @@ class ShareManager {
   }
 
   /**
+   * Shares a content from one group to another.
+   *
    * @param \Drupal\group\Entity\GroupInterface $source_group
+   *   The group entity from which we want to share.
    * @param \Drupal\group\Entity\GroupInterface $target_group
+   *   The group entity to which we want to share.
    * @param \Drupal\node\NodeInterface $node
+   *   The node entity we want to share.
    * @param string|null $message
+   *   The message that accompanies the share action.
    *
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
@@ -105,17 +129,17 @@ class ShareManager {
   ) {
     // First we check if this node belongs to a group.
     if (!$this->groupsHelper->getGroupByEntity($node)) {
-      throw new \InvalidArgumentException($this->t("This content can't be shared"));
+      throw new \InvalidArgumentException("This content can't be shared");
     }
 
     // If source and target groups are the same, we can't share.
     if ($target_group->id() === $source_group->id()) {
-      throw new \InvalidArgumentException($this->t("This content can't be shared"));
+      throw new \InvalidArgumentException("This content can't be shared");
     }
 
     // If the content is already shared to the target group, we can't share.
     if ($this->isShared($node, $target_group)) {
-      throw new \InvalidArgumentException($this->t('This content is already shared with this group'));
+      throw new \InvalidArgumentException('This content is already shared with this group');
     }
 
     // Create the group content entity.
@@ -140,7 +164,7 @@ class ShareManager {
 
     // Reindex the node immediately.
     // There seem to be multiple implementation of reindexing logics.
-    // @TODO Write a single service for this.
+    // @todo Write a single service for this.
     $indexes = ContentEntity::getIndexesForEntity($node);
     foreach ($indexes as $index) {
       $index->trackItemsUpdated(

--- a/lib/modules/eic_groups/src/EICGroupsHelper.php
+++ b/lib/modules/eic_groups/src/EICGroupsHelper.php
@@ -389,9 +389,16 @@ class EICGroupsHelper implements EICGroupsHelperInterface {
 
     if ($entity instanceof NodeInterface) {
       // Load all the group content for this entity.
-      $group_content = GroupContent::loadByEntity($entity);
-      // Assuming that the content can be related only to 1 group.
-      $group_content = reset($group_content);
+      $group_contents = GroupContent::loadByEntity($entity);
+
+      // We look for the first group_node group_content entity.
+      foreach ($group_contents as $group_content_item) {
+        if (strpos($group_content_item->getGroupContentType()->getContentPluginId(), 'group_node:') === 0) {
+          $group = $group_content_item->getGroup();
+          break;
+        }
+      }
+
       if (!empty($group_content)) {
         $group = $group_content->getGroup();
       }


### PR DESCRIPTION
### Improvements

- Created a new group_content relation type: `group_shared_content`

### Tests

- [x] As TU try to share a node from a public group to another public group (you must be member of the target group)
- [x] Try to share again to the same group, you should get a message "This content is already shared with this group"
- [x] Go to the target group and check that the content appears in the group homepage and/or content-specific overview
- [x] As GO/Ga of the target group, check that you can't edit the shared node