### PR TITLE
EICNET-2172: No avatar shown on news articles

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/layout/page.inc
+++ b/lib/themes/eic_community/includes/preprocess/layout/page.inc
@@ -187,6 +187,7 @@ function _preprocess_node_page(&$variables) {
           '#theme' => 'eic_community_author',
           '#name' => $author['name'],
           '#path' => $author['path'] ?? '',
+          '#image' => $author['image'] ?? NULL,
         ];
 
         if (isset($author['image'])) {


### PR DESCRIPTION
### Fixes

- Show author avatar when viewing News/Story detail page.

### Test

- [x] Go to a News detail page
- [x] Make sure the author avatar is displayed in the News banner