### PR TITLE
EICNET-1993: Drupal default workflow improvements in message creations 

### DIFF
--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Hooks/FormOperations.php
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Hooks/FormOperations.php
@@ -8,6 +8,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\State\StateInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\eic_content\Constants\DefaultContentModerationStates;
 use Drupal\eic_content\EICContentHelper;
 use Drupal\eic_message_subscriptions\Event\MessageSubscriptionEvent;
 use Drupal\eic_message_subscriptions\Event\MessageSubscriptionEvents;
@@ -182,6 +183,20 @@ class FormOperations implements ContainerInjectionInterface {
 
     switch ($entity->getEntityTypeId()) {
       case 'node':
+        // We don't create message subscription if node is in DRAFT or ARCHIVED
+        // state.
+        if (
+          in_array(
+            $entity->get('moderation_state')->value,
+            [
+              DefaultContentModerationStates::DRAFT_STATE,
+              DefaultContentModerationStates::ARCHIVED_STATE,
+            ]
+          )
+        ) {
+          break;
+        }
+
         // Node is not published and therefore we don't send any notification.
         if (!$entity->isPublished()) {
           break;


### PR DESCRIPTION
### Improvements

- Skip entity activity stream and subscription message creation when user creates a new DRAFT from a PUBLISHED version.

### Tests

- [x] As GM go to a group, create a new published discussion
- [x] Edit the discussion, set the moderation state to draft and check the option "Post message in the activity stream"
- [x] Go to the lastest activity -> `/groups/<group-name>/latest-activity` and make sure there is no message about the discussion update.