### PR TITLE
EICNET-2120: Make sure we don't show the group sharing link if user doesn't have access to it

### DIFF
--- a/lib/modules/eic_groups/modules/eic_share_content/src/Service/ShareManager.php
+++ b/lib/modules/eic_groups/modules/eic_share_content/src/Service/ShareManager.php
@@ -161,7 +161,7 @@ class ShareManager {
     }
 
     // Check if we can share from source group to target group.
-    if (!$this->canShare($source_group, $target_group)) {
+    if (!$this->canShareToGroup($source_group, $target_group)) {
       throw new \InvalidArgumentException("This content can't be shared");
     }
 
@@ -283,7 +283,7 @@ class ShareManager {
     }
 
     foreach ($unfiltered_groups as $group) {
-      if ($this->canShare($source_group, $group, $visibility_types)) {
+      if ($this->canShareToGroup($source_group, $group, $visibility_types)) {
         $groups[] = $group;
       }
     }
@@ -307,7 +307,7 @@ class ShareManager {
    *
    * @throws \Drupal\Core\TypedData\Exception\MissingDataException
    */
-  public function canShare(
+  public function canShareToGroup(
     GroupInterface $source_group,
     GroupInterface $target_group,
     array $target_group_visibility_types = [GroupVisibilityType::GROUP_VISIBILITY_PUBLIC]
@@ -334,7 +334,7 @@ class ShareManager {
 
     return TRUE;
   }
-  
+
   /**
    * Returns the type for a shared content and given group type.
    *

--- a/lib/themes/eic_community/includes/preprocess/common.inc
+++ b/lib/themes/eic_community/includes/preprocess/common.inc
@@ -61,6 +61,13 @@ function _eic_community_get_share_group_content_link(
   GroupInterface $current_group,
   NodeInterface $node
 ) {
+  $account = \Drupal::currentUser();
+
+  // Check if user has permission to share.
+  if (!$current_group->hasPermission('share content between groups', $account)) {
+    return [];
+  }
+
   static $formatted_groups;
   /** @var \Drupal\oec_group_flex\GroupVisibilityDatabaseStorage $group_visibility_storage */
   $group_visibility_storage = \Drupal::service('oec_group_flex.group_visibility.storage');
@@ -74,7 +81,6 @@ function _eic_community_get_share_group_content_link(
   }
 
   if (empty($formatted_groups)) {
-    $account = \Drupal::currentUser();
     $share_manager = \Drupal::service('eic_share_content.share_manager');
     foreach ($share_manager->getShareableTargetGroupsForUser($account, $current_group) as $group) {
       if (!isset($formatted_groups[$group->bundle()])) {


### PR DESCRIPTION
### Tests

- [x] As TU, go to a (fresh) group and check that you can share content to antoehr group
- [x] Remove the `share content between groups` permission from the group
- [x] Clear the cache
- [x] As TU, check that you don't have the share to group link anymore