### PR TITLE
EICNET-1991: Make image fields optional for organisations.

### DIFF
--- a/config/sync/field.field.group.organisation.field_header_visual.yml
+++ b/config/sync/field.field.group.organisation.field_header_visual.yml
@@ -12,7 +12,7 @@ entity_type: group
 bundle: organisation
 label: 'Banner Image'
 description: ''
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/config/sync/field.field.group.organisation.field_thumbnail.yml
+++ b/config/sync/field.field.group.organisation.field_thumbnail.yml
@@ -12,7 +12,7 @@ entity_type: group
 bundle: organisation
 label: 'Thumbnail image'
 description: ''
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''


### PR DESCRIPTION
### Tests

- [x] Create a new organisation without banner and thumbnail images
- [x] Make sure the display is not broken on organisation homepage and organisation overview