### PR TITLE
[EICNET-2129]fix: put body of about page as raw

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/groups/group.inc
+++ b/lib/themes/eic_community/includes/preprocess/groups/group.inc
@@ -212,7 +212,7 @@ function _group_about_group_tab($variables, &$sections) {
   $about_items[] = [
     'title' => t('Group description'),
     'content' => $group->hasField('field_body') ?
-      strip_tags($group->get('field_body')->value) :
+      $group->get('field_body')->value :
       '',
   ];
 

--- a/lib/themes/eic_community/patterns/compositions/extended-list/extended-list-item.html.twig
+++ b/lib/themes/eic_community/patterns/compositions/extended-list/extended-list-item.html.twig
@@ -15,7 +15,7 @@
 
   {% if content is not empty %}
     <div class="ecl-extended-list__item-content ecl-editable-wrapper">
-      {{ content }}
+      {{ content | raw }}
     </div>
   {% endif %}
 


### PR DESCRIPTION
How to test:

- [x] Go to a group detail page
- [x] Go to tab "About" and see if you see correct text on the description without any html characters