### PR TITLE
EICNET-1818: Update CTA button URI of contact box block

### DIFF
--- a/lib/modules/eic_default_content/src/Generator/BlockContentGenerator.php
+++ b/lib/modules/eic_default_content/src/Generator/BlockContentGenerator.php
@@ -119,7 +119,7 @@ class BlockContentGenerator extends CoreGenerator {
       ],
       'field_title' => "Didn't find what you were looking for?",
       'field_cta_button' => [
-        'uri' => Url::fromRoute('<front>')->toUriString(),
+        'uri' => Url::fromRoute('contact.site_page')->toString(),
         'title' => 'Contact us',
         'link_type' => 'default',
       ],

--- a/lib/modules/eic_deploy/eic_deploy.install
+++ b/lib/modules/eic_deploy/eic_deploy.install
@@ -101,7 +101,7 @@ function eic_deploy_update_9002(&$sandbox) {
     ],
     'field_title' => "Didn't find what you were looking for?",
     'field_cta_button' => [
-      'uri' => Url::fromRoute('contact.site_page')->toUriString(),
+      'uri' => Url::fromRoute('contact.site_page')->toString(),
       'title' => 'Contact us',
       'link_type' => 'default',
     ],

--- a/lib/modules/eic_deploy/eic_deploy.install
+++ b/lib/modules/eic_deploy/eic_deploy.install
@@ -101,7 +101,7 @@ function eic_deploy_update_9002(&$sandbox) {
     ],
     'field_title' => "Didn't find what you were looking for?",
     'field_cta_button' => [
-      'uri' => Url::fromRoute('<front>')->toUriString(),
+      'uri' => Url::fromRoute('contact.site_page')->toUriString(),
       'title' => 'Contact us',
       'link_type' => 'default',
     ],


### PR DESCRIPTION
### Fixes

- Update CTA button URI of contact box block when generating with fixtures.

### Tests

- [x] Run a fresh install
- [x] Go to -> `/admin/content/block-content`
- [x] Click on edit button of "Contact box - Help & Guidance" block
- [x] Make sure the contact button URL points to the global contact page `/contact`