### PR TITLE
[EICNET-1952]feat: Create my groups overview, filters, subnav menu item, ...

### DIFF
--- a/config/sync/context.context.groups.yml
+++ b/config/sync/context.context.groups.yml
@@ -1,0 +1,61 @@
+uuid: 3974204b-99e9-49eb-b09a-b072df673869
+langcode: en
+status: true
+dependencies:
+  module:
+    - eic_search
+    - route_condition
+label: Groups
+name: groups
+group: 'My profile'
+description: ''
+requireAllConditions: false
+disabled: false
+conditions:
+  route:
+    id: route
+    negate: false
+    uuid: bd458314-a647-4ec3-9956-b2ca1b311580
+    context_mapping: {  }
+    routes: eic_user.user.my_groups
+reactions:
+  blocks:
+    id: blocks
+    uuid: 51f37ab4-072e-402d-83ae-1f389f21e09e
+    blocks:
+      79680eb5-d2aa-4cdf-ae18-6a558fe7a72a:
+        uuid: 79680eb5-d2aa-4cdf-ae18-6a558fe7a72a
+        id: eic_search_overview
+        label: ''
+        provider: eic_search
+        label_display: visible
+        region: content
+        custom_id: eic_search_overview
+        theme: eic_community
+        css_class: ''
+        unique: 0
+        context_id: groups
+        context_mapping: {  }
+        source_type: Drupal\eic_search\Search\Sources\Profile\MyGroupsSourceType
+        facets:
+          ss_group_visibility_label: ss_group_visibility_label
+          sm_group_topic_name: sm_group_topic_name
+          ss_group_field_vocab_geo_string: ss_group_field_vocab_geo_string
+          ss_group_user_fullname: 0
+        sort_options:
+          ss_drupal_changed_timestamp: ss_drupal_changed_timestamp
+          timestamp: 0
+          tm_global_title: 0
+          ss_group_user_fullname: 0
+          its_last_flagged_like_content: 0
+          score: 0
+        enable_search: 1
+        page_options: normal
+        prefilter_group: 0
+        enable_date_filter: 0
+        add_facet_interests: 0
+        add_facet_my_groups: 0
+        third_party_settings: {  }
+    include_default_blocks: 0
+    saved: false
+weight: 0

--- a/config/sync/context.context.my_profile.yml
+++ b/config/sync/context.context.my_profile.yml
@@ -54,31 +54,6 @@ reactions:
         context_id: my_profile
         context_mapping: {  }
         third_party_settings: {  }
-      0e7c3901-f227-4b04-a47c-d795b9e3477f:
-        uuid: 0e7c3901-f227-4b04-a47c-d795b9e3477f
-        id: eic_search_overview
-        label: ''
-        provider: eic_search
-        label_display: visible
-        region: content
-        custom_id: eic_search_overview
-        theme: eic_community
-        css_class: ''
-        unique: 0
-        context_id: my_profile
-        context_mapping: {  }
-        source_type: Drupal\eic_search\Search\Sources\Profile\ActivityStreamSourceType
-        facets:
-          ss_activity_type: ss_activity_type
-          sm_content_field_vocab_topics_string: sm_content_field_vocab_topics_string
-        sort_options: {  }
-        enable_search: 1
-        page_options: normal
-        prefilter_group: 0
-        enable_date_filter: 0
-        add_facet_interests: 0
-        add_facet_my_groups: 1
-        third_party_settings: {  }
     include_default_blocks: 0
     saved: false
 weight: 0

--- a/lib/modules/eic_search/eic_search.services.yml
+++ b/lib/modules/eic_search/eic_search.services.yml
@@ -71,6 +71,10 @@ services:
     class: Drupal\eic_search\Search\Sources\Profile\ContributionSourceType
     tags:
       - { name: eic_search.source }
+  eic_search.source_my_profile_groups:
+    class: Drupal\eic_search\Search\Sources\Profile\MyGroupsSourceType
+    tags:
+      - { name: eic_search.source }
   eic_search.solr_document_processor:
     class: Drupal\eic_search\Service\SolrDocumentProcessor
     arguments: ['@search_api.post_request_indexing', '@queue', '@plugin.manager.queue_worker', '@entity_type.manager']

--- a/lib/modules/eic_search/src/Plugin/Block/SearchOverviewBlock.php
+++ b/lib/modules/eic_search/src/Plugin/Block/SearchOverviewBlock.php
@@ -316,6 +316,7 @@ class SearchOverviewBlock extends BlockBase implements ContainerFactoryPluginInt
           'commented_on' => $this->t('commented on', [], ['context' => 'eic_group']),
           'custom_search_text' => [
             'user_gallery' => $this->t('Search for a member', [], ['context' => 'eic_group']),
+            'group' => $this->t('Search for a group', [], ['context' => 'eic_group']),
           ],
           'no_results_title' => $this->t(
             'We haven’t found any search results',

--- a/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorGlobal.php
+++ b/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorGlobal.php
@@ -109,6 +109,7 @@ class ProcessorGlobal extends DocumentProcessor {
           }
         }
 
+        $changed = $fields['ds_aggregated_changed'];
         $title = $fields['tm_X3b_en_group_label_fulltext'];
         $type = $fields['ss_group_type'];
         $date = $fields['ds_group_created'];

--- a/lib/modules/eic_search/src/Search/Sources/Profile/MyGroupsSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/Profile/MyGroupsSourceType.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Drupal\eic_search\Search\Sources\Profile;
+
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\eic_flags\FlagType;
+use Drupal\eic_search\Search\Sources\SourceType;
+use Drupal\eic_search\Service\SolrDocumentProcessor;
+
+/**
+ * Class MyGroupsSourceType
+ *
+ * @package Drupal\eic_groups\Search\Sources
+ */
+class MyGroupsSourceType extends SourceType {
+
+  use StringTranslationTrait;
+
+  /**
+   * @inheritDoc
+   */
+  public function getSourcesId(): array {
+    return ['group'];
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getLabel(): string {
+    return $this->t('Profile - My groups', [], ['context' => 'eic_search']);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getEntityBundle(): string {
+    return 'group';
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getAvailableFacets(): array {
+    return [
+      'ss_group_visibility_label' => $this->t('Visibility', [], ['context' => 'eic_search']),
+      'sm_group_topic_name' => $this->t('Topic', [], ['context' => 'eic_search']),
+      'ss_group_field_vocab_geo_string' => $this->t('Region & countries', [], ['context' => 'eic_search']),
+      'ss_group_user_fullname' => $this->t('Full name', [], ['context' => 'eic_search']),
+    ];
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getAvailableSortOptions(): array {
+    return [
+      'timestamp' => [
+        'label' => $this->t('Timestamp', [], ['context' => 'eic_search']),
+        'ASC' => $this->t('Old', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Recent', [], ['context' => 'eic_search']),
+      ],
+      'ss_drupal_changed_timestamp' => [
+        'label' => $this->t('Recently updated', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Recent', [], ['context' => 'eic_search']),
+      ],
+      'tm_global_title' => [
+        'label' => $this->t('Group label', [], ['context' => 'eic_search']),
+        'ASC' => $this->t('Group label A-Z', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Group label Z-A', [], ['context' => 'eic_search']),
+      ],
+      'ss_group_user_fullname' => [
+        'label' => $this->t('Fullname', [], ['context' => 'eic_search']),
+        'ASC' => $this->t('Fullname A-Z', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Fullname Z-A', [], ['context' => 'eic_search']),
+      ],
+      'its_' . SolrDocumentProcessor::LAST_FLAGGED_KEY . '_' . FlagType::LIKE_CONTENT => [
+        'label' => $this->t('Last liked', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Last liked', [], ['context' => 'eic_search']),
+      ],
+      'score' => [
+        'label' => $this->t('Relevance', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Relevance', [], ['context' => 'eic_search']),
+      ],
+    ];
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getSearchFieldsId(): array {
+    return [
+      'tm_global_title',
+      'tm_global_fullname',
+    ];
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getLayoutTheme(): string {
+    return self::LAYOUT_COLUMNS_COMPACT;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function ableToPrefilteredByGroup(): bool {
+    return TRUE;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getPrefilteredContentType(): array {
+    return ['group'];
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getPrefilteredGroupFieldId(): array {
+    return ['its_group_id_integer'];
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function prefilterByGroupsMembership(): bool {
+    return TRUE;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getDefaultSort(): array {
+    return ['ss_drupal_changed_timestamp', 'DESC'];
+  }
+
+}

--- a/lib/modules/eic_user/eic_user.routing.yml
+++ b/lib/modules/eic_user/eic_user.routing.yml
@@ -22,6 +22,14 @@ eic_user.user.contribution:
   requirements:
     _custom_access: '\Drupal\eic_user\Controller\MyProfileController::access'
 
+eic_user.user.my_groups:
+  path: '/user/{user}/groups'
+  defaults:
+    _controller: '\Drupal\eic_user\Controller\MyProfileController::activity'
+    _title: 'My groups'
+  requirements:
+    _custom_access: '\Drupal\eic_user\Controller\MyProfileController::access'
+
 eic_user.my_settings:
   path: '/my-settings'
   defaults:

--- a/lib/modules/eic_user/src/Plugin/Block/UserActivitySubnavigationBlock.php
+++ b/lib/modules/eic_user/src/Plugin/Block/UserActivitySubnavigationBlock.php
@@ -70,6 +70,11 @@ class UserActivitySubnavigationBlock extends BlockBase implements ContainerFacto
         'route_parameters' => ['user' => $this->currentUser->id()]
       ],
       [
+        'label' => $this->t('My groups', [], ['context' => 'eic_user']),
+        'route' => 'eic_user.user.my_groups',
+        'route_parameters' => ['user' => $this->currentUser->id()]
+      ],
+      [
         'label' => $this->t('Bookmarked', [], ['context' => 'eic_user']),
         'route' => 'eic_search.global_search',
       ],

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/GroupResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/GroupResultItem.js
@@ -85,7 +85,7 @@ class GroupResultItem extends React.Component {
                     dangerouslySetInnerHTML={{__html: svg('time', 'ecl-icon ecl-icon--s ecl-timestamp__icon')}}
                   />
                   <time className="ecl-timestamp__label">Last
-                    activity {timeDifferenceFromNow(this.props.result.ss_drupal_timestamp)}</time>
+                    activity {timeDifferenceFromNow(this.props.result.ss_drupal_changed_timestamp)}</time>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
How to test:

- [x]  Create a group, be a GM of a group, be a GA of a group
- [x]  Now go to /user/USER_ID/groups

FILTERS:

- [x]  Check if you have the visibility type, topic and region & countries filter
- [x]  You can also search by group title and fullname (case insensitive)

RESULTS:

- [x]  The group item displays:

- Group featured image
- Group visibility type: public, restricted, private
- Group name
- Group owner avatar: shows the image of the GO or his initials in case no image is available
- Group owner name: the full author name (clickable to the member detail page unless the logged in user is an anonymous user)
- Group last activity: displays how long the last activity happened in the group.
- Number of comments in the group.
- Number of views in the group.
- Number of files in the group.

- [x] It's sorted by default on recent update
- [x] You can choose number of items in pagination
- [x] Verify that you see groups from where you are GO, GM, GA

SUBNAVIGATION:

- [x]  The active state should be enable on the menu item with label "My groups"