### PR TITLE
[EICNET]fix: reindex messages and node when downloading media

### DIFF
--- a/lib/modules/eic_media/src/MediaHelper.php
+++ b/lib/modules/eic_media/src/MediaHelper.php
@@ -4,6 +4,7 @@ namespace Drupal\eic_media;
 
 use Drupal\Core\Url;
 use Drupal\media\MediaInterface;
+use Drupal\node\NodeInterface;
 
 /**
  * MediaHelper service that provides helper functions for media.
@@ -20,7 +21,20 @@ class MediaHelper {
    *   The URL object.
    */
   public static function formatMediaDownloadLink(MediaInterface $media) {
-    return Url::fromRoute('media_entity_download.download', ['media' => $media->id()]);
+    /** @var \Drupal\node\NodeInterface $node */
+    $node = \Drupal::routeMatch()->getParameter('node');
+
+    return Url::fromRoute(
+      'media_entity_download.download',
+      ['media' => $media->id()],
+      [
+        'query' => [
+          'node_id' => $node instanceof NodeInterface ?
+            $node->id() :
+            NULL,
+        ],
+      ]
+    );
   }
 
 }

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Partials/StatisticsFooterResult.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Partials/StatisticsFooterResult.js
@@ -30,7 +30,7 @@ const StatisticsFooterResult = ({result, enableViews = true, enableMembers = fal
       <span className="ecl-teaser__stat-label">Likes</span>
       <span className="ecl-teaser__stat-value">{result.its_flag_recommend_group || 0}</span>
     </div>}
-    {result?.ss_content_type === 'document' && <div className="ecl-teaser__stat">
+    {(result?.ss_content_type === 'document' || result?.ss_type === 'document') && <div className="ecl-teaser__stat">
       <div dangerouslySetInnerHTML={{__html: svg('download', 'ecl-icon--xs ecl-teaser__stat-icon')}}/>
       <span className="ecl-teaser__stat-label">Downloads</span>
       <span className="ecl-teaser__stat-value">{result?.its_document_download_total || 0}</span>


### PR DESCRIPTION
How to test:

- [ ] Go to /user/USER_ID/activity and be sure you have a document activity listed
- [ ] You should have download statistics
- [ ] Try to download again on the document node and go back to your interests and see if it has been updated