### PR TITLE
[EICNET]fix: use load more for activity feed

### DIFF
--- a/lib/modules/eic_search/src/Plugin/Block/SearchOverviewBlock.php
+++ b/lib/modules/eic_search/src/Plugin/Block/SearchOverviewBlock.php
@@ -293,7 +293,7 @@ class SearchOverviewBlock extends BlockBase implements ContainerFactoryPluginInt
           $user_group_roles
         ),
         '#allow_pagination' => $source instanceof SourceTypeInterface ? (int) $source->allowPagination() : 1,
-        '#load_more_number' => SourceTypeInterface::READ_MORE_NUMBER_TO_LOAD,
+        '#load_more_number' => $source->getLoadMoreBatchItems(),
         '#is_route_group_search_results' =>
           (int) ('eic_overviews.groups.overview_page.search' === $route_name),
         '#enable_invite_user_action' =>

--- a/lib/modules/eic_search/src/Search/Sources/Profile/ActivityStreamSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/Profile/ActivityStreamSourceType.php
@@ -87,14 +87,21 @@ class ActivityStreamSourceType extends SourceType {
    * @inheritDoc
    */
   public function allowPagination(): bool {
-    return TRUE;
+    return FALSE;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getLoadMoreBatchItems(): int {
+    return 10;
   }
 
   /**
    * @inheritDoc
    */
   public function ignoreContentFromCurrentUser(): bool {
-    return TRUE;
+    return FALSE;
   }
 
   /**

--- a/lib/modules/eic_search/src/Search/Sources/SourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/SourceType.php
@@ -113,6 +113,13 @@ abstract class SourceType implements SourceTypeInterface {
   /**
    * @inheritDoc
    */
+  public function getLoadMoreBatchItems(): int {
+    return SourceTypeInterface::READ_MORE_NUMBER_TO_LOAD;
+  }
+
+  /**
+   * @inheritDoc
+   */
   public function supportDateFilter(): bool {
     return FALSE;
   }

--- a/lib/modules/eic_search/src/Search/Sources/SourceTypeInterface.php
+++ b/lib/modules/eic_search/src/Search/Sources/SourceTypeInterface.php
@@ -130,6 +130,13 @@ interface SourceTypeInterface {
   public function allowPagination(): bool;
 
   /**
+   * Get the number of items to load by batch.
+   *
+   * @return int
+   */
+  public function getLoadMoreBatchItems(): int;
+
+  /**
    * Check if Source allow to have a date filter.
    *
    * @return bool

--- a/lib/themes/eic_community/react/components/Block/Overview/index.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/index.js
@@ -6,6 +6,7 @@ import Pagination from "./Search/Pagination";
 import TopOptions from "./Search/TopOptions";
 import SearchField from "./Search/Field/SearchField";
 import {getParamsFromUrl} from "../../Utils/Url";
+import LoadMore from "../ActivityStream/LoadMore";
 
 class Overview extends React.Component {
   constructor(props) {
@@ -228,6 +229,13 @@ class Overview extends React.Component {
                   total={Math.ceil(this.state.total / this.state.resultsPerPage)}
                   page={this.state.page}
                   changePage={this.changePage}
+                />}
+                {(this.state.results.numFound !== 0 && this.state.results?.docs?.length < this.state.total && this.props.allowPagination === 0) &&
+                <LoadMore
+                    changePage={this.changePage}
+                    results={this.state.results}
+                    page={this.state.page}
+                    translations={this.state.translations}
                 />}
               </main>
             </div>


### PR DESCRIPTION
How to test:

- [x] Go to /user/USER_ID/activity
- [x] Check if you have a loadmore with 10 items  by batch

PS: if you do not have enough items, add group contents with another use. Cause your user's content will be prefiltered on results