### PR TITLE
Feature/eicnet 2109 views data export shared nodes

### DIFF
--- a/config/sync/group.content_type.event-group_shared_content.yml
+++ b/config/sync/group.content_type.event-group_shared_content.yml
@@ -1,0 +1,18 @@
+uuid: 3e678500-41a5-4839-8dad-51b5bc60e31d
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.event
+  module:
+    - eic_share_content
+    - node
+id: event-group_shared_content
+label: 'Event: Group Shared content'
+description: 'Adds shared content to groups.'
+group_type: event
+content_plugin: group_shared_content
+plugin_config:
+  group_cardinality: 0
+  entity_cardinality: 1
+  use_creation_wizard: false

--- a/config/sync/group.content_type.group-group_shared_content.yml
+++ b/config/sync/group.content_type.group-group_shared_content.yml
@@ -1,0 +1,18 @@
+uuid: b12db388-963a-4058-b3cb-0609eca598a6
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.group
+  module:
+    - eic_share_content
+    - node
+id: group-group_shared_content
+label: 'Group: Group Shared content'
+description: 'Adds shared content to groups.'
+group_type: group
+content_plugin: group_shared_content
+plugin_config:
+  group_cardinality: 0
+  entity_cardinality: 1
+  use_creation_wizard: false

--- a/config/sync/group.content_type.group_content_type_4a2cdf9ed8847.yml
+++ b/config/sync/group.content_type.group_content_type_4a2cdf9ed8847.yml
@@ -1,0 +1,18 @@
+uuid: 04e6130e-d1e3-4a4a-948d-754b2989cd8f
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.organisation
+  module:
+    - eic_share_content
+    - node
+id: group_content_type_4a2cdf9ed8847
+label: 'Organisation: Group Shared content'
+description: 'Adds shared content to groups.'
+group_type: organisation
+content_plugin: group_shared_content
+plugin_config:
+  group_cardinality: 0
+  entity_cardinality: 1
+  use_creation_wizard: false

--- a/config/sync/views.view.eic_admin_groups_data_export.yml
+++ b/config/sync/views.view.eic_admin_groups_data_export.yml
@@ -1750,6 +1750,128 @@ display:
               story: 0
               video: 0
               wiki_page: 0
+        group_metrics_14:
+          id: group_metrics_14
+          table: groups_field_data
+          field: group_metrics
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: group
+          plugin_id: group_metrics
+          label: 'Shared content'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ','
+          format_plural: 0
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+          metric: eic_groups_shared_content
+          eic_groups_flags_conf:
+            flags:
+              bookmark_content: 0
+              follow_content: 0
+              follow_group: 0
+              follow_taxonomy_term: 0
+              follow_user: 0
+              highlight_content: 0
+              like_comment: 0
+              like_content: 0
+              recommend: 0
+              recommend_group: 0
+              request_archive_comment: 0
+              request_archive_content: 0
+              request_archive_group: 0
+              request_block_group: 0
+              request_delete_comment: 0
+              request_delete_content: 0
+              request_delete_group: 0
+              transfer_owner_request_group: 0
+          eic_groups_invitations_conf:
+            status:
+              pending: 0
+              accepted: 0
+              rejected: 0
+          eic_groups_group_members_conf:
+            roles:
+              event-admin: 0
+              event-owner: 0
+              group-admin: 0
+              group-owner: 0
+              organisation-admin: 0
+              organisation-owner: 0
+          eic_groups_membership_requests_conf:
+            status:
+              new: 0
+              pending: 0
+              approved: 0
+              rejected: 0
+          eic_groups_content_conf:
+            node_types:
+              book: 0
+              discussion: 0
+              document: 0
+              event: 0
+              gallery: 0
+              news: 0
+              page: 0
+              story: 0
+              video: 0
+              wiki_page: 0
+          eic_groups_shared_content_conf:
+            node_types:
+              book: 0
+              discussion: 0
+              document: 0
+              event: 0
+              gallery: 0
+              news: 0
+              page: 0
+              story: 0
+              video: 0
+              wiki_page: 0
         group_metrics_9:
           id: group_metrics_9
           table: groups_field_data

--- a/lib/modules/eic_content/src/EICContentHelper.php
+++ b/lib/modules/eic_content/src/EICContentHelper.php
@@ -4,11 +4,8 @@ namespace Drupal\eic_content;
 
 use Drupal\Component\Plugin\Exception\PluginException;
 use Drupal\Core\Entity\ContentEntityInterface;
-use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
-use Drupal\group\Entity\GroupInterface;
-use Drupal\node\NodeInterface;
 
 /**
  * EICContentHelper service that provides helper functions for content.
@@ -58,39 +55,6 @@ class EICContentHelper implements EICContentHelperInterface {
     }
     catch (PluginException $e) {
       return FALSE;
-    }
-  }
-
-  /**
-   * @param \Drupal\group\Entity\GroupInterface $group
-   * @param \Drupal\node\NodeInterface $node
-   *
-   * @return \Drupal\Core\Entity\EntityInterface|null
-   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
-   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
-   */
-  public function getGroupContent(
-    GroupInterface $group,
-    NodeInterface $node
-  ): ?EntityInterface {
-    if (!$this->moduleHandler->moduleExists('group')) {
-      return NULL;
-    }
-
-    $storage = $this->entityTypeManager->getStorage('group_content');
-    try {
-      $group_contents = $storage->loadByProperties([
-        'gid' => $group->id(),
-        'entity_id' => $node->id(),
-      ]);
-
-      if (empty($group_contents)) {
-        return NULL;
-      }
-
-      return reset($group_contents);
-    } catch (\Exception $e) {
-      return NULL;
     }
   }
 

--- a/lib/modules/eic_groups/modules/eic_share_content/eic_share_content.services.yml
+++ b/lib/modules/eic_groups/modules/eic_share_content/eic_share_content.services.yml
@@ -1,4 +1,4 @@
 services:
   eic_share_content.share_manager:
     class: 'Drupal\eic_share_content\Service\ShareManager'
-    arguments: [ '@eic_content.helper', '@entity_type.manager', '@plugin.manager.group_content_enabler', '@eic_messages.message_bus', '@eic_search.solr_document_processor' ]
+    arguments: [ '@eic_groups.helper', '@entity_type.manager', '@plugin.manager.group_content_enabler', '@eic_messages.message_bus', '@eic_search.solr_document_processor' ]

--- a/lib/modules/eic_groups/modules/eic_share_content/src/Hooks/SolrDocumentDecorator.php
+++ b/lib/modules/eic_groups/modules/eic_share_content/src/Hooks/SolrDocumentDecorator.php
@@ -10,21 +10,32 @@ use Drupal\node\NodeInterface;
 use Solarium\Core\Query\DocumentInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
+/**
+ * Class that decorates Solr documents for sharing feature.
+ */
 class SolrDocumentDecorator implements ContainerInjectionInterface {
 
   /**
+   * The share manager.
+   *
    * @var \Drupal\eic_share_content\Service\ShareManager
    */
   private $shareManager;
 
   /**
+   * The entity type manager.
+   *
    * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   private $entityTypeManager;
 
   /**
+   * Constructs a new SolrDocumentDecorator object.
+   *
    * @param \Drupal\eic_share_content\Service\ShareManager $manager
+   *   The share manager.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
    */
   public function __construct(
     ShareManager $manager,
@@ -38,14 +49,21 @@ class SolrDocumentDecorator implements ContainerInjectionInterface {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
-    return new static($container->get('eic_share_content.share_manager'),
-      $container->get('entity_type.manager'));
+    return new static(
+      $container->get('eic_share_content.share_manager'),
+      $container->get('entity_type.manager')
+    );
   }
 
   /**
+   * Alters the search api documents to include sharing information.
+   *
    * @param \Solarium\Core\Query\DocumentInterface $document
+   *   The Search API document.
    *
    * @return \Solarium\Core\Query\DocumentInterface
+   *   The altered Search API document.
+   *
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
@@ -61,13 +79,13 @@ class SolrDocumentDecorator implements ContainerInjectionInterface {
       return $document;
     }
 
-    if (!$shares = $this->shareManager->getShares($entity)) {
+    if (!$shares = $this->shareManager->getSharedEntities($entity)) {
       return $document;
     }
 
     $shared_groups = [];
     foreach ($shares as $share) {
-      $group = $share->get('field_group_ref')->entity;
+      $group = $share->get('gid')->entity;
       if (!$group instanceof GroupInterface) {
         continue;
       }

--- a/lib/modules/eic_groups/modules/eic_share_content/src/Plugin/GroupContentEnabler/SharedContent.php
+++ b/lib/modules/eic_groups/modules/eic_share_content/src/Plugin/GroupContentEnabler/SharedContent.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Drupal\eic_share_content\Plugin\GroupContentEnabler;
+
+use Drupal\group\Plugin\GroupContentEnablerBase;
+
+/**
+ * Provides a content enabler to request the archival of the group.
+ *
+ * @GroupContentEnabler(
+ *   id = "group_shared_content",
+ *   label = @Translation("Group Shared content"),
+ *   description = @Translation("Adds shared content to groups."),
+ *   entity_type_id = "node",
+ *   pretty_path_key = "shared_content",
+ *   reference_label = @Translation("Shared content"),
+ *   reference_description = @Translation("Shared content."),
+ * )
+ */
+class SharedContent extends GroupContentEnablerBase {
+
+}

--- a/lib/modules/eic_groups/modules/eic_share_content/src/Service/ShareManager.php
+++ b/lib/modules/eic_groups/modules/eic_share_content/src/Service/ShareManager.php
@@ -4,7 +4,7 @@ namespace Drupal\eic_share_content\Service;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
-use Drupal\eic_content\EICContentHelperInterface;
+use Drupal\eic_groups\EICGroupsHelperInterface;
 use Drupal\eic_messages\ActivityStreamOperationTypes;
 use Drupal\eic_messages\Service\MessageBusInterface;
 use Drupal\eic_messages\Util\ActivityStreamMessageTemplates;
@@ -15,7 +15,7 @@ use Drupal\node\NodeInterface;
 use Drupal\search_api\Plugin\search_api\datasource\ContentEntity;
 
 /**
- * Class ShareManager
+ * Class that manages functions for the sharing feature.
  *
  * @package Drupal\eic_share_content\Service
  */
@@ -24,47 +24,72 @@ class ShareManager {
   use StringTranslationTrait;
 
   /**
-   * @var \Drupal\eic_content\EICContentHelperInterface
+   * The Group Content plugin ID for shared content.
+   *
+   * @var string
    */
-  private $contentHelper;
+  const GROUP_CONTENT_SHARED_PLUGIN_ID = 'group_shared_content';
 
   /**
+   * The EIC Groups helper.
+   *
+   * @var \Drupal\eic_groups\EICGroupsHelperInterface
+   */
+  private $groupsHelper;
+
+  /**
+   * The entity type manager.
+   *
    * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   private $entityTypeManager;
 
   /**
+   * The group content enabler manager.
+   *
    * @var \Drupal\group\Plugin\GroupContentEnablerManagerInterface
    */
   private $groupContentPluginManager;
 
   /**
+   * The EIC message bus.
+   *
    * @var \Drupal\eic_messages\Service\MessageBusInterface
    */
   private $messageBus;
 
   /**
-   * @param \Drupal\eic_content\EICContentHelperInterface $content_helper
+   * Constructs a new ShareManager object.
+   *
+   * @param \Drupal\eic_groups\EICGroupsHelperInterface $groups_helper
+   *   The EIC Groups helper.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
    * @param \Drupal\group\Plugin\GroupContentEnablerManagerInterface $plugin_manager
+   *   The group content enabler manager.
    * @param \Drupal\eic_messages\Service\MessageBusInterface $message_bus
+   *   The EIC message bus.
    */
   public function __construct(
-    EICContentHelperInterface $content_helper,
+    EICGroupsHelperInterface $groups_helper,
     EntityTypeManagerInterface $entity_type_manager,
     GroupContentEnablerManagerInterface $plugin_manager,
     MessageBusInterface $message_bus
   ) {
-    $this->contentHelper = $content_helper;
+    $this->groupsHelper = $groups_helper;
     $this->entityTypeManager = $entity_type_manager;
     $this->groupContentPluginManager = $plugin_manager;
     $this->messageBus = $message_bus;
   }
 
   /**
+   * Checks if a node bundle is eligible for group sharing.
+   *
    * @param string $node_bundle
+   *   The node bundle machine name.
    *
    * @return bool
+   *   TRUE if node bundle is supported.
    */
   public function isSupported(string $node_bundle): bool {
     static $shareableNodeBundles = [
@@ -74,16 +99,23 @@ class ShareManager {
       'discussion',
       'gallery',
       'event',
+      'news',
     ];
 
     return in_array($node_bundle, $shareableNodeBundles) ?? FALSE;
   }
 
   /**
+   * Shares a content from one group to another.
+   *
    * @param \Drupal\group\Entity\GroupInterface $source_group
+   *   The group entity from which we want to share.
    * @param \Drupal\group\Entity\GroupInterface $target_group
+   *   The group entity to which we want to share.
    * @param \Drupal\node\NodeInterface $node
+   *   The node entity we want to share.
    * @param string|null $message
+   *   The message that accompanies the share action.
    *
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
@@ -95,34 +127,30 @@ class ShareManager {
     NodeInterface $node,
     ?string $message
   ) {
-    $group_content = $this->contentHelper->getGroupContent($source_group, $node);
-    if (empty($group_content)) {
-      throw new \InvalidArgumentException($this->t('This content can\'t be shared'));
+    // First we check if this node belongs to a group.
+    if (!$this->groupsHelper->getGroupByEntity($node)) {
+      throw new \InvalidArgumentException("This content can't be shared");
     }
 
-    if (
-      $target_group->id() === $source_group->id() ||
-      $group_content->getGroup()->id() !== $source_group->id()
-    ) {
-      throw new \InvalidArgumentException($this->t('This content can\'t be shared'));
+    // If source and target groups are the same, we can't share.
+    if ($target_group->id() === $source_group->id()) {
+      throw new \InvalidArgumentException("This content can't be shared");
     }
 
+    // If the content is already shared to the target group, we can't share.
     if ($this->isShared($node, $target_group)) {
-      throw new \InvalidArgumentException($this->t('This content is already shared with this group'));
+      throw new \InvalidArgumentException('This content is already shared with this group');
     }
 
-    $plugin_id = $this->getGroupContentId($target_group, $node);
-    if (!$plugin_id) {
-      throw new \InvalidArgumentException($this->t('This content can\'t be shared'));
-    }
-
+    // Create the group content entity.
     $shared_group_content = GroupContent::create([
-      'type' => $plugin_id,
+      'type' => $target_group->getGroupType()->id() . '-' . self::GROUP_CONTENT_SHARED_PLUGIN_ID,
       'gid' => $target_group->id(),
       'entity_id' => $node->id(),
     ]);
     $shared_group_content->save();
 
+    // Dispatch the message.
     $this->messageBus->dispatch([
       'template' => ActivityStreamMessageTemplates::SHARE_CONTENT,
       'uid' => $node->getOwnerId(),
@@ -136,7 +164,7 @@ class ShareManager {
 
     // Reindex the node immediately.
     // There seem to be multiple implementation of reindexing logics.
-    // @TODO Write a single service for this.
+    // @todo Write a single service for this.
     $indexes = ContentEntity::getIndexesForEntity($node);
     foreach ($indexes as $index) {
       $index->trackItemsUpdated(
@@ -147,82 +175,46 @@ class ShareManager {
   }
 
   /**
+   * Determines if a node has been shared.
+   *
    * @param \Drupal\node\NodeInterface $node
-   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The node entity for which we're looking shares.
+   * @param \Drupal\group\Entity\GroupInterface|null $target_group
+   *   The group to filter on. If null, will check for all groups.
    *
    * @return bool
+   *   TRUE if node has been shared.
+   *
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
-  public function isShared(NodeInterface $node, GroupInterface $group): bool {
-    return !empty($this->getShareEntity($node, $group));
+  public function isShared(NodeInterface $node, GroupInterface $target_group = NULL): bool {
+    return !empty($this->getSharedEntities($node, $target_group));
   }
 
   /**
-   * @param \Drupal\node\NodeInterface $node
-   * @param \Drupal\group\Entity\GroupInterface $group
+   * Returns the list of shared group_content entities.
    *
-   * @return \Drupal\Core\Entity\EntityInterface[]
+   * @param \Drupal\node\NodeInterface $node
+   *   The node entity for which we're looking shares.
+   * @param \Drupal\group\Entity\GroupInterface|null $target_group
+   *   The group to filter on. If null, shared entities will be returned for all
+   *   groups.
+   *
+   * @return \Drupal\group\Entity\GroupContentInterface[]
+   *   The list of found group_content entities.
+   *
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
-  public function getShareEntity(
-    NodeInterface $node,
-    GroupInterface $group
-  ): array {
-    return $this->entityTypeManager->getStorage('message')
-      ->loadByProperties([
-        'template' => ActivityStreamMessageTemplates::SHARE_CONTENT,
-        'field_group_ref' => $group->id(),
-        'field_referenced_node' => $node->id(),
-      ]);
-  }
-
-  /**
-   * Return the group content plugin id for the given node.
-   *
-   * @param \Drupal\group\Entity\GroupInterface $group
-   * @param \Drupal\node\NodeInterface $node
-   *
-   * @return string|null
-   */
-  public function getGroupContentId(
-    GroupInterface $group,
-    NodeInterface $node
-  ): ?string {
-    static $enabled_ids;
-    if (empty($enabled_ids)) {
-      $plugin_ids = $this->groupContentPluginManager
-        ->getInstalledIds($group->getGroupType());
-
-      foreach ($plugin_ids as $plugin_id) {
-        if (strpos($plugin_id, 'group_node:') !== 0) {
-          continue;
-        }
-
-        [, $content_type] = explode(':', $plugin_id);
-        $enabled_ids[$content_type] = $group->getGroupType()
-          ->getContentPlugin("group_node:$content_type")
-          ->getContentTypeConfigId();;
-      }
+  public function getSharedEntities(NodeInterface $node, GroupInterface $target_group = NULL): array {
+    $query = $this->entityTypeManager->getStorage('group_content')->getQuery();
+    $query->condition('type', '%-' . self::GROUP_CONTENT_SHARED_PLUGIN_ID, 'LIKE');
+    $query->condition('entity_id', $node->id());
+    if ($target_group) {
+      $query->condition('gid', $target_group->id());
     }
-
-    return $enabled_ids[$node->bundle()] ?? NULL;
-  }
-
-  /**
-   * @param \Drupal\node\NodeInterface $node
-   *
-   * @return \Drupal\Core\Entity\EntityInterface[]
-   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
-   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
-   */
-  public function getShares(NodeInterface $node): array {
-    return $this->entityTypeManager->getStorage('message')
-      ->loadByProperties([
-        'template' => ActivityStreamMessageTemplates::SHARE_CONTENT,
-        'field_referenced_node' => $node->id(),
-      ]);
+    return $this->entityTypeManager->getStorage('group_content')->loadMultiple($query->execute());
   }
 
 }

--- a/lib/modules/eic_groups/src/EICGroupsHelper.php
+++ b/lib/modules/eic_groups/src/EICGroupsHelper.php
@@ -389,9 +389,16 @@ class EICGroupsHelper implements EICGroupsHelperInterface {
 
     if ($entity instanceof NodeInterface) {
       // Load all the group content for this entity.
-      $group_content = GroupContent::loadByEntity($entity);
-      // Assuming that the content can be related only to 1 group.
-      $group_content = reset($group_content);
+      $group_contents = GroupContent::loadByEntity($entity);
+
+      // We look for the first group_node group_content entity.
+      foreach ($group_contents as $group_content_item) {
+        if (strpos($group_content_item->getGroupContentType()->getContentPluginId(), 'group_node:') === 0) {
+          $group = $group_content_item->getGroup();
+          break;
+        }
+      }
+
       if (!empty($group_content)) {
         $group = $group_content->getGroup();
       }

--- a/lib/modules/eic_groups/src/EICGroupsHelper.php
+++ b/lib/modules/eic_groups/src/EICGroupsHelper.php
@@ -672,7 +672,7 @@ class EICGroupsHelper implements EICGroupsHelperInterface {
    * @param array $filters
    *   Filters to apply to the query. See GroupInterface::getContent().
    *
-   * @return array
+   * @return \Drupal\node\NodeInterface[]
    *   An array of node entities.
    */
   public function getGroupNodes(GroupInterface $group, array $filters = []) {

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/Plugin/GroupMetric/GroupSharedContent.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/Plugin/GroupMetric/GroupSharedContent.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Drupal\eic_group_statistics\Plugin\GroupMetric;
+
+use Drupal\eic_group_statistics\GroupMetricPluginBase;
+use Drupal\group\Entity\GroupInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Group metric plugin implementation for group shared content.
+ *
+ * @GroupMetric(
+ *   id = "eic_groups_shared_content",
+ *   label = @Translation("Group shared content"),
+ *   description = @Translation("Provides a counter for group shared content.")
+ * )
+ */
+class GroupSharedContent extends GroupMetricPluginBase {
+
+  /**
+   * The EIC share manager.
+   *
+   * @var \Drupal\eic_share_content\Service\ShareManager
+   */
+  protected $shareManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(
+    ContainerInterface $container,
+    array $configuration,
+    $plugin_id,
+    $plugin_definition
+  ) {
+    $instance = parent::create(
+      $container,
+      $configuration,
+      $plugin_id,
+      $plugin_definition
+    );
+    $instance->shareManager = $container->get('eic_share_content.share_manager');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getValue(GroupInterface $group, array $configuration = []): int {
+    $count = 0;
+    // Get group nodes first.
+    foreach ($this->groupsHelper->getGroupNodes($group) as $node) {
+      $count += count($this->shareManager->getSharedEntities($node));
+    }
+    return $count;
+  }
+
+}


### PR DESCRIPTION
### Improvements

- Added a new `eic_groups_shared_content` GroupMetric plugin

### Tests

- [x] Go to `/admin/community/groups/groups` and click export button
- [x] Now go to a group and share a node to another group
- [x] Go back to `/admin/community/groups/groups` and export again
- [x] You should have the `Shared content` column increased by one for the group you shared from

### Remarks

- To be tested after https://github.com/EIC-EA/EIC-community-D8/pull/1178 has been reviewed/merged