### PR TITLE
EICNET-2181: Documents - Topic label links to same page

### DIFF
--- a/config/sync/core.entity_view_display.node.document.default.yml
+++ b/config/sync/core.entity_view_display.node.document.default.yml
@@ -20,6 +20,11 @@ targetEntityType: node
 bundle: document
 mode: default
 content:
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
   field_body:
     type: text_default
     label: hidden
@@ -72,7 +77,7 @@ content:
     type: entity_reference_label
     label: hidden
     settings:
-      link: false
+      link: true
     third_party_settings: {  }
     weight: 3
     region: content


### PR DESCRIPTION
### Fixes

- Update field topics in document default view mode in order fix the topic link when viewing the document detail page

### Tests

- [x] As TU, go to a group document detail page
- [x] Make sure each topic in the sidebar redirects you to the correct topic detail page 