### PR TITLE
EICNET-2169: Error when create a book page without assigning it to a book

### DIFF
--- a/lib/modules/eic_content/modules/eic_content_book/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_content/modules/eic_content_book/src/Hooks/EntityOperations.php
@@ -96,7 +96,7 @@ class EntityOperations implements ContainerInjectionInterface {
             // If top level book page.
             $build['link_add_child_book_page_renderable'] = Link::fromTextAndUrl($this->t('Add a new book page'), $add_book_page_urls['add_child_book_page'])->toRenderable();
           }
-          else {
+          elseif (isset($entity->book) && !empty($entity->book['pid'])) {
             // If child book page.
             $build['link_add_current_level_book_page_renderable'] = Link::fromTextAndUrl($this->t('Add page on same level'), $add_book_page_urls['add_current_level_book_page'])->toRenderable();
             $build['link_add_current_level_book_page_renderable']['#suffix'] = '<br>';


### PR DESCRIPTION
### Fixes

- Fix error when creating book page with book outline settings as empty.

### Tests

- [x] Create a new book page and leave the book outline options as empty
- [x] Make sure there is no error when viewing the book page