### PR TITLE
organisation contact collapsed adress

### DIFF
--- a/lib/themes/eic_community/sass/compositions/_editorial-article.scss
+++ b/lib/themes/eic_community/sass/compositions/_editorial-article.scss
@@ -13,12 +13,11 @@
       align-items: stretch;
       flex-direction: row;
     }
-
   }
 
   &__header,
   &__content,
-  &__container--wiki{
+  &__container--wiki {
     #{$node}--is-ready#{$node}--is-collapsible & {
       @include ecl-media-breakpoint-up('md') {
         margin-left: 0;
@@ -47,11 +46,11 @@
   }
 
   &__container--wiki,
-  &__content{
+  &__content {
     @include ecl-media-breakpoint-up('md') {
       flex-grow: 1;
 
-      #{$node}--is-ready#{$node}--is-collapsible[aria-collapsed = true] &{
+      #{$node}--is-ready#{$node}--is-collapsible[aria-collapsed='true'] & {
         flex-basis: 100%;
       }
     }
@@ -98,16 +97,15 @@
       @extend .ecl-u-type-heading-4;
     }
 
-    h5, {
+    h5 {
       @extend .ecl-u-type-heading-5;
     }
 
-    &--wiki img{
+    &--wiki img {
       max-width: 100%;
       width: 100%;
       height: auto;
     }
-
   }
 
   &__aside {
@@ -122,7 +120,6 @@
         box-sizing: border-box;
       }
     }
-
 
     #{$node}--is-collapsible & {
       margin-top: 0;
@@ -149,11 +146,10 @@
         margin-bottom: ecl-layout('gutter');
       }
 
-      #{$node}--is-ready#{$node}--is-collapsible[aria-collapsed="true"] & {
+      #{$node}--is-ready#{$node}--is-collapsible[aria-collapsed='true'] & {
         height: auto;
         width: auto;
       }
-
 
       flex-shrink: 0;
     }
@@ -166,7 +162,7 @@
     }
   }
 
-  &__aside-wrapper {
+  &:not(#{$node}--organisation) &__aside-wrapper {
     @include ecl-media-breakpoint-up('md') {
       position: sticky;
       top: ecl-layout('gutter');

--- a/lib/themes/eic_community/sass/compositions/_featured-list.scss
+++ b/lib/themes/eic_community/sass/compositions/_featured-list.scss
@@ -85,7 +85,7 @@
           width: auto;
 
           & .ecl-featured-list__expand,
-          & .ecl-featured-list__collapse{
+          & .ecl-featured-list__collapse {
             background: $ecl-color-grey;
             color: $ecl-color-white;
             & svg {
@@ -96,7 +96,7 @@
       }
     }
 
-    #{$node}--is-collapsible#{$node}--is-ready:not([aria-collapsed="false"]) &:nth-child(1n+6) {
+    #{$node}--is-collapsible#{$node}--is-ready:not([aria-collapsed='false']) &:nth-child(1n + 6) {
       &:not(#{$node}__item--expand) {
         @include visually-hidden();
       }
@@ -110,8 +110,8 @@
       }
     }
 
-    #{$node}--is-collapsible#{$node}--is-tag#{$node}--is-ready:not([aria-collapsed="false"]) &{
-      &:nth-child(1n+4) {
+    #{$node}--is-collapsible#{$node}--is-tag#{$node}--is-ready:not([aria-collapsed='false']) & {
+      &:nth-child(1n + 4) {
         &:not(#{$node}__item--expand) {
           @include visually-hidden();
         }
@@ -126,12 +126,14 @@
       }
     }
 
-    #{$node}--is-collapsible#{$node}--is-organisation-announcements#{$node}--is-ready:not([aria-collapsed="false"]) &,
-    #{$node}--is-collapsible#{$node}--is-organisation-adresses#{$node}--is-ready:not([aria-collapsed="false"]) & {
+    #{$node}--is-collapsible#{$node}--is-organisation-announcements#{$node}--is-ready:not([aria-collapsed='false'])
+      &,
+    #{$node}--is-collapsible#{$node}--is-organisation-adresses#{$node}--is-ready:not([aria-collapsed='false'])
+      & {
       & ~ #{$node}__item--expand button {
         padding: 0;
       }
-      &:nth-child(1n+3) {
+      &:nth-child(1n + 3) {
         &:not(#{$node}__item--expand) {
           @include visually-hidden();
         }
@@ -146,11 +148,12 @@
       }
     }
 
-    #{$node}--is-collapsible#{$node}--is-organisation-locations#{$node}--is-ready:not([aria-collapsed="false"]) &{
+    #{$node}--is-collapsible#{$node}--is-organisation-locations#{$node}--is-ready:not([aria-collapsed='false'])
+      & {
       & ~ #{$node}__item--expand button {
         padding: 0;
       }
-      &:nth-child(1n+0) {
+      &:nth-child(1n + 0) {
         &:not(#{$node}__item--expand) {
           @include visually-hidden();
         }
@@ -166,7 +169,6 @@
     }
 
     #{$node}--has-grid-layout#{$node}--is-collapsible#{$node}--is-ready & {
-
       margin: 0;
       padding: 0;
       padding-right: map-get($ecl-spacing, 'xs');
@@ -178,7 +180,8 @@
       }
     }
 
-    #{$node}--has-grid-layout#{$node}--is-collapsible#{$node}--is-ready:not([aria-collapsed="false"]) &:nth-child(1n+65) {
+    #{$node}--has-grid-layout#{$node}--is-collapsible#{$node}--is-ready:not([aria-collapsed='false'])
+      &:nth-child(1n + 65) {
       &:not(#{$node}__item--expand) {
         @include visually-hidden();
       }
@@ -239,6 +242,10 @@
     @extend .ecl-u-type-heading-5;
   }
 
+  &__btn-no-padding {
+    padding: 0;
+  }
+
   &.wide-view {
     .ecl-author__information {
       display: grid;
@@ -248,13 +255,23 @@
         'line3 status3';
       flex-grow: 0;
 
-      .ecl-author__label {grid-area: line1;}
-      .ecl-author__description {grid-area: line2;}
-      .ecl-author__meta {grid-area: line3;}
+      .ecl-author__label {
+        grid-area: line1;
+      }
+      .ecl-author__description {
+        grid-area: line2;
+      }
+      .ecl-author__meta {
+        grid-area: line3;
+      }
       .ecl-author__actions {
         grid-area: status2;
 
-        .ecl-author__action {width: 18px; height: 18px; margin-left: map-get($ecl-spacing, 'm');}
+        .ecl-author__action {
+          width: 18px;
+          height: 18px;
+          margin-left: map-get($ecl-spacing, 'm');
+        }
       }
     }
   }

--- a/lib/themes/eic_community/templates/group/group--organisation--full.html.twig
+++ b/lib/themes/eic_community/templates/group/group--organisation--full.html.twig
@@ -10,7 +10,9 @@
 {% endblock %}
 
 {% block content %}
-    {% embed "@theme/patterns/compositions/editorial-article.html.twig" with editorial_article|default({}) %}
+    {% embed "@theme/patterns/compositions/editorial-article.html.twig" with editorial_article|default({})|merge({
+      extra_classes: "ecl-editorial-article--organisation"
+    }) %}
         {% block content %}
             {% if details is not empty %}
                 <section class="ecl-organisation__details ecl-organisation__item">
@@ -151,7 +153,36 @@
                   {% endwith %}
                 </div>
               {% endfor %}
-              <div class="ecl-featured-list__item ecl-featured-list__item--expand">
+              <div class="ecl-featured-list__item ecl-featured-list__item--expand  ecl-featured-list__item--collapse">
+            {% include "@ecl-twig/ec-component-button/ecl-button.html.twig" with {
+                  icon_position: 'after',
+                  icon: icon_file_path ? {
+                    path: icon_file_path,
+                    type: 'ui',
+                    name: 'rounded-arrow',
+                    size: '2xs',
+                  } : {},
+                  label: contact.adresses.collapse_label|default('Show less'),
+                  variant: 'ghost',
+                  extra_classes: 'ecl-featured-list__collapse ecl-featured-list__btn-no-padding'
+                } %}
+          </div>
+          <div class="ecl-featured-list__item ecl-featured-list__item--expand">
+            {% include "@ecl-twig/ec-component-button/ecl-button.html.twig" with {
+                  icon_position: 'after',
+                  icon: icon_file_path ? {
+                    path: icon_file_path,
+                    type: 'ui',
+                    name: 'rounded-arrow',
+                    transform: 'rotate-180',
+                    size: '2xs',
+                  } : {},
+                  label: contact.adresses.collapse_label|default('Show all'),
+                  variant: 'ghost',
+                  extra_classes: 'ecl-featured-list__expand'
+                } %}
+          </div>
+              {# <div class="ecl-featured-list__item ecl-featured-list__item--expand">
                 {% include "@ecl-twig/ec-component-button/ecl-button.html.twig" with {
                   icon_position: 'after',
                   icon: icon_file_path ? {
@@ -165,7 +196,7 @@
                   variant: 'ghost',
                   extra_classes: 'ecl-featured-list__expand'
                 } %}
-              </div>
+              </div> #}
             </div>
           </div>
           </div>


### PR DESCRIPTION
https://citnet.tech.ec.europa.eu/CITnet/jira/secure/RapidBoard.jspa?rapidView=6628&projectKey=EICNET&view=detail&selectedIssue=EICNET-2142&quickFilter=26822

### What I did

- Now in organisation contact sidebar, we can collapse/expand the addresses items