### PR TITLE
EICNET-2116: News articles within organisation can be promoted on homepage

### DIFF
--- a/config/sync/views.view.latest_news_and_stories.yml
+++ b/config/sync/views.view.latest_news_and_stories.yml
@@ -9,9 +9,12 @@ dependencies:
     - node.type.story
   module:
     - entity_browser
+    - group
     - media
     - node
+    - oec_group_flex
     - user
+    - views_autocomplete_filters
 id: latest_news_and_stories
 label: 'Latest News and Stories'
 module: views
@@ -518,6 +521,49 @@ display:
             field_identifier: title
           exposed: true
       filters:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: title_op
+            label: Title
+            description: ''
+            use_operator: false
+            operator: title_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: title
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
         status:
           id: status
           table: node_field_data
@@ -574,36 +620,79 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-        title:
-          id: title
+        private:
+          id: private
           table: node_field_data
-          field: title
+          field: private
           relationship: none
           group_type: group
           admin_label: ''
           entity_type: node
-          entity_field: title
-          plugin_id: string
-          operator: contains
-          value: ''
+          entity_field: private
+          plugin_id: boolean
+          operator: '='
+          value: '0'
           group: 1
-          exposed: true
+          exposed: false
           expose:
-            operator_id: title_op
-            label: Title
+            operator_id: ''
+            label: ''
             description: ''
             use_operator: false
-            operator: title_op
+            operator: ''
             operator_limit_selection: false
             operator_list: {  }
-            identifier: title
+            identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        id:
+          id: id
+          table: group_content_field_data
+          field: id
+          relationship: group_content
+          group_type: group
+          admin_label: ''
+          entity_type: group_content
+          entity_field: id
+          plugin_id: numeric
+          operator: empty
+          value:
+            min: ''
+            max: ''
+            value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            min_placeholder: ''
+            max_placeholder: ''
             placeholder: ''
           is_grouped: false
           group_info:
@@ -617,10 +706,178 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        status_1:
+          id: status_1
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 2
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        type_1:
+          id: type_1
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value:
+            news: news
+            story: story
+          group: 2
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        private_1:
+          id: private_1
+          table: node_field_data
+          field: private
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: private
+          plugin_id: boolean
+          operator: '='
+          value: '0'
+          group: 2
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        group_visibility:
+          id: group_visibility
+          table: groups_field_data
+          field: group_visibility
+          relationship: gid
+          group_type: group
+          admin_label: ''
+          entity_type: group
+          plugin_id: group_visibility
+          operator: '='
+          value: null
+          group: 2
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          visibility:
+            public: public
+            private: 0
+            restricted_community_members: 0
+            custom_restricted: 0
       filter_groups:
-        operator: AND
+        operator: OR
         groups:
           1: AND
+          2: AND
       style:
         type: table
         options:
@@ -677,10 +934,45 @@ display:
         access: false
         style: false
         row: false
+        relationships: false
         fields: false
         sorts: false
         filters: false
         filter_groups: false
+      relationships:
+        group_content:
+          id: group_content
+          table: node_field_data
+          field: group_content
+          relationship: none
+          group_type: group
+          admin_label: 'Content group content'
+          entity_type: node
+          plugin_id: group_content_to_entity_reverse
+          required: false
+          group_content_plugins:
+            'group_node:news': 'group_node:news'
+            group_shared_content: '0'
+            'group_node:book': '0'
+            'group_node:discussion': '0'
+            'group_node:document': '0'
+            'group_node:event': '0'
+            'group_node:gallery': '0'
+            'group_node:page': '0'
+            'group_node:story': '0'
+            'group_node:video': '0'
+            'group_node:wiki_page': '0'
+        gid:
+          id: gid
+          table: group_content_field_data
+          field: gid
+          relationship: group_content
+          group_type: group
+          admin_label: Group
+          entity_type: group_content
+          entity_field: gid
+          plugin_id: standard
+          required: false
       display_description: ''
       display_extenders: {  }
     cache_metadata:

--- a/lib/modules/eic_default_content/src/Generator/NewsGenerator.php
+++ b/lib/modules/eic_default_content/src/Generator/NewsGenerator.php
@@ -2,10 +2,11 @@
 
 namespace Drupal\eic_default_content\Generator;
 
+use Drupal\eic_private_content\PrivateContentConst;
 use Drupal\node\Entity\Node;
 
 /**
- * Class NewsGenerator
+ * Class to generate news using fixtures.
  *
  * @package Drupal\eic_default_content\Generator
  */
@@ -31,6 +32,7 @@ class NewsGenerator extends CoreGenerator {
         'field_vocab_topics' => $this->getRandomEntities('taxonomy_term', ['vid' => 'topics'], 1),
         'field_vocab_geo' => $this->getRandomEntities('taxonomy_term', ['vid' => 'geo'], 1),
         'moderation_state' => 'published',
+        PrivateContentConst::FIELD_NAME => FALSE,
       ];
 
       $node = Node::create($values);

--- a/lib/modules/oec_group_flex/oec_group_flex.module
+++ b/lib/modules/oec_group_flex/oec_group_flex.module
@@ -145,6 +145,10 @@ function oec_group_flex_views_data() {
     'field' => [
       'id' => 'group_visibility',
     ],
+    'filter' => [
+      'title' => t('Visibility'),
+      'id' => 'group_visibility',
+    ],
   ];
   $data['groups_field_data']['group_visibility_custom_restricted_email_domains'] = [
     'title' => t('Visibility Custom: Restricted email domains'),

--- a/lib/modules/oec_group_flex/src/Plugin/views/filter/GroupVisibility.php
+++ b/lib/modules/oec_group_flex/src/Plugin/views/filter/GroupVisibility.php
@@ -4,7 +4,6 @@ namespace Drupal\oec_group_flex\Plugin\views\filter;
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\group_flex\Plugin\GroupVisibilityManager;
-use Drupal\oec_group_flex\OECGroupFlexHelper;
 use Drupal\views\Plugin\views\filter\FilterPluginBase;
 use Drupal\views\Views;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -26,7 +25,7 @@ class GroupVisibility extends FilterPluginBase {
   protected $groupVisibilityManager;
 
   /**
-   * Constructs a PluginBase object.
+   * Constructs a GroupVisibility object.
    *
    * @param array $configuration
    *   A configuration array containing information about the plugin instance.

--- a/lib/modules/oec_group_flex/src/Plugin/views/filter/GroupVisibility.php
+++ b/lib/modules/oec_group_flex/src/Plugin/views/filter/GroupVisibility.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Drupal\oec_group_flex\Plugin\views\filter;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\group_flex\Plugin\GroupVisibilityManager;
+use Drupal\oec_group_flex\OECGroupFlexHelper;
+use Drupal\views\Plugin\views\filter\FilterPluginBase;
+use Drupal\views\Views;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * A handler to provide a filter for group visibility.
+ *
+ * @ingroup views_field_handlers
+ *
+ * @ViewsFilter("group_visibility")
+ */
+class GroupVisibility extends FilterPluginBase {
+
+  /**
+   * The Group visibility manager.
+   *
+   * @var \Drupal\group_flex\Plugin\GroupVisibilityManager
+   */
+  protected $groupVisibilityManager;
+
+  /**
+   * Constructs a PluginBase object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\group_flex\Plugin\GroupVisibilityManager $group_visibility_manager
+   *   The Group visibility manager.
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    GroupVisibilityManager $group_visibility_manager
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->groupVisibilityManager = $group_visibility_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('plugin.manager.group_visibility')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function defineOptions() {
+    $options = parent::defineOptions();
+    $options['visibility'] = [];
+
+    // By default all visibility options are disabled.
+    foreach ($this->groupVisibilityManager->getAllAsArrayForGroup() as $key => $plugin) {
+      $options['visibility'][$key] = FALSE;
+    }
+
+    return $options;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildOptionsForm(&$form, FormStateInterface $form_state) {
+    $options = [];
+    $default_values = [];
+
+    // Build the checkbox options and default values.
+    foreach ($this->groupVisibilityManager->getAllAsArrayForGroup() as $key => $plugin) {
+      $options[$key] = $plugin->getLabel();
+      if (!empty($this->options['visibility'][$key])) {
+        $default_values[] = $key;
+      }
+    }
+
+    $form['visibility'] = [
+      '#type' => 'checkboxes',
+      '#title' => $this->t('Filter by group visibility'),
+      '#options' => $options,
+      '#default_value' => $default_values,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function valueSubmit($form, FormStateInterface $form_state) {
+    // Drupal's FAPI system automatically puts '0' in for any checkbox that
+    // was not set, and the key to the checkbox if it is set.
+    // Unfortunately, this means that if the key to that checkbox is 0,
+    // we are unable to tell if that checkbox was set or not.
+
+    // Luckily, the '#value' on the checkboxes form actually contains
+    // *only* a list of checkboxes that were set, and we can use that
+    // instead.
+
+    $form_state->setValue(['options', 'value'], $form['value']['#value']);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    $this->ensureMyTable();
+    /** @var \Drupal\views\Plugin\views\query\Sql $query */
+    $query = $this->query;
+    // Creates new configuration for views join plugin. This will join the
+    // group visibility table with groups field data table in order to filter
+    // the query by the selected group visibilities.
+    $definition = [
+      'table' => 'oec_group_visibility',
+      'field' => 'gid',
+      'left_table' => 'groups_field_data_group_content_field_data',
+      'left_field' => 'id',
+    ];
+    // Instantiates the join plugin.
+    $join = Views::pluginManager('join')->createInstance('standard', $definition);
+    // Adds the join relationship to the query.
+    $query->addRelationship('group_visibility', $join, 'oec_group_visibility');
+    // Grabs the group visibilities from the selected options.
+    $options = array_filter($this->options['visibility'], function ($value, $key) {
+      return $value != FALSE;
+    }, ARRAY_FILTER_USE_BOTH);
+    // Filters out the query by the selected group visibilities.
+    $query->addWhere($this->options['group'], 'group_visibility.type', array_values($options), 'IN');
+  }
+
+}


### PR DESCRIPTION
### Improvements

- Create new views filter plugin for group visibility;
- Update entity browser for selecting News and Stories to show in the homepage so that it only allows SA/SCM users to select published content (including content from public groups).

### Tests

- [x] As SA/SCM, navigate to -> `/admin/content/block-content`
- [x] Edit the block "Latest News & Stories"
- [x] In the edit form, make sure you can only select News or Stories that are published + not private (community members only checkbox disabled) + from public events