### PR TITLE
Feature/eicnet 2115 add missing bread crumbs inside groups

### DIFF
--- a/lib/modules/eic_flags/src/Plugin/Flag/EntityFlagType.php
+++ b/lib/modules/eic_flags/src/Plugin/Flag/EntityFlagType.php
@@ -81,7 +81,7 @@ class EntityFlagType extends EntityFlagTypeBase {
       // Get the group from the flaggable, if any.
       $parent_group = NULL;
       if ($flaggable && !$flaggable->isNew()) {
-        $parent_group = $this->groupsHelper->getGroupByEntity($flaggable);
+        $parent_group = $this->groupsHelper->getOwnerGroupByEntity($flaggable);
       }
       if (
         $parent_group instanceof GroupInterface &&

--- a/lib/modules/eic_groups/modules/eic_share_content/src/Service/ShareManager.php
+++ b/lib/modules/eic_groups/modules/eic_share_content/src/Service/ShareManager.php
@@ -128,7 +128,7 @@ class ShareManager {
     ?string $message
   ) {
     // First we check if this node belongs to a group.
-    if (!$this->groupsHelper->getGroupByEntity($node)) {
+    if (!$this->groupsHelper->getOwnerGroupByEntity($node)) {
       throw new \InvalidArgumentException("This content can't be shared");
     }
 

--- a/lib/modules/eic_groups/src/Breadcrumb/GroupBreadcrumbBuilder.php
+++ b/lib/modules/eic_groups/src/Breadcrumb/GroupBreadcrumbBuilder.php
@@ -179,7 +179,7 @@ class GroupBreadcrumbBuilder implements BreadcrumbBuilderInterface {
             $breadcrumb->addCacheableDependency($access);
           }
 
-          if ($group = $this->eicGroupsHelper->getGroupByEntity($node)) {
+          if ($group = $this->eicGroupsHelper->getOwnerGroupByEntity($node)) {
             $links[] = $group->toLink();
 
             switch ($node->bundle()) {

--- a/lib/modules/eic_groups/src/Breadcrumb/GroupBreadcrumbBuilder.php
+++ b/lib/modules/eic_groups/src/Breadcrumb/GroupBreadcrumbBuilder.php
@@ -179,11 +179,7 @@ class GroupBreadcrumbBuilder implements BreadcrumbBuilderInterface {
             $breadcrumb->addCacheableDependency($access);
           }
 
-          if ($group_content = GroupContent::loadByEntity($node)) {
-            // Because a node can only belong to 1 group, we get the first
-            // group content entity from the array.
-            $group_content_entity = reset($group_content);
-            $group = $group_content_entity->getGroup();
+          if ($group = $this->eicGroupsHelper->getGroupByEntity($node)) {
             $links[] = $group->toLink();
 
             switch ($node->bundle()) {
@@ -230,6 +226,26 @@ class GroupBreadcrumbBuilder implements BreadcrumbBuilderInterface {
                   $this->t('Discussions'),
                   GroupOverviewPages::getGroupOverviewPageUrl(
                     'discussions',
+                    $group
+                  )
+                );
+                break;
+
+              case 'news':
+                $links[] = Link::fromTextAndUrl(
+                  $this->t('News'),
+                  GroupOverviewPages::getGroupOverviewPageUrl(
+                    'news',
+                    $group
+                  )
+                );
+                break;
+
+              case 'event':
+                $links[] = Link::fromTextAndUrl(
+                  $this->t('Events'),
+                  GroupOverviewPages::getGroupOverviewPageUrl(
+                    'events',
                     $group
                   )
                 );

--- a/lib/modules/eic_groups/src/EICGroupsHelper.php
+++ b/lib/modules/eic_groups/src/EICGroupsHelper.php
@@ -363,7 +363,7 @@ class EICGroupsHelper implements EICGroupsHelperInterface {
       }
     }
     if ($entity) {
-      return $this->getGroupByEntity($entity);
+      return $this->getOwnerGroupByEntity($entity);
     }
     return FALSE;
   }
@@ -371,7 +371,7 @@ class EICGroupsHelper implements EICGroupsHelperInterface {
   /**
    * {@inheritdoc}
    */
-  public function getGroupByEntity(EntityInterface $entity) {
+  public function getOwnerGroupByEntity(EntityInterface $entity) {
     $group = FALSE;
     if ($entity instanceof GroupInterface) {
       return $entity;
@@ -901,7 +901,7 @@ class EICGroupsHelper implements EICGroupsHelperInterface {
           break;
         }
 
-        $group = $this->getGroupByEntity($node);
+        $group = $this->getOwnerGroupByEntity($node);
 
         if (!$group) {
           break;

--- a/lib/modules/eic_groups/src/EICGroupsHelperInterface.php
+++ b/lib/modules/eic_groups/src/EICGroupsHelperInterface.php
@@ -29,7 +29,7 @@ interface EICGroupsHelperInterface {
    * @return bool|\Drupal\group\Entity\GroupInterface
    *   The Group entity.
    */
-  public function getGroupByEntity(EntityInterface $entity);
+  public function getOwnerGroupByEntity(EntityInterface $entity);
 
   /**
    * Get operations links of a given group.

--- a/lib/modules/eic_groups/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_groups/src/Hooks/EntityOperations.php
@@ -271,7 +271,7 @@ class EntityOperations implements ContainerInjectionInterface {
     switch ($this->routeMatch->getRouteName()) {
       case 'entity.node.canonical':
         if ($entity->bundle() === 'book') {
-          if ($group = $this->eicGroupsHelper->getGroupByEntity($entity)) {
+          if ($group = $this->eicGroupsHelper->getOwnerGroupByEntity($entity)) {
             // Add empty wiki section message.
             $build['wiki_section_message'] = [
               '#type' => 'item',
@@ -355,7 +355,7 @@ class EntityOperations implements ContainerInjectionInterface {
    */
   private function getWikiPageAddFormUrls(EntityInterface $entity, $group = FALSE) {
     if (!($group instanceof GroupInterface)) {
-      if (!$group = $this->eicGroupsHelper->getGroupByEntity($entity)) {
+      if (!$group = $this->eicGroupsHelper->getOwnerGroupByEntity($entity)) {
         return $group;
       }
     }

--- a/lib/modules/eic_groups/src/Hooks/Preprocess.php
+++ b/lib/modules/eic_groups/src/Hooks/Preprocess.php
@@ -62,7 +62,7 @@ class Preprocess implements ContainerInjectionInterface {
         // group.
         if (($node = $this->routeMatch->getParameter('node')) && $node instanceof NodeInterface) {
           if (in_array($node->bundle(), ['book', 'wiki_page'])) {
-            if ($this->eicGroupsHelper->getGroupByEntity($node)) {
+            if ($this->eicGroupsHelper->getOwnerGroupByEntity($node)) {
               unset($variables['links']['book_add_child']);
             }
           }

--- a/lib/modules/eic_overviews/src/GroupOverviewPages.php
+++ b/lib/modules/eic_overviews/src/GroupOverviewPages.php
@@ -64,29 +64,15 @@ class GroupOverviewPages {
    *   The URL object or NULL if does not apply.
    */
   public static function getGroupOverviewPageUrl(string $page, GroupInterface $group) {
-    $page_id = NULL;
-    switch ($page) {
-      case 'discussions':
-        $page_id = self::DISCUSSIONS;
-        break;
-
-      case 'files':
-        $page_id = self::FILES;
-        break;
-
-      case 'events':
-        $page_id = self::EVENTS;
-        break;
-
-      case 'members':
-        $page_id = self::MEMBERS;
-        break;
-
-      case 'group_search':
-        $page_id = self::SEARCH;
-        break;
-
-    }
+    $pages = [
+      'discussions' => self::DISCUSSIONS,
+      'files' => self::FILES,
+      'events' => self::EVENTS,
+      'members' => self::MEMBERS,
+      'news' => self::NEWS,
+      'group_search' => self::SEARCH,
+    ];
+    $page_id = $pages[$page] ?? NULL;
 
     if (!empty($page_id) && !$group->isNew()) {
       return Url::fromRoute($page_id, ['group' => $group->id()]);

--- a/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorVisibility.php
+++ b/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorVisibility.php
@@ -75,7 +75,7 @@ class ProcessorVisibility extends DocumentProcessor {
 
     $original_object = $item->getOriginalObject()->getEntity();
 
-    $group = $this->groupsHelper->getGroupByEntity($original_object);
+    $group = $this->groupsHelper->getOwnerGroupByEntity($original_object);
 
     if (!$group) {
       $document->addField('ss_group_visibility', $group_visibility);


### PR DESCRIPTION
### Improvements

- Renamed `EICGroupsHelper::getGroupByEntity()` to `EICGroupsHelper::getOwnerGroupByEntity()` for clarity

### Tests

- [x] Create a news and an event in an organisation
- [x] Check that the breadcrumb includes "News" or "Events" after the organisation name
