### PR TITLE
[EICNET-1952]fix: Replace method used to get unpublished groups where user is owner

### DIFF
--- a/lib/modules/eic_search/src/Controller/SolrSearchController.php
+++ b/lib/modules/eic_search/src/Controller/SolrSearchController.php
@@ -474,7 +474,8 @@ class SolrSearchController extends ControllerBase {
 
     $status_query = ' AND (bs_global_status:true';
 
-    if ($source instanceof GroupSourceType) {
+    // User can see their group if status false but he is owner.
+    if ('group' === $source->getEntityBundle()) {
       $status_query .= ' OR (its_group_owner_id:' . $user_id . ')';
     }
 


### PR DESCRIPTION
How to test:

- [x] Create a group as NON SUPERADMIN user and do not publish it, let it as draft
- [x] Check if it's shown in /groups
- [x] Now get to /user/{USER_ID}/activity/groups and check if you can also see it in the overview