### PR TITLE
[EICNET-2071] remove bg color on img in editorial header

### DIFF
--- a/lib/themes/eic_community/sass/compositions/_editorial-header.scss
+++ b/lib/themes/eic_community/sass/compositions/_editorial-header.scss
@@ -32,7 +32,6 @@
 
   &__image-wrapper {
     position: relative;
-    background-color: map-get($ecl-colors, 'grey-10');
     overflow: hidden;
     padding: 0;
     margin: 0;


### PR DESCRIPTION
https://citnet.tech.ec.europa.eu/CITnet/jira/secure/RapidBoard.jspa?rapidView=6628&view=detail&selectedIssue=EICNET-2071&quickFilter=26822

### What I did

- remove bg color on img in editorial header