### PR TITLE
EICNET-2116: News articles within organisation can be promoted on homepage (rework)

### DIFF
--- a/config/sync/user.role.content_administrator.yml
+++ b/config/sync/user.role.content_administrator.yml
@@ -36,6 +36,7 @@ dependencies:
     - eic_private_content
     - eic_private_message
     - eic_topics
+    - entity_browser
     - file
     - filter
     - flag
@@ -65,6 +66,7 @@ permissions:
   - 'access files overview'
   - 'access group overview'
   - 'access media overview'
+  - 'access news_stories entity browser pages'
   - 'access overview page overview'
   - 'access toolbar'
   - 'access topics activity stream'

--- a/config/sync/user.role.site_admin.yml
+++ b/config/sync/user.role.site_admin.yml
@@ -38,6 +38,7 @@ dependencies:
     - eic_private_content
     - eic_private_message
     - eic_topics
+    - entity_browser
     - file
     - filter
     - flag
@@ -67,6 +68,7 @@ permissions:
   - 'access files overview'
   - 'access group overview'
   - 'access media overview'
+  - 'access news_stories entity browser pages'
   - 'access overview page overview'
   - 'access toolbar'
   - 'access topics activity stream'


### PR DESCRIPTION
### Fixes

- Add permission to access entity browser for the Latest News and Stories.

### Tests

- [x] As **SA/SCM**, navigate to -> /admin/content/block-content
- [x] Edit the block "Latest News & Stories"
- [x] In the edit form, make sure you can only select News or Stories that are published + not private (community members only checkbox disabled) + from public events