### PR TITLE
EICNET-2174: Group activity stream cannot be viewed by non logged (anonymous) users

### DIFF
--- a/lib/modules/eic_deploy/eic_deploy.install
+++ b/lib/modules/eic_deploy/eic_deploy.install
@@ -112,8 +112,7 @@ function eic_deploy_update_9002(&$sandbox) {
 /**
  * Re-create news_stories moderation states for existing entities.
  */
-function eic_deploy_update_9003(&$sandbox)
-{
+function eic_deploy_update_9003(&$sandbox) {
   $mapping = [
     'draft' => 'draft',
     'published' => 'published',
@@ -142,5 +141,55 @@ function eic_deploy_update_9003(&$sandbox)
       ->load($entity_id);
     $entity->set('moderation_state', $state);
     $entity->save();
+  }
+}
+
+/**
+ * Remove group permission to access latest activity stream from anonymous.
+ */
+function eic_deploy_update_9004(&$sandbox) {
+  $groups = Drupal::entityTypeManager()->getStorage('group')
+    ->loadByProperties([
+      'type' => 'group',
+    ]);
+
+  foreach ($groups as $group) {
+    $groupPermissionsManager = \Drupal::service('group_permission.group_permissions_manager');
+    $groupPermissions = $groupPermissionsManager->loadByGroup($group);
+
+    $rolePermissions = [
+      'access latest activity stream',
+    ];
+    $role = $group->getGroupType()->getAnonymousRoleId();
+
+    $permissions = $groupPermissions->getPermissions();
+    foreach ($rolePermissions as $permission) {
+      if (
+        array_key_exists($role, $permissions) ||
+        in_array($permission, $permissions[$role], TRUE)
+      ) {
+        $permissions[$role] = array_diff($permissions[$role], [$permission]);
+      }
+    }
+    $groupPermissions->setPermissions($permissions);
+
+    $violations = $groupPermissions->validate();
+
+    if (count($violations) > 0) {
+      $message = '';
+      foreach ($violations as $violation) {
+        $message .= "\n" . $violation->getMessage();
+      }
+      \Drupal::messenger()->addMessage('Group permissions are not saved correctly, because:' . $message);
+      continue;
+    }
+
+    // Saves the GroupPermission object with a new revision.
+    $groupPermissions->setNewRevision();
+    $groupPermissions->setRevisionUserId(1);
+    $groupPermissions->setRevisionCreationTime(\Drupal::service('datetime.time')
+      ->getRequestTime());
+    $groupPermissions->setRevisionLogMessage('Group features enabled/disabled.');
+    $groupPermissions->save();
   }
 }

--- a/lib/modules/eic_groups/src/Plugin/GroupFeature/GroupLatestActivityStream.php
+++ b/lib/modules/eic_groups/src/Plugin/GroupFeature/GroupLatestActivityStream.php
@@ -3,6 +3,7 @@
 namespace Drupal\eic_groups\Plugin\GroupFeature;
 
 use Drupal\Core\Url;
+use Drupal\group\Entity\GroupInterface;
 
 /**
  * Group feature plugin implementation for Latest activity stream.
@@ -33,6 +34,15 @@ class GroupLatestActivityStream extends EicGroupsGroupFeaturePluginBase {
     // Set a specific weight for the menu item.
     $menu_item->set('weight', 1);
     return $menu_item;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getGroupPublicRoleIds(GroupInterface $group) {
+    return [
+      $group->getGroupType()->getOutsiderRoleId(),
+    ];
   }
 
 }


### PR DESCRIPTION
### Improvements

- Remove group permission "access latest activity stream" from anonymous users.

### Tests

- [x] As GO, edit a public group and enable the feature "**Latest activity**" 
- [x] As anonymous, try to access the latest activity stream page of the previous group `/groups/<group-name>/latest-activity` and make sure you get access denied.
- [x] As TU/GM/GO/GA/SA/SCM, make sure you can still access the latest activity stream

### QA deploy notes

- We need to run drush updb in order to remove the group permission (for anonymous user role) from all groups.