### PR TITLE
[EICNET-190]fix: do not enable add news/event add content for GM

### DIFF
--- a/config/sync/eic_groups.group_features.eic_groups_anchor_group_events.yml
+++ b/config/sync/eic_groups.group_features.eic_groups_anchor_group_events.yml
@@ -10,6 +10,5 @@ roles:
   - group-member
   - group-admin
   - group-owner
-  - organisation-member
   - organisation-admin
   - organisation-owner

--- a/config/sync/eic_groups.group_features.eic_groups_anchor_members.yml
+++ b/config/sync/eic_groups.group_features.eic_groups_anchor_members.yml
@@ -8,6 +8,5 @@ roles:
   - group-member
   - group-admin
   - group-owner
-  - organisation-member
   - organisation-admin
   - organisation-owner

--- a/config/sync/eic_groups.group_features.eic_groups_anchor_news.yml
+++ b/config/sync/eic_groups.group_features.eic_groups_anchor_news.yml
@@ -10,6 +10,5 @@ roles:
   - group-member
   - group-admin
   - group-owner
-  - organisation-member
   - organisation-admin
   - organisation-owner


### PR DESCRIPTION
How to test:

- [x] Create an organisation
- [x] Enable feature news & event
- [x] as a GM of the group, verify that you cannot add news/event