### PR TITLE
EICNET-2072: Group overview with "view all" links below every content block have a faulty link

### DIFF
--- a/config/sync/views.view.group_discussions.yml
+++ b/config/sync/views.view.group_discussions.yml
@@ -270,7 +270,7 @@ display:
       use_more_always: true
       use_more_text: 'View all'
       link_display: custom_url
-      link_url: '<front>'
+      link_url: 'group/{{ raw_arguments.gid }}/discussions'
       header:
         area:
           id: area

--- a/config/sync/views.view.group_documents.yml
+++ b/config/sync/views.view.group_documents.yml
@@ -300,7 +300,7 @@ display:
       use_more_always: true
       use_more_text: 'View all'
       link_display: custom_url
-      link_url: '<front>'
+      link_url: 'group/{{ raw_arguments.gid }}/library'
       header:
         area:
           id: area

--- a/config/sync/views.view.group_events.yml
+++ b/config/sync/views.view.group_events.yml
@@ -340,7 +340,7 @@ display:
       use_more_always: true
       use_more_text: 'View all'
       link_display: custom_url
-      link_url: '<front>'
+      link_url: 'group/{{ raw_arguments.gid }}/events'
       header:
         area:
           id: area

--- a/config/sync/views.view.group_related_groups.yml
+++ b/config/sync/views.view.group_related_groups.yml
@@ -156,7 +156,7 @@ display:
           replica: false
           query_tags: {  }
       relationships: {  }
-      use_more: true
+      use_more: false
       use_more_always: true
       use_more_text: 'View all'
       link_display: custom_url
@@ -326,6 +326,9 @@ display:
         - url
       tags:
         - 'config:core.entity_view_display.group.event.default'
+        - 'config:core.entity_view_display.group.event.small_teaser'
+        - 'config:core.entity_view_display.group.event.teaser'
         - 'config:core.entity_view_display.group.group.about_page'
         - 'config:core.entity_view_display.group.group.default'
         - 'config:core.entity_view_display.group.group.teaser'
+        - 'config:core.entity_view_display.group.organisation.default'

--- a/lib/themes/eic_community/includes/preprocess/views.inc
+++ b/lib/themes/eic_community/includes/preprocess/views.inc
@@ -176,11 +176,15 @@ function eic_community_preprocess_views_view(&$variables) {
   }
 
   // Add the read more link if there is one.
-  if ($view->display_handler->getOption('use_more') == TRUE) {
+  if (
+    $view->display_handler->getOption('use_more') == TRUE &&
+    !empty($variables['more'])
+  ) {
+    // $link_display = $view->display_handler->
     $variables['call_to_action'] = [
       'link' => [
-        'label' => $view->display_handler->getOption('use_more_text'),
-        'path' => $view->display_handler->getOption('link_url'),
+        'label' => $variables['more']['#title'],
+        'path' => $variables['more']['#url']->toString(),
       ],
     ];
   }


### PR DESCRIPTION
### Fixes

- Fix "View all" links in group overview page blocks.
- Removed link "View all" from **Related News and Stories** and **Related groups**

### Tests

- [x] Go to a group overview page -> `/groups/<group-name>`
- [x] Check if the link "View all" is presented in the blocks Discussions, Documents and Events. Also make sure the link redirects the user to the right overview page inside the group (`/groups/<group-name>/discussions`, `/groups/<group-name>/library` and `/groups/<group-name>/events`)
- [x] Check if the blocks **Related News and Stories** and "Related groups" don't have a link "View all" at the bottom

### To be discussed before merging or any rework

- [x] I removed the link "View all" from the blocks Related News and Stories and Related groups since we don't have an overview page for those contents. Should we make this link to redirect to the global overview pages? 

Created a follow-up ticket to discuss what to do with link "View all" -> https://citnet.tech.ec.europa.eu/CITnet/jira/browse/EICNET-2177