### PR TITLE
EICNET-2171: Fix quote author in News

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/paragraphs/paragraph--quote.inc
+++ b/lib/themes/eic_community/includes/preprocess/paragraphs/paragraph--quote.inc
@@ -18,7 +18,8 @@ function eic_community_preprocess_paragraph__quote(array &$variables) {
     case 'external_person':
       // Add external person name.
       if (!$paragraph->get('field_name')->isEmpty()) {
-        $variables['paragraph_content']['author'] = $paragraph->get('field_name')->value;
+        $variables['paragraph_content']['name'] = $paragraph->get('field_name')->value;
+        $variables['paragraph_content']['author'] = TRUE;
       }
 
       // Add external person image.
@@ -36,11 +37,12 @@ function eic_community_preprocess_paragraph__quote(array &$variables) {
 
     case 'platform_member':
       if (!$paragraph->get('field_user_ref')->isEmpty()) {
+        $variables['paragraph_content']['author'] = TRUE;
         /** @var \Drupal\user\UserInterface $user */
         $user = $paragraph->get('field_user_ref')->entity;
 
         // Add user full name to the theme variables.
-        $variables['paragraph_content']['author'] = $user->getDisplayName();
+        $variables['paragraph_content']['name'] = $user->getDisplayName();
 
         // Add user image.
         if (!$user->get('field_media')->isEmpty()) {

--- a/lib/themes/eic_community/sass/components/_blockquote.scss
+++ b/lib/themes/eic_community/sass/components/_blockquote.scss
@@ -1,6 +1,10 @@
 .ecl-blockquote {
   margin: ecl-box-model('margin') 0;
 
+  & p {
+    display: inline;
+  }
+
   &:first-child {
     margin-top: 0;
   }

--- a/lib/themes/eic_community/styleguide/components/blockquote.stories.js
+++ b/lib/themes/eic_community/styleguide/components/blockquote.stories.js
@@ -8,9 +8,9 @@ import { without } from '@theme/snippets';
 
 export const Base = () => BlockquoteTemplate(without(blockquote, 'author', 'image'));
 
-export const Author = () => BlockquoteTemplate(without(blockquote, 'image'));
+export const Author = () => BlockquoteTemplate({...without(blockquote, 'image'), author: true});
 
-export const AuthorAndImage = () => BlockquoteTemplate(blockquote);
+export const AuthorAndImage = () => BlockquoteTemplate({...blockquote, author: true});
 
 export default {
   title: 'Components / Blockquote',


### PR DESCRIPTION
### Fixes

- Fix regression where quote paragraphs in News were not showing the author name + image anymore.

### Tests

- [x] Create a News with a quote (add an author name + image)
- [x] Make sure the quote is shown properly