### PR TITLE
[EICNET-1959]fix: Put parent breadcrumb for activities user

### DIFF
--- a/lib/modules/eic_user/eic_user.routing.yml
+++ b/lib/modules/eic_user/eic_user.routing.yml
@@ -7,7 +7,7 @@ eic_user.user.activity:
     _custom_access: '\Drupal\eic_user\Controller\MyProfileController::access'
 
 eic_user.user.following:
-  path: '/user/{user}/following'
+  path: '/user/{user}/activity/following'
   defaults:
     _controller: '\Drupal\eic_user\Controller\MyProfileController::activity'
     _title: 'My followings'
@@ -15,7 +15,7 @@ eic_user.user.following:
     _custom_access: '\Drupal\eic_user\Controller\MyProfileController::access'
 
 eic_user.user.contribution:
-  path: '/user/{user}/contribution'
+  path: '/user/{user}/activity/contribution'
   defaults:
     _controller: '\Drupal\eic_user\Controller\MyProfileController::activity'
     _title: 'My contributions'
@@ -23,7 +23,7 @@ eic_user.user.contribution:
     _custom_access: '\Drupal\eic_user\Controller\MyProfileController::access'
 
 eic_user.user.my_groups:
-  path: '/user/{user}/groups'
+  path: '/user/{user}/activity/groups'
   defaults:
     _controller: '\Drupal\eic_user\Controller\MyProfileController::activity'
     _title: 'My groups'
@@ -31,7 +31,7 @@ eic_user.user.my_groups:
     _custom_access: '\Drupal\eic_user\Controller\MyProfileController::access'
 
 eic_user.user.my_events:
-  path: '/user/{user}/events'
+  path: '/user/{user}/activity/events'
   defaults:
     _controller: '\Drupal\eic_user\Controller\MyProfileController::activity'
     _title: 'My events'

--- a/lib/modules/eic_user/src/Breadcrumb/UserBreadcrumbBuilder.php
+++ b/lib/modules/eic_user/src/Breadcrumb/UserBreadcrumbBuilder.php
@@ -8,6 +8,7 @@ use Drupal\Core\Link;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\Url;
 use Drupal\user\UserInterface;
 
 /**
@@ -53,6 +54,13 @@ class UserBreadcrumbBuilder implements BreadcrumbBuilderInterface {
       $links[] = Link::fromTextAndUrl(
         $this->t('My profile', [], ['context' => 'eic_user']),
         $user->toUrl()
+      );
+    }
+
+    if ('eic_user.user.activity' !== $route_match->getRouteName()) {
+      $links[] = Link::fromTextAndUrl(
+        $this->t('My activty feed', [], ['context' => 'eic_user']),
+        Url::fromRoute('eic_user.user.activity', [], ['context' => 'eic_user'])
       );
     }
 

--- a/lib/modules/eic_user/src/Breadcrumb/UserBreadcrumbBuilder.php
+++ b/lib/modules/eic_user/src/Breadcrumb/UserBreadcrumbBuilder.php
@@ -59,8 +59,12 @@ class UserBreadcrumbBuilder implements BreadcrumbBuilderInterface {
 
     if ('eic_user.user.activity' !== $route_match->getRouteName()) {
       $links[] = Link::fromTextAndUrl(
-        $this->t('My activty feed', [], ['context' => 'eic_user']),
-        Url::fromRoute('eic_user.user.activity', [], ['context' => 'eic_user'])
+        $this->t('My activity feed', [], ['context' => 'eic_user']),
+        Url::fromRoute(
+          'eic_user.user.activity',
+          ['user' => $user->id()],
+          ['context' => 'eic_user']
+        )
       );
     }
 


### PR DESCRIPTION
How to test:

- [x] Go to /user/USER_ID/activity
- [x] Except "my interests" go to other activities overview and check that you have in breadcrumbs: [Home]
[My profile]
[My activity feed][My followings (or your current overview title)]
- [x] When you click on the breadcrumb item "my activity feed" you should be redirected to the activity feed "my interests"
