### PR TITLE
EICNET-2097: Teaser image height fix.

### DIFF
--- a/lib/themes/eic_community/sass/compositions/_teaser.scss
+++ b/lib/themes/eic_community/sass/compositions/_teaser.scss
@@ -203,7 +203,6 @@
 
     @include ecl-media-breakpoint-up('sm') {
       width: map-get($ecl-media, 'l');
-      height: map-get($ecl-media, 'm');
       margin: 0 ecl-box-model('padding') 0 0;
     }
 
@@ -215,6 +214,12 @@
       width: 3rem;
       height: 3rem;
       color: #ffffff;
+    }
+
+    #{$node}--story & {
+      @include ecl-media-breakpoint-up('sm') {
+        height: map-get($ecl-media, 'm');
+      }
     }
 
     #{$node}--as-card & {


### PR DESCRIPTION
Fixed regression issue caused by update to image height for story teaser. This caused group overview teasers to not have correct height. Moved fix for story teaser to a more specific selector.

### To test
Check that height of images on group overview is correct.