### PR TITLE
[EICNET-1909]fix: Set event type instead of topics in teaser tag + format image

### DIFF
--- a/config/sync/search_api.index.global.yml
+++ b/config/sync/search_api.index.global.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.storage.group.field_date_range
     - field.storage.group.field_location
+    - field.storage.group.field_vocab_event_type
     - field.storage.user.field_first_name
     - field.storage.user.field_last_name
     - field.storage.media.oe_media_image
@@ -14,12 +15,12 @@ dependencies:
     - field.storage.group.field_vocab_geo
     - field.storage.group.field_vocab_services_products
     - field.storage.group.field_vocab_target_markets
-    - field.storage.group.field_image
     - field.storage.group.field_thumbnail
+    - field.storage.media.oe_media_file
+    - field.storage.group.field_image
     - field.storage.group.field_vocab_topics
     - field.storage.group.field_body
     - field.storage.message.field_entity_type
-    - field.storage.node.field_introduction
     - field.storage.message.field_group_ref
     - field.storage.message.field_operation_type
     - field.storage.message.field_referenced_comment
@@ -36,12 +37,12 @@ dependencies:
     - field.storage.node.field_location
     - field.storage.node.field_vocab_event_type
     - field.storage.node.field_image
+    - field.storage.node.field_introduction
     - field.storage.node.field_language
     - field.storage.node.field_location_type
     - field.storage.node.field_vocab_geo
     - field.storage.node.field_gallery_slides
     - field.storage.paragraph.field_gallery_slide_legend
-    - field.storage.media.oe_media_file
     - field.storage.paragraph.field_gallery_slide_media
     - field.storage.node.field_date_range
     - field.storage.node.field_subtitle
@@ -59,11 +60,11 @@ dependencies:
   module:
     - search_api_solr
     - flag
+    - taxonomy
     - group
     - user
     - file
     - media
-    - taxonomy
     - content_moderation
     - message
     - comment
@@ -726,6 +727,16 @@ field_settings:
       module:
         - file
         - media
+  group_event_type_string:
+    label: 'Event type » Taxonomy term » Name'
+    datasource_id: 'entity:group'
+    property_path: 'field_vocab_event_type:entity:name'
+    type: string
+    dependencies:
+      config:
+        - field.storage.group.field_vocab_event_type
+      module:
+        - taxonomy
   group_field_body:
     label: '[Group] Body'
     datasource_id: 'entity:group'
@@ -877,6 +888,18 @@ field_settings:
     dependencies:
       module:
         - group
+  group_teaser_fid:
+    label: 'Thumbnail image » Media » File » File » File ID'
+    datasource_id: 'entity:group'
+    property_path: 'field_thumbnail:entity:oe_media_file:entity:fid'
+    type: integer
+    dependencies:
+      config:
+        - field.storage.group.field_thumbnail
+        - field.storage.media.oe_media_file
+      module:
+        - file
+        - media
   group_teaser_url_string:
     label: 'Thumbnail image » Media » Image » File » URI » Root-relative file URL'
     datasource_id: 'entity:group'

--- a/lib/modules/eic_overviews/src/GroupOverviewPages.php
+++ b/lib/modules/eic_overviews/src/GroupOverviewPages.php
@@ -86,10 +86,6 @@ class GroupOverviewPages {
         $page_id = self::SEARCH;
         break;
 
-      case 'events':
-        $page_id = self::EVENTS;
-        break;
-
     }
 
     if (!empty($page_id) && !$group->isNew()) {

--- a/lib/modules/eic_search/eic_search.services.yml
+++ b/lib/modules/eic_search/eic_search.services.yml
@@ -115,10 +115,12 @@ services:
       - { name: eic_search.document_processor, priority: 22 }
   eic_search.document_processor_group_event:
     class: Drupal\eic_search\Search\DocumentProcessor\ProcessorGroupEvent
+    arguments: ['@file_url_generator']
     tags:
       - { name: eic_search.document_processor, priority: 28 }
   eic_search.document_processor_global_event:
     class: Drupal\eic_search\Search\DocumentProcessor\ProcessorGlobalEvent
+    arguments: ['@file_url_generator']
     tags:
       - { name: eic_search.document_processor, priority: 30 }
   eic_search.document_processor_organisation:

--- a/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorGlobalEvent.php
+++ b/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorGlobalEvent.php
@@ -3,8 +3,11 @@
 namespace Drupal\eic_search\Search\DocumentProcessor;
 
 use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\Core\Locale\CountryManager;
 use Drupal\eic_search\Search\Sources\GroupEventSourceType;
+use Drupal\file\Entity\File;
+use Drupal\image\Entity\ImageStyle;
 use Solarium\QueryType\Update\Query\Document;
 
 /**
@@ -15,9 +18,42 @@ use Solarium\QueryType\Update\Query\Document;
 class ProcessorGlobalEvent extends DocumentProcessor {
 
   /**
+   * @var FileUrlGeneratorInterface $urlGenerator
+   */
+  private $urlGenerator;
+
+  /**
+   * @param FileUrlGeneratorInterface $urlGenerator
+   */
+  public function __construct(FileUrlGeneratorInterface $urlGenerator) {
+    $this->urlGenerator = $urlGenerator;
+  }
+
+  /**
    * @inheritDoc
    */
   public function process(Document &$document, array $fields, array $items = []): void {
+    $fid = array_key_exists('its_group_teaser_fid', $fields) ?
+      $fields['its_group_teaser_fid'] :
+      NULL;
+
+    $teaser_relative = '';
+
+    if ($fid) {
+      $image_style = ImageStyle::load('large');
+      $file = File::load($fid);
+      $image_uri = $file->getFileUri();
+
+      $teaser_relative = $this->urlGenerator->transformRelative($image_style->buildUrl($image_uri));
+    }
+
+    $this->addOrUpdateDocumentField(
+      $document,
+      'ss_event_formatted_image',
+      $fields,
+      $teaser_relative
+    );
+
     $start_date = new DrupalDateTime($fields['ds_group_field_date_range']);
     $end_date = new DrupalDateTime($fields['ds_group_field_date_range_end_value']);
 

--- a/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorGroupEvent.php
+++ b/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorGroupEvent.php
@@ -3,8 +3,11 @@
 namespace Drupal\eic_search\Search\DocumentProcessor;
 
 use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\Core\Locale\CountryManager;
 use Drupal\eic_search\Search\Sources\GroupEventSourceType;
+use Drupal\file\Entity\File;
+use Drupal\image\Entity\ImageStyle;
 use Solarium\QueryType\Update\Query\Document;
 
 /**
@@ -15,9 +18,42 @@ use Solarium\QueryType\Update\Query\Document;
 class ProcessorGroupEvent extends DocumentProcessor {
 
   /**
+   * @var FileUrlGeneratorInterface $urlGenerator
+   */
+  private $urlGenerator;
+
+  /**
+   * @param FileUrlGeneratorInterface $urlGenerator
+   */
+  public function __construct(FileUrlGeneratorInterface $urlGenerator) {
+    $this->urlGenerator = $urlGenerator;
+  }
+
+  /**
    * @inheritDoc
    */
   public function process(Document &$document, array $fields, array $items = []): void {
+    $fid = array_key_exists('its_content_teaser_image_fid', $fields) ?
+      $fields['its_content_teaser_image_fid'] :
+      NULL;
+
+    $teaser_relative = '';
+
+    if ($fid) {
+      $image_style = ImageStyle::load('large');
+      $file = File::load($fid);
+      $image_uri = $file->getFileUri();
+
+      $teaser_relative = $this->urlGenerator->transformRelative($image_style->buildUrl($image_uri));
+    }
+
+    $this->addOrUpdateDocumentField(
+      $document,
+      'ss_event_formatted_image',
+      $fields,
+      $teaser_relative
+    );
+
     $start_date = new DrupalDateTime($fields['ds_content_field_date_range']);
     $end_date = new DrupalDateTime($fields['ds_content_field_date_range_end_value']);
 

--- a/lib/modules/eic_search/src/Search/Sources/GlobalEventSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/GlobalEventSourceType.php
@@ -43,6 +43,7 @@ class GlobalEventSourceType extends SourceType {
   public function getAvailableFacets(): array {
     return [
       'ss_group_topic_name' => $this->t('Topic', [], ['context' => 'eic_search']),
+      'ss_group_event_type_string' => $this->t('Event type', [], ['context' => 'eic_search']),
       'sm_group_field_location_type' => $this->t('Location', [], ['context' => 'eic_search']),
       Event::SOLR_FIELD_ID_WEIGHT_STATE_LABEL => $this->t('Time', [], ['context' => 'eic_search']),
       'ss_group_event_country' => $this->t('Country', [], ['context' => 'eic_search']),

--- a/lib/themes/eic_community/includes/preprocess/content/node--event.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--event.inc
@@ -6,6 +6,9 @@
  */
 
 use Drupal\eic_helper\DateTimeHelper;
+use Drupal\eic_search\SearchHelper;
+use Drupal\eic_overviews\GroupOverviewPages;
+use Drupal\group\Entity\GroupInterface;
 
 /**
  * Implements hook_preprocess_node__event() for event node.
@@ -39,10 +42,31 @@ function eic_community_preprocess_node__event(array &$variables) {
 
       // Get the event type.
       $event_type_label = '';
-      if (!$node->field_vocab_event_type->isEmpty()) {
+      /** @var \Drupal\group\Entity\GroupInterface $group */
+      $group = \Drupal::routeMatch()->getParameter('group');
+      if (!$node->field_vocab_event_type->isEmpty() && $group instanceof GroupInterface) {
         /** @var \Drupal\taxonomy\Entity\Term $event_type */
         $event_type = $node->get('field_vocab_event_type')->entity;
-        $event_type_label = $event_type->get('name')->getString();
+
+        // Build solr query parameters for the events overview page to filter
+        // by topic.
+        $params = SearchHelper::buildSolrQueryParams(
+          [
+            'ss_content_event_type_string' => $event_type->label(),
+          ]
+        );
+
+        $url = GroupOverviewPages::getGroupOverviewPageUrl('events', $group);
+        $url->setOption('query', $params)->toString();
+
+        $teaser['tags'] = [
+          [
+            'type' => 'link',
+            'label' => $event_type->get('name')->getString(),
+            'path' => $url,
+            'aria_label' => '',
+          ]
+        ];
       }
       $teaser['type'] = [
         'label' => $event_type_label,

--- a/lib/themes/eic_community/includes/preprocess/groups/event.inc
+++ b/lib/themes/eic_community/includes/preprocess/groups/event.inc
@@ -70,32 +70,31 @@ function eic_community_preprocess_group__event(&$variables) {
       }
 
       // Add event topics to the theme variables.
-      if (!$group->get('field_vocab_topics')->isEmpty()) {
-        $event_topics = $group->get('field_vocab_topics')->referencedEntities();
+      if (!$group->get('field_vocab_event_type')->isEmpty()) {
+        /** @var \Drupal\taxonomy\TermInterface $event_type */
+        $event_type = $group->get('field_vocab_event_type')->entity;
 
         $teaser['tags'] = [];
-        foreach ($event_topics as $event_topic) {
-          // Build solr query parameters for the events overview page to filter
-          // by topic.
-          $params = SearchHelper::buildSolrQueryParams(
-            [
-              'itm_aggregated_field_vocab_topics' => $event_topic->id(),
-            ]
-          );
-          $tag = [
-            'label' => $event_topic->getName(),
-          ];
+        // Build solr query parameters for the events overview page to filter
+        // by topic.
+        $params = SearchHelper::buildSolrQueryParams(
+          [
+            'ss_group_event_type_string' => $event_type->label(),
+          ]
+        );
+        $tag = [
+          'label' => $event_type->getName(),
+        ];
 
-          $url = GlobalOverviewPages::getGlobalOverviewPageLink(GlobalOverviewPages::EVENTS)->getUrl();
+        $url = GlobalOverviewPages::getGlobalOverviewPageLink(GlobalOverviewPages::EVENTS)->getUrl();
 
-          if ($url) {
-            $url->setOption('query', $params)
-              ->toString();
-            $tag['path'] = $url;
-          }
-
-          $teaser['tags'][] = $tag;
+        if ($url) {
+          $url->setOption('query', $params)
+            ->toString();
+          $tag['path'] = $url;
         }
+
+        $teaser['tags'][] = $tag;
       }
 
       // Adds number of group members to the theme variables.
@@ -111,7 +110,10 @@ function eic_community_preprocess_group__event(&$variables) {
         $event_date_status = \Drupal::service('eic_helper.datetime')->getDateRangeStatus($group, 'field_date_range');
         $registration_start_date = strtotime($group->get('field_event_registration_date')->value);
         $registration_end_date = strtotime($group->get('field_event_registration_date')->end_value);
-        $registration_status = \Drupal::service('eic_helper.datetime')->getDateRangeStatus($group, 'field_event_registration_date');
+        $registration_status = \Drupal::service('eic_helper.datetime')->getDateRangeStatus(
+          $group,
+          'field_event_registration_date'
+        );
 
         switch ($registration_status) {
           case DateTimeHelper::DATE_RANGE_UPCOMING:
@@ -166,8 +168,16 @@ function eic_community_preprocess_group__event(&$variables) {
         ];
       }
 
-      $teaser['date']['start'] = _eic_community_preprocess_ecl_date_block($event_start_date, NULL, DateTimeHelper::DATE_FORMAT_SHORT);
-      $teaser['date']['end'] = _eic_community_preprocess_ecl_date_block($event_end_date, NULL, DateTimeHelper::DATE_FORMAT_SHORT);
+      $teaser['date']['start'] = _eic_community_preprocess_ecl_date_block(
+        $event_start_date,
+        NULL,
+        DateTimeHelper::DATE_FORMAT_SHORT
+      );
+      $teaser['date']['end'] = _eic_community_preprocess_ecl_date_block(
+        $event_end_date,
+        NULL,
+        DateTimeHelper::DATE_FORMAT_SHORT
+      );
 
       // Get the event state.
       $teaser['date']['variant'] = _eic_community_get_ecl_date_block_variant($group, 'field_date_range');
@@ -261,7 +271,9 @@ function _event_about_permissions_tab($variables, &$sections) {
       'content' => [
         '#theme' => 'eic_community_extended_list',
         '#title' => t('Event Permissions'),
-        '#description' => t("Below is explained to whom this event is visible in order to understand the private or public character of the event's content."),
+        '#description' => t(
+          "Below is explained to whom this event is visible in order to understand the private or public character of the event's content."
+        ),
         '#items' => $admin_items,
       ],
     ];

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/GlobalEventResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/GlobalEventResultItem.js
@@ -25,7 +25,7 @@ const GlobalEventResultItem = ({result}) => {
           <a href={result?.ss_url}>
             <figure className={`ecl-teaser__image-wrapper ${!hasTeaser ? 'ecl-teaser__image-wrapper--empty' : ''}`}>
               {result.ss_group_event_teaser_url_string !== undefined &&
-              <img className="ecl-teaser__image" src={result.ss_group_event_teaser_url_string} alt=""/>
+              <img className="ecl-teaser__image" src={result?.ss_event_formatted_image} alt=""/>
               }
               {result.ss_group_event_teaser_url_string === undefined &&
               <div className="ecl-teaser__image-fallback-wrapper">
@@ -39,13 +39,9 @@ const GlobalEventResultItem = ({result}) => {
               <div className="ecl-teaser__content">
                 <div className="ecl-teaser__tags-wrapper">
                   <div className="ecl-teaser__tags">
-                    {
-                      result?.sm_content_field_vocab_topics_string?.map((topic, index) => (
-                        <div className="ecl-teaser__tag" key={index}>
-                          <span className="ecl-tag ecl-tag--display">{topic}</span>
-                        </div>
-                      ))
-                    }
+                      <div className="ecl-teaser__tag">
+                        <span className="ecl-tag ecl-tag--display">{result?.ss_group_event_type_string}</span>
+                      </div>
                   </div>
                 </div>
                 <h2 className="ecl-teaser__title">

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/GroupEventResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/GroupEventResultItem.js
@@ -27,7 +27,7 @@ const GroupEventResultItem = ({result}) => {
           <a href={result?.ss_url}>
             <figure className={`ecl-teaser__image-wrapper ${!hasTeaser ? 'ecl-teaser__image-wrapper--empty' : ''}`}>
               {result.ss_content_image_url !== undefined &&
-              <img className="ecl-teaser__image" src={result.ss_content_image_url} alt=""/>
+              <img className="ecl-teaser__image" src={result?.ss_event_formatted_image} alt=""/>
               }
               {result.ss_content_image_url === undefined &&
               <div className="ecl-teaser__image-fallback-wrapper">
@@ -41,13 +41,9 @@ const GroupEventResultItem = ({result}) => {
               <div className="ecl-teaser__content">
                 <div className="ecl-teaser__tags-wrapper">
                   <div className="ecl-teaser__tags">
-                    {
-                      result?.sm_content_field_vocab_topics_string?.map((topic, index) => (
-                        <div className="ecl-teaser__tag" key={index}>
-                          <span className="ecl-tag ecl-tag--display">{topic}</span>
-                        </div>
-                      ))
-                    }
+                    <div className="ecl-teaser__tag">
+                      <span className="ecl-tag ecl-tag--display">{result?.ss_content_event_type_string}</span>
+                    </div>
                   </div>
                 </div>
                 <h2 className="ecl-teaser__title">


### PR DESCRIPTION
How to test:

- [x] Go to an organisation detail page
- [x] Be sure you have different events
- [x] In the block events, verify you have in the tag the event type field
- [x] Click on the"View all events" and see if in the overview we still have the event type field
- [x] Now check if the teaser image is no more in Portrait mode but more square to match design