### PR TITLE
EICNET-1907: Overview double load fix.

### DIFF
--- a/lib/themes/eic_community/react/components/Block/Overview/index.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/index.js
@@ -84,7 +84,9 @@ class Overview extends React.Component {
 
   updateSort(value) {
     this.state.sortValue = value;
-    this.searchSolr();
+    if (this.state.initiated) {
+      this.searchSolr();
+    }
   }
 
   updateFacet(name, value, facet, search = true) {


### PR DESCRIPTION
When there is a sort field the search query was executed before applying the facets. This resulted in 2 search calls being launched and thus the results on the page might not be correct (depending on which request finishes last). I added a check to make sure the update sort request is not executed when the component is still initializing.