### PR TITLE
EICNET-2087: About section in global events

### DIFF
--- a/lib/modules/eic_groups/src/EICGroupsHelper.php
+++ b/lib/modules/eic_groups/src/EICGroupsHelper.php
@@ -473,31 +473,33 @@ class EICGroupsHelper implements EICGroupsHelperInterface {
    *   - joining_method: the GroupJoiningMethod plugin type.
    * @param string $plugin_id
    *   The plugin ID.
+   * @param string $group_type
+   *   (optional) The group type.
    *
    * @return \Drupal\Core\StringTranslation\TranslatableMarkup|string
    *   The description for the given plugin.
    */
-  public function getGroupFlexPluginDescription(string $plugin_type, string $plugin_id) {
+  public function getGroupFlexPluginDescription(string $plugin_type, string $plugin_id, string $group_type = 'group') {
     $key = "$plugin_type-$plugin_id";
 
     switch ($key) {
       case 'visibility-' . GroupVisibilityType::GROUP_VISIBILITY_PUBLIC:
-        return $this->t("This group is visible to everyone visiting the group. You're welcome to scroll through the group's content. If you want to participate, please become a group member.");
+        return $this->t("This @group-type is visible to everyone visiting the @group-type. You're welcome to scroll through the @group-type's content. If you want to participate, please become a group member.", ['@group-type' => $group_type]);
 
       case 'visibility-' . GroupVisibilityType::GROUP_VISIBILITY_COMMUNITY:
-        return $this->t("This group is visible to every person that is a member of the EIC Community and has joined this platform. You're welcome to scroll through the group's content. If you want to participate, please become a group member.");
+        return $this->t("This @group-type is visible to every person that is a member of the EIC Community and has joined this platform. You're welcome to scroll through the @group-type's content. If you want to participate, please become a group member.", ['@group-type' => $group_type]);
 
       case 'visibility-' . GroupVisibilityType::GROUP_VISIBILITY_CUSTOM_RESTRICTED:
-        return $this->t('This group is visible to every person that has joined the EIC community that also complies with the following restrictions. You can see this group because the organisation you work for is allowed to see this content or the group owners and administrators have chosen to specifically grant you access to this group. If you want to participate, please become a group member.');
+        return $this->t('This @group-type is visible to every person that has joined the EIC community that also complies with the following restrictions. You can see this @group-type because the organisation you work for is allowed to see this content or the @group-type owners and administrators have chosen to specifically grant you access to this @group-type. If you want to participate, please become a group member.', ['@group-type' => $group_type]);
 
       case 'visibility-' . GroupVisibilityType::GROUP_VISIBILITY_PRIVATE:
-        return $this->t('A private group is only visible to people who received an invitation via email and accepted it. No one else can see this group.');
+        return $this->t('A private @group-type is only visible to people who received an invitation via email and accepted it. No one else can see this @group-type.', ['@group-type' => $group_type]);
 
       case 'joining_method-' . GroupJoiningMethodType::GROUP_JOINING_METHOD_TU_OPEN:
-        return $this->t('This means that EIC Community members can join this group immediately by clicking "join group".');
+        return $this->t('This means that EIC Community members can join this @group-type immediately by clicking "join group".', ['@group-type' => $group_type]);
 
       case 'joining_method-' . GroupJoiningMethodType::GROUP_JOINING_METHOD_TU_MEMBERSHIP_REQUEST:
-        return $this->t('This means that EIC Community members can request to join this group. This request needs to be validated by the group owner or administrator.');
+        return $this->t('This means that EIC Community members can request to join this @group-type. This request needs to be validated by the @group-type owner or administrator.', ['@group-type' => $group_type]);
 
       default:
         return '';
@@ -538,16 +540,23 @@ class EICGroupsHelper implements EICGroupsHelperInterface {
    * @param string $format
    *   The format of the label. Can be 'default' or 'short'. Defaults to
    *   'default'.
+   * @param string $group_type
+   *   The group type. Defaults to 'group'.
    *
    * @return \Drupal\Core\StringTranslation\TranslatableMarkup|string
    *   The description for the given plugin.
    */
-  public function getGroupFlexPluginTitle(string $plugin_type, string $plugin_id, string $format = 'default') {
+  public function getGroupFlexPluginTitle(
+    string $plugin_type,
+    string $plugin_id,
+    string $format = 'default',
+    string $group_type = 'group'
+  ) {
     $key = "$plugin_type-$plugin_id";
 
     $labels = [
       'visibility-' . GroupVisibilityType::GROUP_VISIBILITY_PUBLIC => [
-        'default' => $this->t('Public group'),
+        'default' => $this->t('Public @group-type', ['@group-type' => $group_type]),
         'short' => $this->t('Public'),
       ],
       'visibility-' . GroupVisibilityType::GROUP_VISIBILITY_COMMUNITY => [
@@ -555,11 +564,11 @@ class EICGroupsHelper implements EICGroupsHelperInterface {
         'short' => $this->t('Community members'),
       ],
       'visibility-' . GroupVisibilityType::GROUP_VISIBILITY_CUSTOM_RESTRICTED => [
-        'default' => $this->t('Restricted group'),
+        'default' => $this->t('Restricted @group-type', ['@group-type' => $group_type]),
         'short' => $this->t('Restricted'),
       ],
       'visibility-' . GroupVisibilityType::GROUP_VISIBILITY_PRIVATE => [
-        'default' => $this->t('Private group'),
+        'default' => $this->t('Private @group-type', ['@group-type' => $group_type]),
         'short' => $this->t('Private'),
       ],
       'joining_method-' . GroupJoiningMethodType::GROUP_JOINING_METHOD_TU_OPEN => [
@@ -947,9 +956,11 @@ class EICGroupsHelper implements EICGroupsHelperInterface {
   /**
    * Format array of a field address to string.
    *
-   * @param $address
+   * @param mixed $address
+   *   The address field array.
    *
    * @return string
+   *   The formatted address.
    */
   public static function formatAddress($address) {
     $countries_map = CountryManager::getStandardList();

--- a/lib/modules/eic_groups/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_groups/src/Hooks/EntityOperations.php
@@ -218,11 +218,11 @@ class EntityOperations implements ContainerInjectionInterface {
         $variables['joining_methods'] = $this->oecGroupFlexHelper->getGroupJoiningMethod($entity);
 
         // Get the title and descriptions for each plugin.
-        $variables['visibility']['title'] = $this->eicGroupsHelper->getGroupFlexPluginTitle('visibility', $variables['visibility']['plugin_id']);
-        $variables['visibility']['description'] = $this->eicGroupsHelper->getGroupFlexPluginDescription('visibility', $variables['visibility']['plugin_id']);
+        $variables['visibility']['title'] = $this->eicGroupsHelper->getGroupFlexPluginTitle('visibility', $variables['visibility']['plugin_id'], 'default', $entity->bundle());
+        $variables['visibility']['description'] = $this->eicGroupsHelper->getGroupFlexPluginDescription('visibility', $variables['visibility']['plugin_id'], $entity->bundle());
         foreach ($variables['joining_methods'] as $index => $joining_method) {
           $variables['joining_methods'][$index]['title'] = $this->eicGroupsHelper->getGroupFlexPluginTitle('joining_method', $joining_method['plugin_id']);
-          $variables['joining_methods'][$index]['description'] = $this->eicGroupsHelper->getGroupFlexPluginDescription('joining_method', $joining_method['plugin_id']);
+          $variables['joining_methods'][$index]['description'] = $this->eicGroupsHelper->getGroupFlexPluginDescription('joining_method', $joining_method['plugin_id'], $entity->bundle());
         }
 
         $build += $variables;

--- a/lib/themes/eic_community/includes/preprocess/events.inc
+++ b/lib/themes/eic_community/includes/preprocess/events.inc
@@ -91,7 +91,7 @@ function _eic_community_render_event_detail_page(array &$variables, EntityInterf
   // Event detail items.
   $items = [
     [
-      'content' => ucfirst(implode($location_types, ' & ')),
+      'content' => ucfirst(implode(' & ', $location_types)),
       'icon' => [
         'type' => 'custom',
         'name' => 'tag',

--- a/lib/themes/eic_community/includes/preprocess/groups/event.inc
+++ b/lib/themes/eic_community/includes/preprocess/groups/event.inc
@@ -188,10 +188,82 @@ function eic_community_preprocess_group__event(&$variables) {
 function _preprocess_event_about_page(&$variables) {
   $sections = [];
 
-  _group_about_permissions_tab($variables, $sections);
+  _event_about_permissions_tab($variables, $sections);
 
   $variables['sections'] = [
     'as_tabs' => TRUE,
     'items' => $sections,
   ];
+}
+
+/**
+ * About permissions tab.
+ */
+function _event_about_permissions_tab($variables, &$sections) {
+  if (isset($variables['elements']['visibility'])) {
+    $admin_items = [];
+    $visibility = $variables['elements']['visibility'];
+    $visibility_id = $visibility['plugin_id'];
+    $access_items = [];
+
+    switch ($visibility_id) {
+      case 'custom_restricted':
+        $restrictions = array_map(function ($restriction) {
+          return [
+            'title' => $restriction['label'],
+            'content' => $restriction['options'],
+          ];
+        }, $visibility['settings']);
+
+        $access_items = $restrictions;
+        break;
+
+    }
+
+    $admin_items[] = [
+      'title' => t('Event access'),
+      'content' => [
+        '#theme' => 'eic_community_well',
+        '#content' => [
+          '#theme' => 'eic_community_harmonica',
+          '#title' => $visibility['title'],
+          '#description' => $visibility['description'],
+          '#icon' => [
+            'icon' => [
+              'name' => 'lock',
+              'type' => 'custom',
+            ],
+          ],
+          '#icon_file_path' => $variables['eic_icon_path'],
+          '#items' => $access_items,
+        ],
+      ],
+    ];
+
+    if (count($variables['elements']['joining_methods']) > 0) {
+      $request_title = $variables['elements']['joining_methods'][0]['title'];
+      $request_content = $variables['elements']['joining_methods'][0]['description'];
+
+      $admin_items[] = [
+        'title' => t('Membership Request type'),
+        'items' => [
+          [
+            'title' => $request_title,
+            'content' => $request_content,
+          ],
+        ],
+      ];
+    }
+
+    $sections[] = [
+      'id' => 'admin',
+      'title' => t('Permission and visibility'),
+      'content' => [
+        '#theme' => 'eic_community_extended_list',
+        '#title' => t('Event Permissions'),
+        '#description' => t("Below is explained to whom this event is visible in order to understand the private or public character of the event's content."),
+        '#items' => $admin_items,
+      ],
+    ];
+  }
 }

--- a/lib/themes/eic_community/includes/preprocess/groups/event.inc
+++ b/lib/themes/eic_community/includes/preprocess/groups/event.inc
@@ -175,4 +175,23 @@ function eic_community_preprocess_group__event(&$variables) {
       break;
 
   }
+
+  // About page preprocessing.
+  if (isset($variables['elements']['owners'])) {
+    _preprocess_event_about_page($variables);
+  }
+}
+
+/**
+ * The about page has two tabs with content.
+ */
+function _preprocess_event_about_page(&$variables) {
+  $sections = [];
+
+  _group_about_permissions_tab($variables, $sections);
+
+  $variables['sections'] = [
+    'as_tabs' => TRUE,
+    'items' => $sections,
+  ];
 }

--- a/lib/themes/eic_community/templates/group/group--event--about-page.html.twig
+++ b/lib/themes/eic_community/templates/group/group--event--about-page.html.twig
@@ -1,0 +1,1 @@
+{% extends "@eic_community/group/group--about-page.html.twig" %}


### PR DESCRIPTION
### Fixes

- Fix event about page;
- Improve method to retrieve group visibility descriptions;
- Fix coding standards.

### Tests

- [x] As SA/SCM, go to a group event about page -> `/events/<event-name>/about`
- [x] Make sure the page shows an overview about the event permissions and visibility