### PR TITLE
EICNET-2110: Share content: make sure users can share to the groups they belong only

### DIFF
--- a/config/sync/views.view.admin_groups.yml
+++ b/config/sync/views.view.admin_groups.yml
@@ -8,6 +8,7 @@ dependencies:
   module:
     - content_moderation
     - group
+    - oec_group_flex
     - user
     - views_autocomplete_filters
 id: admin_groups
@@ -157,6 +158,56 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        group_visibility:
+          id: group_visibility
+          table: groups_field_data
+          field: group_visibility
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: group
+          plugin_id: group_visibility
+          label: Visibility
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
         moderation_state:
           id: moderation_state
           table: groups_field_data
@@ -783,6 +834,7 @@ display:
           columns:
             id: id
             label: label
+            group_visibility: group_visibility
             moderation_state: moderation_state
             name: name
             created: created
@@ -798,6 +850,13 @@ display:
               empty_column: false
               responsive: ''
             label:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            group_visibility:
               sortable: true
               default_sort_order: asc
               align: ''

--- a/config/sync/workflows.workflow.groups.yml
+++ b/config/sync/workflows.workflow.groups.yml
@@ -16,7 +16,7 @@ type_settings:
     archived:
       label: Archived
       weight: 3
-      published: false
+      published: true
       default_revision: true
     blocked:
       label: Blocked

--- a/lib/modules/eic_groups/modules/eic_share_content/eic_share_content.services.yml
+++ b/lib/modules/eic_groups/modules/eic_share_content/eic_share_content.services.yml
@@ -1,4 +1,4 @@
 services:
   eic_share_content.share_manager:
     class: 'Drupal\eic_share_content\Service\ShareManager'
-    arguments: [ '@eic_groups.helper', '@entity_type.manager', '@plugin.manager.group_content_enabler', '@eic_messages.message_bus', '@eic_search.solr_document_processor' ]
+    arguments: [ '@eic_groups.helper', '@entity_type.manager', '@plugin.manager.group_content_enabler', '@group.membership_loader', '@group_flex.group', '@eic_messages.message_bus', '@eic_search.solr_document_processor' ]

--- a/lib/modules/eic_groups/modules/eic_share_content/src/Service/ShareManager.php
+++ b/lib/modules/eic_groups/modules/eic_share_content/src/Service/ShareManager.php
@@ -3,14 +3,19 @@
 namespace Drupal\eic_share_content\Service;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\eic_groups\Constants\GroupVisibilityType;
 use Drupal\eic_groups\EICGroupsHelperInterface;
 use Drupal\eic_messages\ActivityStreamOperationTypes;
 use Drupal\eic_messages\Service\MessageBusInterface;
 use Drupal\eic_messages\Util\ActivityStreamMessageTemplates;
+use Drupal\eic_user\UserHelper;
 use Drupal\group\Entity\GroupContent;
 use Drupal\group\Entity\GroupInterface;
+use Drupal\group\GroupMembershipLoader;
 use Drupal\group\Plugin\GroupContentEnablerManagerInterface;
+use Drupal\group_flex\GroupFlexGroup;
 use Drupal\node\NodeInterface;
 use Drupal\search_api\Plugin\search_api\datasource\ContentEntity;
 
@@ -52,6 +57,20 @@ class ShareManager {
   private $groupContentPluginManager;
 
   /**
+   * The group membership loader.
+   *
+   * @var \Drupal\group\GroupMembershipLoader
+   */
+  private $groupMembershipLoader;
+
+  /**
+   * The group flex group service.
+   *
+   * @var \Drupal\group_flex\GroupFlexGroup
+   */
+  private $groupFlexGroup;
+
+  /**
    * The EIC message bus.
    *
    * @var \Drupal\eic_messages\Service\MessageBusInterface
@@ -67,6 +86,10 @@ class ShareManager {
    *   The entity type manager.
    * @param \Drupal\group\Plugin\GroupContentEnablerManagerInterface $plugin_manager
    *   The group content enabler manager.
+   * @param \Drupal\group\GroupMembershipLoader $group_membership_loader
+   *   The group membership loader.
+   * @param \Drupal\group_flex\GroupFlexGroup $group_flex_group
+   *   The group flex group service.
    * @param \Drupal\eic_messages\Service\MessageBusInterface $message_bus
    *   The EIC message bus.
    */
@@ -74,11 +97,15 @@ class ShareManager {
     EICGroupsHelperInterface $groups_helper,
     EntityTypeManagerInterface $entity_type_manager,
     GroupContentEnablerManagerInterface $plugin_manager,
+    GroupMembershipLoader $group_membership_loader,
+    GroupFlexGroup $group_flex_group,
     MessageBusInterface $message_bus
   ) {
     $this->groupsHelper = $groups_helper;
     $this->entityTypeManager = $entity_type_manager;
     $this->groupContentPluginManager = $plugin_manager;
+    $this->groupMembershipLoader = $group_membership_loader;
+    $this->groupFlexGroup = $group_flex_group;
     $this->messageBus = $message_bus;
   }
 
@@ -215,6 +242,65 @@ class ShareManager {
       $query->condition('gid', $target_group->id());
     }
     return $this->entityTypeManager->getStorage('group_content')->loadMultiple($query->execute());
+  }
+
+  /**
+   * Returns the list of target groups a user can share content to.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The user account for which we build the list.
+   * @param \Drupal\group\Entity\GroupInterface $source_group
+   *   The source group from which we want to share.
+   * @param array $visibility_types
+   *   The target groups visibility types to filter on.
+   *   Allowed values are constants provided by GroupVisibilityType.
+   *
+   * @return \Drupal\group\Entity\GroupInterface[]
+   *   A list of group entities.
+   *
+   * @throws \Drupal\Core\TypedData\Exception\MissingDataException
+   */
+  public function getShareableTargetGroupsForUser(AccountInterface $account, GroupInterface $source_group, array $visibility_types = [GroupVisibilityType::GROUP_VISIBILITY_PUBLIC]) {
+    $groups = [];
+    $unfiltered_groups = [];
+
+    // If user is power user, we get all groups with given visibility types
+    // regardless of memberships.
+    if (UserHelper::isPowerUser($account)) {
+      foreach ($visibility_types as $visibility_type) {
+        foreach ($this->groupsHelper->getGroupsByVisibility($visibility_type) as $group) {
+          $unfiltered_groups[] = $group;
+        }
+      }
+    }
+    // Otherwise we get only groups the user is member of.
+    else {
+      /** @var \Drupal\group\GroupMembership $group_membership */
+      foreach ($this->groupMembershipLoader->loadByUser($account) as $group_membership) {
+        $unfiltered_groups[] = $group_membership->getGroup();
+      }
+    }
+
+    foreach ($unfiltered_groups as $group) {
+      // Allow only selected visibility types.
+      if (!in_array($this->groupFlexGroup->getGroupVisibility($group), $visibility_types)) {
+        continue;
+      }
+
+      // Exclude non published groups.
+      if (!$group->isPublished()) {
+        continue;
+      }
+
+      // Exclude source group.
+      if ($group->id() === $source_group->id()) {
+        continue;
+      }
+
+      $groups[] = $group;
+    }
+
+    return $groups;
   }
 
 }

--- a/lib/modules/eic_groups/modules/eic_share_content/src/Service/ShareManager.php
+++ b/lib/modules/eic_groups/modules/eic_share_content/src/Service/ShareManager.php
@@ -7,6 +7,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\eic_groups\Constants\GroupVisibilityType;
 use Drupal\eic_groups\EICGroupsHelperInterface;
+use Drupal\eic_groups\GroupsModerationHelper;
 use Drupal\eic_messages\ActivityStreamOperationTypes;
 use Drupal\eic_messages\Service\MessageBusInterface;
 use Drupal\eic_messages\Util\ActivityStreamMessageTemplates;
@@ -289,6 +290,11 @@ class ShareManager {
 
       // Exclude non published groups.
       if (!$group->isPublished()) {
+        continue;
+      }
+
+      // Exclude blocked groups.
+      if (GroupsModerationHelper::isBlocked($group)) {
         continue;
       }
 

--- a/lib/modules/eic_groups/src/GroupsModerationHelper.php
+++ b/lib/modules/eic_groups/src/GroupsModerationHelper.php
@@ -45,6 +45,23 @@ class GroupsModerationHelper {
   const GROUP_ARCHIVED_STATE = 'archived';
 
   /**
+   * Checks if a group is archived.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group entity.
+   *
+   * @return bool
+   *   TRUE if group is archived, FALSE otherwise.
+   */
+  public static function isArchived(GroupInterface $group) {
+    if ($group->get('moderation_state')->value === GroupsModerationHelper::GROUP_ARCHIVED_STATE) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
    * Checks if a group is blocked.
    *
    * @param \Drupal\group\Entity\GroupInterface $group

--- a/lib/modules/eic_groups/src/GroupsModerationHelper.php
+++ b/lib/modules/eic_groups/src/GroupsModerationHelper.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\eic_groups;
 
+use Drupal\group\Entity\GroupInterface;
+
 /**
  * GroupsModerationHelper helper class.
  */
@@ -41,5 +43,22 @@ class GroupsModerationHelper {
    * @var string
    */
   const GROUP_ARCHIVED_STATE = 'archived';
+
+  /**
+   * Checks if a group is blocked.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group entity.
+   *
+   * @return bool
+   *   TRUE if group is blocked, FALSE otherwise.
+   */
+  public static function isBlocked(GroupInterface $group) {
+    if ($group->get('moderation_state')->value === GroupsModerationHelper::GROUP_BLOCKED_STATE) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
 
 }

--- a/lib/themes/eic_community/includes/preprocess/common.inc
+++ b/lib/themes/eic_community/includes/preprocess/common.inc
@@ -47,10 +47,15 @@ function _eic_community_get_social_share_block() {
 }
 
 /**
- * @param \Drupal\group\Entity\GroupInterface $group
+ * Returns the build for the content share feature.
+ *
+ * @param \Drupal\group\Entity\GroupInterface $current_group
+ *   The group entity we're sharing from.
  * @param \Drupal\node\NodeInterface $node
+ *   The content entity we want to share.
  *
  * @return array
+ *   The build array.
  */
 function _eic_community_get_share_group_content_link(
   GroupInterface $current_group,
@@ -69,14 +74,9 @@ function _eic_community_get_share_group_content_link(
   }
 
   if (empty($formatted_groups)) {
-    /** @var \Drupal\group\Entity\GroupInterface[] $groups */
-    $groups = \Drupal::service('eic_groups.helper')
-      ->getGroupsByVisibility(GroupVisibilityType::GROUP_VISIBILITY_PUBLIC);
-    foreach ($groups as $group) {
-      if ($group->id() === $current_group->id()) {
-        continue;
-      }
-
+    $account = \Drupal::currentUser();
+    $share_manager = \Drupal::service('eic_share_content.share_manager');
+    foreach ($share_manager->getShareableTargetGroupsForUser($account, $current_group) as $group) {
       if (!isset($formatted_groups[$group->bundle()])) {
         $formatted_groups[$group->bundle()] = [
           'label' => $group->type->entity->label(),


### PR DESCRIPTION
### Improvements

- Moved the logic to get target groups to the ShareManager module
- Now filtering traget groups based on user
- Created a static method to check if group is blocked
- Created a static method to check if group is archived
- Changed the Archived state to remain published

### Tests

- [x] Make sure you have a mix of published public/private groups
- [x] Add TU as GM to some public and private groups
- [x] As TU create a public group and as SA/SCM publish it
- [x] As TU go to a public group and try to share a content
- [x] Make sure you can share only to _public_ groups you are member of
- [x] As SA/SCM, try to sahre the same content
- [x] Make sure you can share to all public groups, even if you're not a member of all groups (e.g. the group created by TU)
- [x] As SA/SCM block one of those public groups
- [x] As SA/SCM/TU make sure you can't share to the blocked group
- [x] As SA/SCM archive one of those public groups
- [x] As SA/SCM/TU make sure you can't share to the archived group