### PR TITLE
EICNET-2182: Create eic_dummy_content_type module.

### DIFF
--- a/lib/modules/eic_dummy_content_type/config/install/core.base_field_override.node.dummy.promote.yml
+++ b/lib/modules/eic_dummy_content_type/config/install/core.base_field_override.node.dummy.promote.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.dummy
+_core:
+  default_config_hash: Jh0p9lZhLpM2NRjgqJLvgHfxEZcLDAzNsQNdwKZIKbM
+id: node.dummy.promote
+field_name: promote
+entity_type: node
+bundle: dummy
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/lib/modules/eic_dummy_content_type/config/install/core.entity_form_display.node.dummy.default.yml
+++ b/lib/modules/eic_dummy_content_type/config/install/core.entity_form_display.node.dummy.default.yml
@@ -1,0 +1,513 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.dummy.body
+    - field.field.node.dummy.field_date_range
+    - field.field.node.dummy.field_disclaimer
+    - field.field.node.dummy.field_discussion_type
+    - field.field.node.dummy.field_document_media
+    - field.field.node.dummy.field_document_type
+    - field.field.node.dummy.field_dummy_checkboxes
+    - field.field.node.dummy.field_dummy_file
+    - field.field.node.dummy.field_dummy_test
+    - field.field.node.dummy.field_dummy_test_2
+    - field.field.node.dummy.field_email
+    - field.field.node.dummy.field_image
+    - field.field.node.dummy.field_link
+    - field.field.node.dummy.field_location
+    - field.field.node.dummy.field_number_integer
+    - field.field.node.dummy.field_organised_by
+    - field.field.node.dummy.field_related_contributors
+    - field.field.node.dummy.field_related_groups
+    - field.field.node.dummy.field_social_links
+    - field.field.node.dummy.field_text_plain_long
+    - field.field.node.dummy.field_vocab_topics
+    - node.type.dummy
+  module:
+    - address
+    - datetime_range
+    - eic_content
+    - field_group
+    - file
+    - link
+    - media_library
+    - paragraphs
+    - path
+    - publication_date
+    - scheduler
+    - scheduler_content_moderation_integration
+    - social_link_field
+    - text
+    - workflow_buttons
+third_party_settings:
+  field_group:
+    group_tabs:
+      children:
+        - group_text
+        - group_media
+        - group_dates
+        - group_paragraphs
+        - group_entity_references
+        - group_taxonomies
+        - group_other
+      label: Tabs
+      region: content
+      parent_name: ''
+      weight: 1
+      format_type: tabs
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        direction: horizontal
+        width_breakpoint: 640
+    group_taxonomies:
+      children:
+        - field_vocab_topics
+        - field_discussion_type
+        - field_document_type
+      label: Taxonomies
+      region: content
+      parent_name: group_tabs
+      weight: 21
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_media:
+      children:
+        - field_image
+        - field_document_media
+      label: Media
+      region: content
+      parent_name: group_tabs
+      weight: 17
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_dates:
+      children:
+        - field_date_range
+      label: Dates
+      region: content
+      parent_name: group_tabs
+      weight: 18
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_paragraphs:
+      children:
+        - field_related_contributors
+      label: Paragraphs
+      region: content
+      parent_name: group_tabs
+      weight: 19
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_entity_references:
+      children:
+        - field_related_groups
+        - field_disclaimer
+      label: 'Entity references'
+      region: content
+      parent_name: group_tabs
+      weight: 20
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_text:
+      children:
+        - body
+        - field_organised_by
+        - field_text_plain_long
+      label: Text
+      region: content
+      parent_name: group_tabs
+      weight: 16
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: 'Only text fields'
+        required_fields: true
+    group_other:
+      children:
+        - field_link
+        - field_location
+        - field_social_links
+        - field_send_notification
+        - member_content_edit_access
+        - private
+        - field_post_activity
+        - field_number_integer
+        - field_email
+        - field_dummy_checkboxes
+      label: Other
+      region: content
+      parent_name: group_tabs
+      weight: 22
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_details_group:
+      children:
+        - field_dummy_test
+      label: 'Details group'
+      region: content
+      parent_name: ''
+      weight: 3
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        open: false
+        description: 'With a description'
+        required_fields: true
+    group_fieldset_group:
+      children:
+        - field_dummy_test_2
+      label: 'Fieldset group'
+      region: content
+      parent_name: ''
+      weight: 4
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        description: 'A small description'
+        required_fields: true
+_core:
+  default_config_hash: YGk73E6NxFxrD2b1BX2E4JFlg1CuOlktvxnoI3N940c
+id: node.dummy.default
+targetEntityType: node
+bundle: dummy
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 13
+    region: content
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: false
+    third_party_settings: {  }
+  created:
+    type: datetime_timestamp
+    weight: 9
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_date_range:
+    type: daterange_default
+    weight: 12
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_disclaimer:
+    type: options_select
+    weight: 5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_discussion_type:
+    type: options_buttons
+    weight: 5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_document_media:
+    type: media_library_widget
+    weight: 17
+    region: content
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+  field_document_type:
+    type: options_select
+    weight: 6
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_dummy_checkboxes:
+    type: options_buttons
+    weight: 28
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_dummy_file:
+    type: file_generic
+    weight: 20
+    region: content
+    settings:
+      progress_indicator: throbber
+    third_party_settings: {  }
+  field_dummy_test:
+    type: string_textfield
+    weight: 7
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_dummy_test_2:
+    type: string_textfield
+    weight: 5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_email:
+    type: email_default
+    weight: 27
+    region: content
+    settings:
+      placeholder: ''
+      size: 60
+    third_party_settings: {  }
+  field_image:
+    type: media_library_widget
+    weight: 16
+    region: content
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+  field_link:
+    type: link_default
+    weight: 19
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+  field_location:
+    type: address_default
+    weight: 20
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_number_integer:
+    type: number
+    weight: 26
+    region: content
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+  field_organised_by:
+    type: string_textfield
+    weight: 14
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_post_activity:
+    weight: 25
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_related_contributors:
+    type: entity_reference_paragraphs
+    weight: 17
+    region: content
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: closed
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: _none
+    third_party_settings: {  }
+  field_related_groups:
+    type: entity_reference_autocomplete
+    weight: 4
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_send_notification:
+    weight: 22
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_social_links:
+    type: social_links
+    weight: 21
+    region: content
+    settings:
+      select_social: 0
+      disable_weight: 0
+    third_party_settings: {  }
+  field_text_plain_long:
+    type: string_textarea
+    weight: 15
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_vocab_topics:
+    type: entity_tree
+    weight: 3
+    region: content
+    settings:
+      match_top_level_limit: '3'
+      disable_top_choices: '1'
+      items_to_load: '25'
+      auto_select_parents: '1'
+      load_all: 0
+      ignore_current_user: 0
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 5
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  member_content_edit_access:
+    type: boolean_checkbox
+    weight: 23
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  moderation_state:
+    type: workflow_buttons
+    weight: 7
+    region: content
+    settings:
+      show_current_state: false
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 16
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  private:
+    type: options_buttons
+    weight: 24
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    weight: 10
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  publish_on:
+    type: datetime_timestamp_no_default
+    weight: 17
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  publish_state:
+    type: scheduler_moderation
+    weight: 13
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  published_at:
+    type: publication_date_timestamp
+    weight: 8
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  scheduler_settings:
+    weight: 12
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 19
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    weight: 11
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 6
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  unpublish_on:
+    type: datetime_timestamp_no_default
+    weight: 15
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  unpublish_state:
+    type: scheduler_moderation
+    weight: 14
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  url_redirects:
+    weight: 18
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden: {  }

--- a/lib/modules/eic_dummy_content_type/config/install/core.entity_view_display.node.dummy.default.yml
+++ b/lib/modules/eic_dummy_content_type/config/install/core.entity_view_display.node.dummy.default.yml
@@ -1,0 +1,250 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.dummy.body
+    - field.field.node.dummy.field_date_range
+    - field.field.node.dummy.field_disclaimer
+    - field.field.node.dummy.field_discussion_type
+    - field.field.node.dummy.field_document_media
+    - field.field.node.dummy.field_document_type
+    - field.field.node.dummy.field_dummy_checkboxes
+    - field.field.node.dummy.field_dummy_file
+    - field.field.node.dummy.field_dummy_test
+    - field.field.node.dummy.field_dummy_test_2
+    - field.field.node.dummy.field_email
+    - field.field.node.dummy.field_image
+    - field.field.node.dummy.field_link
+    - field.field.node.dummy.field_location
+    - field.field.node.dummy.field_number_integer
+    - field.field.node.dummy.field_organised_by
+    - field.field.node.dummy.field_related_contributors
+    - field.field.node.dummy.field_related_groups
+    - field.field.node.dummy.field_social_links
+    - field.field.node.dummy.field_text_plain_long
+    - field.field.node.dummy.field_vocab_topics
+    - node.type.dummy
+  module:
+    - address
+    - datetime_range
+    - entity_reference_revisions
+    - file
+    - link
+    - options
+    - social_link_field
+    - text
+    - user
+_core:
+  default_config_hash: uB_lDMeI9CFzTQYcbjwS_YTIAMrueoj6k9fq6sLVDE4
+id: node.dummy.default
+targetEntityType: node
+bundle: dummy
+mode: default
+content:
+  body:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 101
+    region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
+  field_date_range:
+    type: daterange_default
+    label: above
+    settings:
+      timezone_override: ''
+      format_type: medium
+      separator: '-'
+    third_party_settings: {  }
+    weight: 103
+    region: content
+  field_disclaimer:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 104
+    region: content
+  field_discussion_type:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 111
+    region: content
+  field_document_media:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 105
+    region: content
+  field_document_type:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 106
+    region: content
+  field_dummy_checkboxes:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 121
+    region: content
+  field_dummy_file:
+    type: file_default
+    label: above
+    settings:
+      use_description_as_link_text: true
+    third_party_settings: {  }
+    weight: 120
+    region: content
+  field_dummy_test:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 118
+    region: content
+  field_dummy_test_2:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 119
+    region: content
+  field_email:
+    type: basic_string
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 115
+    region: content
+  field_image:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 107
+    region: content
+  field_link:
+    type: link
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 110
+    region: content
+  field_location:
+    type: address_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 102
+    region: content
+  field_number_integer:
+    type: number_integer
+    label: above
+    settings:
+      thousand_separator: ''
+      prefix_suffix: true
+    third_party_settings: {  }
+    weight: 114
+    region: content
+  field_organised_by:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 113
+    region: content
+  field_related_contributors:
+    type: entity_reference_revisions_entity_view
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 109
+    region: content
+  field_related_groups:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 117
+    region: content
+  field_social_links:
+    type: font_awesome
+    label: above
+    settings:
+      icon_type: common
+      orientation: vertical
+      new_tab: true
+    third_party_settings: {  }
+    weight: 112
+    region: content
+  field_text_plain_long:
+    type: basic_string
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 116
+    region: content
+  field_vocab_topics:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 108
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+  member_content_edit_access:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  private:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  extra_field_eic_theme_helper_short_title_with_fallback: true
+  langcode: true
+  published_at: true
+  search_api_excerpt: true

--- a/lib/modules/eic_dummy_content_type/config/install/core.entity_view_display.node.dummy.teaser.yml
+++ b/lib/modules/eic_dummy_content_type/config/install/core.entity_view_display.node.dummy.teaser.yml
@@ -1,0 +1,100 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.dummy.body
+    - field.field.node.dummy.field_date_range
+    - field.field.node.dummy.field_disclaimer
+    - field.field.node.dummy.field_discussion_type
+    - field.field.node.dummy.field_document_media
+    - field.field.node.dummy.field_document_type
+    - field.field.node.dummy.field_dummy_checkboxes
+    - field.field.node.dummy.field_dummy_file
+    - field.field.node.dummy.field_dummy_test
+    - field.field.node.dummy.field_dummy_test_2
+    - field.field.node.dummy.field_email
+    - field.field.node.dummy.field_image
+    - field.field.node.dummy.field_link
+    - field.field.node.dummy.field_location
+    - field.field.node.dummy.field_number_integer
+    - field.field.node.dummy.field_organised_by
+    - field.field.node.dummy.field_related_contributors
+    - field.field.node.dummy.field_related_groups
+    - field.field.node.dummy.field_social_links
+    - field.field.node.dummy.field_text_plain_long
+    - field.field.node.dummy.field_vocab_topics
+    - node.type.dummy
+  module:
+    - text
+    - user
+_core:
+  default_config_hash: tXwqd-a66NeN-tXgV0XpTcu8lg0594IZrY327n3AV7Y
+id: node.dummy.teaser
+targetEntityType: node
+bundle: dummy
+mode: teaser
+content:
+  body:
+    type: text_summary_or_trimmed
+    label: hidden
+    settings:
+      trim_length: 600
+    third_party_settings: {  }
+    weight: 101
+    region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+  member_content_edit_access:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  private:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  extra_field_eic_theme_helper_short_title_with_fallback: true
+  field_date_range: true
+  field_disclaimer: true
+  field_discussion_type: true
+  field_document_media: true
+  field_document_type: true
+  field_dummy_checkboxes: true
+  field_dummy_file: true
+  field_dummy_test: true
+  field_dummy_test_2: true
+  field_email: true
+  field_image: true
+  field_link: true
+  field_location: true
+  field_number_integer: true
+  field_organised_by: true
+  field_related_contributors: true
+  field_related_groups: true
+  field_social_links: true
+  field_text_plain_long: true
+  field_vocab_topics: true
+  langcode: true
+  published_at: true
+  search_api_excerpt: true

--- a/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.body.yml
+++ b/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.body.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.dummy
+  module:
+    - text
+id: node.dummy.body
+field_name: body
+entity_type: node
+bundle: dummy
+label: Body
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: true
+  required_summary: false
+field_type: text_with_summary

--- a/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_date_range.yml
+++ b/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_date_range.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_date_range
+    - node.type.dummy
+  module:
+    - datetime_range
+id: node.dummy.field_date_range
+field_name: field_date_range
+entity_type: node
+bundle: dummy
+label: Date
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: daterange

--- a/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_disclaimer.yml
+++ b/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_disclaimer.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_disclaimer
+    - fragments.fragment_type.disclaimer
+    - node.type.dummy
+id: node.dummy.field_disclaimer
+field_name: field_disclaimer
+entity_type: node
+bundle: dummy
+label: Disclaimer
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:fragment'
+  handler_settings:
+    target_bundles:
+      disclaimer: disclaimer
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_discussion_type.yml
+++ b/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_discussion_type.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_discussion_type
+    - node.type.dummy
+  module:
+    - options
+id: node.dummy.field_discussion_type
+field_name: field_discussion_type
+entity_type: node
+bundle: dummy
+label: 'Type of Discussion'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_document_media.yml
+++ b/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_document_media.yml
@@ -1,0 +1,30 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_document_media
+    - media.type.document
+    - media.type.eic_document
+    - node.type.dummy
+id: node.dummy.field_document_media
+field_name: field_document_media
+entity_type: node
+bundle: dummy
+label: Document
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      eic_document: eic_document
+      document: document
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: eic_document
+field_type: entity_reference

--- a/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_document_type.yml
+++ b/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_document_type.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_document_type
+    - node.type.dummy
+    - taxonomy.vocabulary.document_types
+id: node.dummy.field_document_type
+field_name: field_document_type
+entity_type: node
+bundle: dummy
+label: 'Document type'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      document_types: document_types
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_dummy_checkboxes.yml
+++ b/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_dummy_checkboxes.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_dummy_checkboxes
+    - node.type.dummy
+  module:
+    - options
+id: node.dummy.field_dummy_checkboxes
+field_name: field_dummy_checkboxes
+entity_type: node
+bundle: dummy
+label: Checkboxes
+description: 'Please select one or more options.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_dummy_file.yml
+++ b/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_dummy_file.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_dummy_file
+    - node.type.dummy
+  module:
+    - file
+id: node.dummy.field_dummy_file
+field_name: field_dummy_file
+entity_type: node
+bundle: dummy
+label: File
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:file'
+  handler_settings: {  }
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'txt doc docx xls xlsx pdf odt ppt pptx ods odp pps ppsx zip rar'
+  max_filesize: ''
+  description_field: true
+field_type: file

--- a/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_dummy_test.yml
+++ b/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_dummy_test.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_dummy_test
+    - node.type.dummy
+id: node.dummy.field_dummy_test
+field_name: field_dummy_test
+entity_type: node
+bundle: dummy
+label: Test
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_dummy_test_2.yml
+++ b/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_dummy_test_2.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_dummy_test_2
+    - node.type.dummy
+id: node.dummy.field_dummy_test_2
+field_name: field_dummy_test_2
+entity_type: node
+bundle: dummy
+label: 'Test 2'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_email.yml
+++ b/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_email.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_email
+    - node.type.dummy
+id: node.dummy.field_email
+field_name: field_email
+entity_type: node
+bundle: dummy
+label: Email
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: email

--- a/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_image.yml
+++ b/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_image.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_image
+    - media.type.image
+    - node.type.dummy
+id: node.dummy.field_image
+field_name: field_image
+entity_type: node
+bundle: dummy
+label: 'Image teaser'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_link.yml
+++ b/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_link.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_link
+    - node.type.dummy
+  module:
+    - link
+id: node.dummy.field_link
+field_name: field_link
+entity_type: node
+bundle: dummy
+label: 'Event website'
+description: 'Link to external Event website.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 0
+  link_type: 16
+field_type: link

--- a/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_location.yml
+++ b/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_location.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_location
+    - node.type.dummy
+  module:
+    - address
+id: node.dummy.field_location
+field_name: field_location
+entity_type: node
+bundle: dummy
+label: Location
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  available_countries: {  }
+  langcode_override: ''
+  field_overrides: {  }
+  fields: {  }
+field_type: address

--- a/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_number_integer.yml
+++ b/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_number_integer.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_number_integer
+    - node.type.dummy
+id: node.dummy.field_number_integer
+field_name: field_number_integer
+entity_type: node
+bundle: dummy
+label: 'Number (integer)'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: null
+  max: null
+  prefix: Price
+  suffix: €
+field_type: integer

--- a/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_organised_by.yml
+++ b/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_organised_by.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_organised_by
+    - node.type.dummy
+id: node.dummy.field_organised_by
+field_name: field_organised_by
+entity_type: node
+bundle: dummy
+label: 'Organised by'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_related_contributors.yml
+++ b/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_related_contributors.yml
@@ -1,0 +1,66 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_related_contributors
+    - node.type.dummy
+    - paragraphs.paragraphs_type.contributor
+  module:
+    - entity_reference_revisions
+id: node.dummy.field_related_contributors
+field_name: field_related_contributors
+entity_type: node
+bundle: dummy
+label: 'Related Contributors'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    target_bundles:
+      contributor: contributor
+    negate: 0
+    target_bundles_drag_drop:
+      announcement:
+        weight: 14
+        enabled: false
+      banner:
+        weight: 15
+        enabled: false
+      contributor:
+        weight: 16
+        enabled: true
+      cta_tile:
+        weight: 17
+        enabled: false
+      full_media_content:
+        weight: 18
+        enabled: false
+      full_text_content:
+        weight: 19
+        enabled: false
+      gallery_slide:
+        weight: 20
+        enabled: false
+      organisation_location:
+        weight: 21
+        enabled: false
+      organisation_member:
+        weight: 22
+        enabled: false
+      organisation_member_external:
+        weight: 23
+        enabled: false
+      quote:
+        weight: 24
+        enabled: false
+      text_and_media_content:
+        weight: 25
+        enabled: false
+      tiles_content:
+        weight: 26
+        enabled: false
+field_type: entity_reference_revisions

--- a/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_related_groups.yml
+++ b/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_related_groups.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_related_groups
+    - group.type.group
+    - node.type.dummy
+id: node.dummy.field_related_groups
+field_name: field_related_groups
+entity_type: node
+bundle: dummy
+label: 'Related groups'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:group'
+  handler_settings:
+    target_bundles:
+      group: group
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: event
+field_type: entity_reference

--- a/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_social_links.yml
+++ b/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_social_links.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_social_links
+    - node.type.dummy
+  module:
+    - social_link_field
+id: node.dummy.field_social_links
+field_name: field_social_links
+entity_type: node
+bundle: dummy
+label: 'Social links'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    link: ''
+    social: facebook
+  -
+    link: ''
+    social: twitter
+default_value_callback: ''
+settings: {  }
+field_type: social_links

--- a/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_text_plain_long.yml
+++ b/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_text_plain_long.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_text_plain_long
+    - node.type.dummy
+id: node.dummy.field_text_plain_long
+field_name: field_text_plain_long
+entity_type: node
+bundle: dummy
+label: 'Text (plain long)'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_vocab_topics.yml
+++ b/lib/modules/eic_dummy_content_type/config/install/field.field.node.dummy.field_vocab_topics.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_vocab_topics
+    - node.type.dummy
+    - taxonomy.vocabulary.topics
+id: node.dummy.field_vocab_topics
+field_name: field_vocab_topics
+entity_type: node
+bundle: dummy
+label: Topics
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      topics: topics
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/lib/modules/eic_dummy_content_type/config/install/field.storage.node.field_dummy_checkboxes.yml
+++ b/lib/modules/eic_dummy_content_type/config/install/field.storage.node.field_dummy_checkboxes.yml
@@ -1,0 +1,35 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.field_dummy_checkboxes
+field_name: field_dummy_checkboxes
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: a
+      label: 'Lorem ipsum'
+    -
+      value: b
+      label: 'Consectetur adipiscing elit'
+    -
+      value: c
+      label: 'Duis aute irure dolor'
+    -
+      value: d
+      label: 'Ut enim ad minim veniam'
+    -
+      value: e
+      label: 'Excepteur sint occaecat cupidatat'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/lib/modules/eic_dummy_content_type/config/install/field.storage.node.field_dummy_file.yml
+++ b/lib/modules/eic_dummy_content_type/config/install/field.storage.node.field_dummy_file.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - node
+id: node.field_dummy_file
+field_name: field_dummy_file
+entity_type: node
+type: file
+settings:
+  target_type: file
+  display_field: false
+  display_default: false
+  uri_scheme: private
+module: file
+locked: false
+cardinality: 3
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/lib/modules/eic_dummy_content_type/config/install/field.storage.node.field_dummy_test.yml
+++ b/lib/modules/eic_dummy_content_type/config/install/field.storage.node.field_dummy_test.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_dummy_test
+field_name: field_dummy_test
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/lib/modules/eic_dummy_content_type/config/install/field.storage.node.field_dummy_test_2.yml
+++ b/lib/modules/eic_dummy_content_type/config/install/field.storage.node.field_dummy_test_2.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_dummy_test_2
+field_name: field_dummy_test_2
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/lib/modules/eic_dummy_content_type/config/install/field.storage.node.field_email.yml
+++ b/lib/modules/eic_dummy_content_type/config/install/field.storage.node.field_email.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_email
+field_name: field_email
+entity_type: node
+type: email
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/lib/modules/eic_dummy_content_type/config/install/field.storage.node.field_number_integer.yml
+++ b/lib/modules/eic_dummy_content_type/config/install/field.storage.node.field_number_integer.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: user.field_number_integer
+field_name: field_number_integer
+entity_type: node
+type: integer
+settings:
+  unsigned: false
+  size: normal
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/lib/modules/eic_dummy_content_type/config/install/field.storage.node.field_text_plain_long.yml
+++ b/lib/modules/eic_dummy_content_type/config/install/field.storage.node.field_text_plain_long.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_text_plain_long
+field_name: field_text_plain_long
+entity_type: node
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/lib/modules/eic_dummy_content_type/config/install/language.content_settings.node.dummy.yml
+++ b/lib/modules/eic_dummy_content_type/config/install/language.content_settings.node.dummy.yml
@@ -1,0 +1,12 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.dummy
+_core:
+  default_config_hash: NPYMEGVraTN6xcAqzWDfQP-hdh4n-6Z4i3ET4rQh130
+id: node.dummy
+target_entity_type_id: node
+target_bundle: dummy
+default_langcode: site_default
+language_alterable: false

--- a/lib/modules/eic_dummy_content_type/config/install/node.type.dummy.yml
+++ b/lib/modules/eic_dummy_content_type/config/install/node.type.dummy.yml
@@ -1,0 +1,36 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - eic_private_content
+    - menu_ui
+    - scheduler
+third_party_settings:
+  eic_private_content:
+    private: 1
+  menu_ui:
+    available_menus:
+      - main
+    parent: 'main:'
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: true
+    publish_past_date: error
+    publish_past_date_created: false
+    publish_required: false
+    publish_revision: false
+    publish_touch: false
+    show_message_after_update: true
+    unpublish_enable: true
+    unpublish_required: false
+    unpublish_revision: false
+_core:
+  default_config_hash: 1ftQgGQXxHOIGifn977txgMgydbWh1XXQPSzLuS25_Y
+name: Dummy
+type: dummy
+description: 'This content type is for development purposes only.'
+help: ''
+new_revision: true
+preview_mode: 0
+display_submitted: false

--- a/lib/modules/eic_dummy_content_type/eic_dummy_content_type.info.yml
+++ b/lib/modules/eic_dummy_content_type/eic_dummy_content_type.info.yml
@@ -1,0 +1,7 @@
+name: EIC Dummy Content Type
+type: module
+description: Provides a dummy content type for development purposes.
+package: European Innovation Council
+core: 8.x
+php: 7.4
+core_version_requirement: ^8 || ^9

--- a/lib/modules/eic_dummy_content_type/eic_dummy_content_type.install
+++ b/lib/modules/eic_dummy_content_type/eic_dummy_content_type.install
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for EIC Dummy Content Type module.
+ */
+
+use Drupal\workflows\Entity\Workflow;
+use Drupal\eic_user\UserHelper;
+use Drupal\user\Entity\Role;
+
+/**
+ * Implements hook_install().
+ */
+function eic_dummy_content_type_install() {
+  // Add permissions to roles.
+  $add_permissions = [
+    UserHelper::ROLE_TRUSTED_USER => [
+      'create dummy content',
+      'edit any dummy content',
+      'delete any dummy content',
+      'schedule publishing of nodes',
+    ],
+    UserHelper::ROLE_CONTENT_ADMINISTRATOR => [
+      'create dummy content',
+      'edit any dummy content',
+      'delete any dummy content',
+    ],
+    UserHelper::ROLE_SITE_ADMINISTRATOR => [
+      'create dummy content',
+      'edit any dummy content',
+      'delete any dummy content',
+    ],
+    UserHelper::ROLE_DRUPAL_ADMINISTRATOR => [
+      'create dummy content',
+      'edit any dummy content',
+      'delete any dummy content',
+    ],
+  ];
+
+  foreach ($add_permissions as $role_name => $permissions) {
+    $role = Role::load($role_name);
+    foreach ($permissions as $permission) {
+      $role->grantPermission($permission);
+    }
+    $role->save();
+  }
+
+  // Remove permissions.
+  $remove_permissions = [
+    UserHelper::ROLE_CONTENT_ADMINISTRATOR => [
+      'view the administration theme',
+    ],
+    UserHelper::ROLE_SITE_ADMINISTRATOR => [
+      'view the administration theme',
+    ],
+    UserHelper::ROLE_DRUPAL_ADMINISTRATOR => [
+      'view the administration theme',
+    ],
+  ];
+
+  foreach ($remove_permissions as $role_name => $permissions) {
+    $role = Role::load($role_name);
+    foreach ($permissions as $permission) {
+      $role->revokePermission($permission);
+    }
+    $role->save();
+  }
+
+  // Apply default workflow to Dummy CT.
+  $workflow = Workflow::load('default');
+  $config = $workflow->getTypePlugin()->getConfiguration();
+  $config['entity_types']['node'][] = 'dummy';
+  $workflow->getTypePlugin()->setConfiguration($config);
+  $workflow->save();
+}

--- a/lib/modules/eic_dummy_content_type/eic_dummy_content_type.module
+++ b/lib/modules/eic_dummy_content_type/eic_dummy_content_type.module
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * @file
+ * Primary module hooks for EIC Dummy Content Type module.
+ *
+ * @DCG
+ * This file is no longer required in Drupal 8.
+ * @see https://www.drupal.org/node/2217931
+ */


### PR DESCRIPTION
### Tests

- [x] Enable `eic_dummy_content_type` module
- [x] You should have a `Dummy` content type created


### Remarks

- This module is for development purpose only and should not be enabled on PROD