### PR TITLE
EICNET-2086: Homepage - upcoming events should show "view all events"

### DIFF
--- a/config/sync/views.view.groups_homepage.yml
+++ b/config/sync/views.view.groups_homepage.yml
@@ -651,6 +651,9 @@ display:
         empty: false
         cache: false
         title: false
+        use_more: false
+        use_more_always: false
+        use_more_text: false
         link_display: false
         link_url: false
         sorts: false
@@ -658,6 +661,9 @@ display:
         filter_groups: false
         header: false
       display_description: ''
+      use_more: true
+      use_more_always: false
+      use_more_text: 'View all events'
       link_display: custom_url
       link_url: /events
       header: {  }


### PR DESCRIPTION
### Fixes

- Fix "view all events" link in group homepage events.

### Tests

- [x] As a TU, go to the homepage and check if the homepage events list has a "View all events" link at the bottom of the list  