### PR TITLE
EICNET-2054: Help and guidance contact box: back-end

### DIFF
--- a/config/sync/block_content.type.contact_box.yml
+++ b/config/sync/block_content.type.contact_box.yml
@@ -1,0 +1,8 @@
+uuid: e5f4ec22-faea-46ef-9d5b-6f9253041b2b
+langcode: en
+status: true
+dependencies: {  }
+id: contact_box
+label: 'Contact box'
+revision: 0
+description: 'A contact box block that shows a title, a description and a CTA button.'

--- a/config/sync/context.context.book_pages.yml
+++ b/config/sync/context.context.book_pages.yml
@@ -2,7 +2,10 @@ uuid: bfebbc46-2f78-4d31-8949-a2edc65524a6
 langcode: en
 status: true
 dependencies:
+  content:
+    - 'block_content:contact_box:63285e84-4aaf-475a-ae6f-169d5dae81e3'
   module:
+    - block_content
     - eic_content_book
     - node
 label: 'Book pages'
@@ -40,6 +43,24 @@ reactions:
         context_id: book_pages
         context_mapping: {  }
         block_mode: null
+      ddc9b63b-5b9c-4947-afa4-e590b1c32561:
+        uuid: ddc9b63b-5b9c-4947-afa4-e590b1c32561
+        id: 'block_content:63285e84-4aaf-475a-ae6f-169d5dae81e3'
+        label: 'Contact box - Help & Guidance'
+        provider: block_content
+        label_display: '0'
+        region: sidebar
+        weight: '1'
+        custom_id: eic_contact_box_help_guindance
+        theme: eic_community
+        css_class: ''
+        unique: 0
+        context_id: book_pages
+        context_mapping: {  }
+        status: true
+        info: ''
+        view_mode: full
+        third_party_settings: {  }
     include_default_blocks: 0
     saved: false
 weight: 0

--- a/config/sync/core.entity_form_display.block_content.contact_box.default.yml
+++ b/config/sync/core.entity_form_display.block_content.contact_box.default.yml
@@ -1,0 +1,59 @@
+uuid: b63296e2-b82c-4d84-be8f-6ee64da57920
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.contact_box
+    - field.field.block_content.contact_box.body
+    - field.field.block_content.contact_box.field_cta_button
+    - field.field.block_content.contact_box.field_title
+  module:
+    - text
+    - typed_link
+id: block_content.contact_box.default
+targetEntityType: block_content
+bundle: contact_box
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 2
+    region: content
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: false
+    third_party_settings: {  }
+  field_cta_button:
+    type: typed_link
+    weight: 3
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+  field_title:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  info:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 4
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+hidden: {  }

--- a/config/sync/core.entity_view_display.block_content.contact_box.default.yml
+++ b/config/sync/core.entity_view_display.block_content.contact_box.default.yml
@@ -1,0 +1,47 @@
+uuid: b1b94c52-cd91-4a92-92b5-4d4d8e3eaf82
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.contact_box
+    - field.field.block_content.contact_box.body
+    - field.field.block_content.contact_box.field_cta_button
+    - field.field.block_content.contact_box.field_title
+  module:
+    - text
+    - typed_link
+id: block_content.contact_box.default
+targetEntityType: block_content
+bundle: contact_box
+mode: default
+content:
+  body:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_cta_button:
+    type: typed_link
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  langcode: true
+  search_api_excerpt: true

--- a/config/sync/field.field.block_content.contact_box.body.yml
+++ b/config/sync/field.field.block_content.contact_box.body.yml
@@ -1,0 +1,23 @@
+uuid: 35723430-1fd8-4daa-8f63-77842346cdbe
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.contact_box
+    - field.storage.block_content.body
+  module:
+    - text
+id: block_content.contact_box.body
+field_name: body
+entity_type: block_content
+bundle: contact_box
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: false
+  required_summary: false
+field_type: text_with_summary

--- a/config/sync/field.field.block_content.contact_box.field_cta_button.yml
+++ b/config/sync/field.field.block_content.contact_box.field_cta_button.yml
@@ -1,0 +1,23 @@
+uuid: 6e61691f-d931-4e20-9434-b599009467ca
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.contact_box
+    - field.storage.block_content.field_cta_button
+  module:
+    - typed_link
+id: block_content.contact_box.field_cta_button
+field_name: field_cta_button
+entity_type: block_content
+bundle: contact_box
+label: 'CTA button'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 2
+  link_type: 17
+field_type: typed_link

--- a/config/sync/field.field.block_content.contact_box.field_title.yml
+++ b/config/sync/field.field.block_content.contact_box.field_title.yml
@@ -1,0 +1,19 @@
+uuid: 19214637-c715-457e-8e21-f4fef111ee50
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.contact_box
+    - field.storage.block_content.field_title
+id: block_content.contact_box.field_title
+field_name: field_title
+entity_type: block_content
+bundle: contact_box
+label: Title
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.block_content.field_cta_button.yml
+++ b/config/sync/field.storage.block_content.field_cta_button.yml
@@ -1,0 +1,24 @@
+uuid: 3df1ce2a-078b-41cb-9322-8b8203ebb682
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - typed_link
+id: block_content.field_cta_button
+field_name: field_cta_button
+entity_type: block_content
+type: typed_link
+settings:
+  allowed_values:
+    default: Default
+    call: 'Call to action'
+    primary: Primary
+  allowed_values_function: ''
+module: typed_link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/language.content_settings.block_content.contact_box.yml
+++ b/config/sync/language.content_settings.block_content.contact_box.yml
@@ -1,0 +1,11 @@
+uuid: 537830c2-17e6-4668-a465-99f90a9cc82c
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.contact_box
+id: block_content.contact_box
+target_entity_type_id: block_content
+target_bundle: contact_box
+default_langcode: site_default
+language_alterable: false

--- a/lib/modules/eic_content/modules/eic_content_book/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_content/modules/eic_content_book/src/Hooks/EntityOperations.php
@@ -94,15 +94,12 @@ class EntityOperations implements ContainerInjectionInterface {
 
           if (isset($entity->book) && empty($entity->book['pid'])) {
             // If top level book page.
-            $build['link_add_child_book_page'] = $add_book_page_urls['add_child_book_page']->toString();
             $build['link_add_child_book_page_renderable'] = Link::fromTextAndUrl($this->t('Add a new book page'), $add_book_page_urls['add_child_book_page'])->toRenderable();
           }
           else {
             // If child book page.
-            $build['link_add_current_level_book_page'] = $add_book_page_urls['add_current_level_book_page']->toString();
             $build['link_add_current_level_book_page_renderable'] = Link::fromTextAndUrl($this->t('Add page on same level'), $add_book_page_urls['add_current_level_book_page'])->toRenderable();
             $build['link_add_current_level_book_page_renderable']['#suffix'] = '<br>';
-            $build['link_add_child_book_page'] = $add_book_page_urls['add_child_book_page']->toString();
             $build['link_add_child_book_page_renderable'] = Link::fromTextAndUrl($this->t('Add a new page below this page'), $add_book_page_urls['add_child_book_page'])->toRenderable();
           }
         }
@@ -125,17 +122,19 @@ class EntityOperations implements ContainerInjectionInterface {
       'node_type' => 'book',
     ];
     $link_options = [
-      'add_current_level_book_page' => [
-        'query' => [
-          'parent' => $entity->book['pid'],
-        ],
-      ],
       'add_child_book_page' => [
         'query' => [
           'parent' => $entity->id(),
         ],
       ],
     ];
+    if (!empty($entity->book['pid'])) {
+      $link_options['add_current_level_book_page'] = [
+        'query' => [
+          'parent' => $entity->book['pid'],
+        ],
+      ];
+    }
     $links = [];
     foreach ($link_options as $key => $options) {
       $links[$key] = Url::fromRoute('node.add', $route_parameters, $options);

--- a/lib/modules/eic_default_content/src/Generator/BlockContentGenerator.php
+++ b/lib/modules/eic_default_content/src/Generator/BlockContentGenerator.php
@@ -3,6 +3,7 @@
 namespace Drupal\eic_default_content\Generator;
 
 use Drupal\block_content\Entity\BlockContent;
+use Drupal\Core\Url;
 use Drupal\fragments\Entity\Fragment;
 
 /**
@@ -104,6 +105,26 @@ class BlockContentGenerator extends CoreGenerator {
       ),
     ]);
     $authenticated_intro->save();
+
+    // Creates contact box block for the help and guidance pages.
+    $block = BlockContent::create([
+      'status' => TRUE,
+      'type' => 'contact_box',
+      // For BC reasons we keep the same UUIDs since they are referenced in configs.
+      'uuid' => '63285e84-4aaf-475a-ae6f-169d5dae81e3',
+      'info' => 'Contact box - Help & Guidance',
+      'body' => [
+        'value' => 'Contact us at</br><a class="" href="mailto:support@eic.com">support@eic.com</a>',
+        'format' => 'full_html',
+      ],
+      'field_title' => "Didn't find what you were looking for?",
+      'field_cta_button' => [
+        'uri' => Url::fromRoute('<front>')->toUriString(),
+        'title' => 'Contact us',
+        'link_type' => 'default',
+      ],
+    ]);
+    $block->save();
   }
 
   /**

--- a/lib/modules/eic_deploy/eic_deploy.install
+++ b/lib/modules/eic_deploy/eic_deploy.install
@@ -5,6 +5,9 @@
  * Install, update and uninstall functions for the EIC Deploy module.
  */
 
+use Drupal\block_content\Entity\BlockContent;
+use Drupal\Core\Url;
+
 /**
  * Implements hook_install().
  */
@@ -80,4 +83,28 @@ function eic_deploy_update_9001(&$sandbox) {
     $entity->set('moderation_state', $state);
     $entity->save();
   }
+}
+
+/**
+ * Creates contact box block for the help and guidance pages.
+ */
+function eic_deploy_update_9002(&$sandbox) {
+  $block = BlockContent::create([
+    'status' => TRUE,
+    'type' => 'contact_box',
+    // We keep the same UUIDs since they are referenced in configs.
+    'uuid' => '63285e84-4aaf-475a-ae6f-169d5dae81e3',
+    'info' => 'Contact box - Help & Guidance',
+    'body' => [
+      'value' => 'Contact us at</br><a class="" href="mailto:support@eic.com">support@eic.com</a>',
+      'format' => 'full_html',
+    ],
+    'field_title' => "Didn't find what you were looking for?",
+    'field_cta_button' => [
+      'uri' => Url::fromRoute('<front>')->toUriString(),
+      'title' => 'Contact us',
+      'link_type' => 'default',
+    ],
+  ]);
+  $block->save();
 }

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Hooks/FormOperations.php
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Hooks/FormOperations.php
@@ -120,12 +120,22 @@ class FormOperations implements ContainerInjectionInterface {
       'gallery',
     ];
 
+    // All content type which have the notification field hidden.
+    $disable_content_types = [
+      'book',
+    ];
+
     /** @var \Drupal\Core\Entity\EntityInterface $entity */
     $entity = $form_state->getFormObject()->getEntity();
     $show_notification_field = FALSE;
 
     switch ($entity->getEntityTypeId()) {
       case 'node':
+        // If node doesn't have notification we don't need to show the field.
+        if (in_array($entity->bundle(), $disable_content_types)) {
+          break;
+        }
+
         $show_notification_field = TRUE;
         break;
 

--- a/lib/themes/eic_community/includes/preprocess/blocks/block--contact-box.inc
+++ b/lib/themes/eic_community/includes/preprocess/blocks/block--contact-box.inc
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @file
+ * Contains implementation for hook_preprocess_block() for contact_box.
+ */
+
+use Drupal\Component\Utility\Xss;
+use Drupal\Core\Render\Markup;
+use Drupal\Core\Url;
+
+/**
+ * Implements hook_preprocess_block() for contact_box.
+ */
+function eic_community_preprocess_block__contact_box(&$variables, &$cache_tags = []) {
+  /** @var \Drupal\block_content\Entity\BlockContent $block_content */
+  $block_content = $variables['content']['#block_content'];
+
+  $variables['contact_box'] = [
+    'title' => $block_content->get('field_title')->value,
+    'body' => Markup::create(
+      Xss::filter(
+        $block_content->get('body')->value,
+        ['a', 'b', 'strong', 'u', 'em', 'br']
+      )
+    ),
+    'cta' => [],
+  ];
+
+  if (!$block_content->get('field_cta_button')->isEmpty()) {
+    $variables['contact_box']['cta'] = [
+      'link' => Url::fromUri($block_content->get('field_cta_button')->uri)->toString(),
+      'label' => $block_content->get('field_cta_button')->title,
+    ];
+
+  }
+}

--- a/lib/themes/eic_community/includes/preprocess/blocks/block.inc
+++ b/lib/themes/eic_community/includes/preprocess/blocks/block.inc
@@ -51,6 +51,10 @@ function eic_community_preprocess_block(array &$variables) {
         eic_community_preprocess_block__basic($variables, $cache_tags);
         break;
 
+      case 'contact_box':
+        eic_community_preprocess_block__contact_box($variables, $cache_tags);
+        break;
+
     }
 
     // Adds cache tags.

--- a/lib/themes/eic_community/patterns/components/navigation-list/navigation-list-items.html.twig
+++ b/lib/themes/eic_community/patterns/components/navigation-list/navigation-list-items.html.twig
@@ -1,3 +1,7 @@
+{% set title_element = title_element|default('h2') %}
+{% if title is not empty %}
+  <{{ title_element }} class="ecl-navigation-list__title">{{ title }}</{{ title_element }}>
+{% endif %}
 {% if items is not empty %}
   <ul class="ecl-navigation-list__items {{ extra_classes }}">
     {% for item in items %}

--- a/lib/themes/eic_community/patterns/components/navigation-list/navigation-list.html.twig
+++ b/lib/themes/eic_community/patterns/components/navigation-list/navigation-list.html.twig
@@ -37,6 +37,10 @@
       {% include "@theme/patterns/components/contact-box.html.twig" with contact_box %}
     {% endif %}
 
+    {% if extra_blocks is not empty %}
+      {{ extra_blocks }}
+    {% endif %}
+
     {% if block('after') is not empty %}
       <div class="ecl-navigation-list__main-after">
         {%- block after -%}{%- endblock -%}

--- a/lib/themes/eic_community/templates/blocks/block--eic-contact-box-help-guindance.html.twig
+++ b/lib/themes/eic_community/templates/blocks/block--eic-contact-box-help-guindance.html.twig
@@ -1,0 +1,28 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ */
+#}
+{% include "@theme/patterns/components/contact-box.html.twig" with contact_box only %}

--- a/lib/themes/eic_community/templates/blocks/block--eic-content-book-navigation.html.twig
+++ b/lib/themes/eic_community/templates/blocks/block--eic-content-book-navigation.html.twig
@@ -1,4 +1,4 @@
-{% embed "@theme/patterns/components/navigation-list/navigation-list.html.twig" with {
+{% embed "@theme/patterns/components/navigation-list/navigation-list-items.html.twig" with {
   extra_attributes: [{
     name: 'data-navigation-list-parent-selector',
     value: '.ecl-editorial-article',

--- a/lib/themes/eic_community/templates/layout/page--node--book.html.twig
+++ b/lib/themes/eic_community/templates/layout/page--node--book.html.twig
@@ -30,7 +30,9 @@
       <div class="ecl-editorial-article {{ extra_classes }}">
         <div class="ecl-container">
           <div class="ecl-editorial-article__wrapper">
+            <div>
             {{ page.content }}
+        </div>
             {% if is_wiki_page is same as(false) %}
               <aside class="ecl-editorial-article__aside">
                 <div class="ecl-editorial-article__aside-wrapper">

--- a/lib/themes/eic_community/templates/layout/page--node--book.html.twig
+++ b/lib/themes/eic_community/templates/layout/page--node--book.html.twig
@@ -34,7 +34,16 @@
             {% if is_wiki_page is same as(false) %}
               <aside class="ecl-editorial-article__aside">
                 <div class="ecl-editorial-article__aside-wrapper">
-                  {{ sidebar }}
+                  {% embed "@theme/patterns/components/navigation-list/navigation-list.html.twig" with {
+                    extra_attributes: [{
+                      name: 'data-navigation-list-parent-selector',
+                      value: '.ecl-editorial-article',
+                    }],
+                    collapse: {"label": "collapse"},
+                    icon_file_path: eic_icon_path,
+                    extra_blocks: sidebar,
+                  } %}
+                  {% endembed %}
                 </div>
               </aside>
             {% endif %}

--- a/lib/themes/eic_community/templates/layout/page--node--wiki-page.html.twig
+++ b/lib/themes/eic_community/templates/layout/page--node--wiki-page.html.twig
@@ -25,7 +25,9 @@
   <div class="ecl-editorial-article ecl-editorial-article--has-reversed-layout ecl-editorial-article--is-collapsible">
     <div class="ecl-container">
       <div class="ecl-editorial-article__wrapper">
+        <div>
         {{ content }}
+        </div>
         <aside class="ecl-editorial-article__aside ecl-editorial-article__aside--wiki">
           <div class="ecl-editorial-article__aside-wrapper">
             {{ sidebar }}


### PR DESCRIPTION
### Features

- Create new block type contact_box and place it in book page contexts;
- Add new block contact_box to fixtures and create hook_update_n;
- Fix twig templates in order to include blocks in the book page sidebar and preprocess variables for the contact box block.

### Tests

Test contact box:

- [x] Go to the "Help and Guidance" page
- [x] Make sure you see the contact box in the sidebar bellow the wiki navigation

Test book page creation:

- [x] Try to create a new book page -> `/node/add/book`
- [x] Make sure the checkbox "Send notification" is not presented

### Todo

- [x] Review FE templates