### PR TITLE
EICNET-1493: Groups - Group owner in group teaser links to groups overview (rework)

### DIFF
--- a/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorGlobal.php
+++ b/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorGlobal.php
@@ -134,8 +134,7 @@ class ProcessorGlobal extends DocumentProcessor {
             $fields,
             UserHelper::getUserAvatar($owner)
           );
-          $user_url = $owner->toUrl()
-            ->toString();
+          $user_url = $owner->toUrl()->toString();
         }
         break;
       case 'entity:message':

--- a/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorGlobal.php
+++ b/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorGlobal.php
@@ -134,6 +134,8 @@ class ProcessorGlobal extends DocumentProcessor {
             $fields,
             UserHelper::getUserAvatar($owner)
           );
+          $user_url = $owner->toUrl()
+            ->toString();
         }
         break;
       case 'entity:message':


### PR DESCRIPTION
### Fixes

- Fix group owner url in groups overview.

### Tests

- [x] Re-index solr
- [x] As TU, go to the groups overview `/groups`
- [x] Click in the avatar or name of a group owner and make sure you get redirected to the user detail page