### PR TITLE
[EICNET-2179]fix: Use new SOLR field for group topic name

### DIFF
--- a/lib/modules/eic_topics/src/Constants/Topics.php
+++ b/lib/modules/eic_topics/src/Constants/Topics.php
@@ -15,7 +15,7 @@ final class Topics {
 
   const TERM_TOPICS_ID_FIELD_USER_SOLR = 'sm_user_profile_field_vocab_topic_interest_array';
 
-  const TERM_TOPICS_ID_FIELD_GROUP_SOLR = 'ss_group_topic_name';
+  const TERM_TOPICS_ID_FIELD_GROUP_SOLR = 'sm_group_topic_name';
 
   const CONTENT_TYPE_ID_FIELD_SOLR = 'ss_global_content_type';
 


### PR DESCRIPTION
How to test:

- [x] Go to a topic detail
- [x] Click on group statistics
- [x] Check if it's correctly redirected and prefiltered on the topic in the groups overview