### PR TITLE
[EICNET]fix: Set type as multi array in teaser event

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/groups/event.inc
+++ b/lib/themes/eic_community/includes/preprocess/groups/event.inc
@@ -67,6 +67,8 @@ function eic_community_preprocess_group__event(&$variables) {
           $value = strtolower($location_type_allowed_values[$value]);
           $teaser['type']['label'] .= " & {$value}";
         }
+
+        $teaser['type'] = [$teaser['type']];
       }
 
       // Add event topics to the theme variables.


### PR DESCRIPTION
How to test:

- [x] Be sure to have global event
- [x] Clear cache
- [x] Go to homepage, see if events have tag and page does not return 500