### PR TITLE
EICNET-2003: Group approved banner "Click here" link improvements

### DIFF
--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -54,6 +54,7 @@ function eic_groups_theme($existing, $type, $theme, $path) {
         'edit_link' => NULL,
         'delete_link' => NULL,
         'invite_link' => NULL,
+        'help_link' => NULL,
         'actions' => [],
         'has_content' => NULL,
         'has_member' => FALSE,

--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupOverviewMessageBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupOverviewMessageBlock.php
@@ -28,29 +28,41 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class EICGroupOverviewMessageBlock extends BlockBase implements ContainerFactoryPluginInterface {
 
   /**
+   * The current user account.
+   *
    * @var \Drupal\Core\Session\AccountProxyInterface
    */
   private $account;
 
   /**
+   * The content moderation information service.
+   *
    * @var \Drupal\content_moderation\ModerationInformationInterface
    */
   private $moderationInformation;
 
   /**
+   * The EIC group helper service.
+   *
    * @var \Drupal\eic_groups\EICGroupsHelper
    */
   private $groupHelper;
 
   /**
-   * EICGroupOverviewMessageBlock constructor.
+   * Constructs a new EICGroupOverviewMessageBlock object.
    *
    * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
    * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
    * @param mixed $plugin_definition
+   *   The plugin implementation definition.
    * @param \Drupal\content_moderation\ModerationInformationInterface $moderation_information
+   *   The content moderation information service.
    * @param \Drupal\Core\Session\AccountProxyInterface $account
+   *   The current user account.
    * @param \Drupal\eic_groups\EICGroupsHelper $group_helper
+   *   The EIC group helper service.
    */
   public function __construct(
     array $configuration,
@@ -110,7 +122,7 @@ class EICGroupOverviewMessageBlock extends BlockBase implements ContainerFactory
       ? array_keys($group_membership->getRoles())
       : [];
 
-    // This block is only shown to group admins.
+    // This block is only shown to group owners.
     if (empty(array_intersect($user_group_roles, $required_roles))) {
       return $build;
     }
@@ -147,6 +159,7 @@ class EICGroupOverviewMessageBlock extends BlockBase implements ContainerFactory
             EICGroupsHelper::GROUP_MEMBER_ROLE,
           ])),
           '#actions' => $content_operations,
+          '#help_link' => Url::fromRoute('contact.site_page')->toString(),
         ];
       }
     }

--- a/lib/themes/eic_community/templates/blocks/eic-group-moderated-message-box.html.twig
+++ b/lib/themes/eic_community/templates/blocks/eic-group-moderated-message-box.html.twig
@@ -41,7 +41,7 @@
         <li>{{ 'Create content in the group'|t }}</li>
         <li>{{ 'Publish your group'|t }}</li>
       </ul>
-      <p>{{ '<a href="@help_link">Click here</a> if you need additional help'|t({'@help_link': '#'}) }}</p>
+      <p>{{ '<a href="@help_link">Click here</a> if you need additional help'|t({'@help_link': help_link}) }}</p>
     {% endblock %}
   {% endembed %}
 {% elseif moderation_state == 'published' and has_member == false %}


### PR DESCRIPTION
### Fixes

- Group approved banner "Click here" link redirects to global contact form.
- Fix coding standards.

### Tests

- [x] As TU, create a new group
- [x] As SA/SCM, approve the group (change from PENDING to DRAFT)
- [x] As TU, go to the group overview page and make sure you see the group approved banner and if you click in the link "Click here" you should be redirected to the global contact form