### PR TITLE
[EICNET-1745]fix: set correct statistics + invalidate cache when event like

### DIFF
--- a/lib/modules/eic_flags/src/EventSubscriber/FlagEventSubscriber.php
+++ b/lib/modules/eic_flags/src/EventSubscriber/FlagEventSubscriber.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\eic_flags\EventSubscriber;
 
+use Drupal\Core\Cache\Cache;
 use Drupal\eic_flags\FlagType;
 use Drupal\eic_search\Service\SolrDocumentProcessor;
 use Drupal\flag\Event\FlagEvents;
@@ -52,6 +53,7 @@ class FlagEventSubscriber implements EventSubscriberInterface {
     if ($this->isReindexTargetedFlag($flagging)) {
       // Get the flagged entity to be updated.
       $parent_entity = $flagging->getFlaggable();
+      Cache::invalidateTags($parent_entity->getCacheTags());
       $this->solrDocumentProcessor->reIndexEntities([$parent_entity]);
     }
 

--- a/lib/modules/eic_groups/src/Controller/DiscussionController.php
+++ b/lib/modules/eic_groups/src/Controller/DiscussionController.php
@@ -6,6 +6,7 @@ use Drupal\comment\CommentInterface;
 use Drupal\comment\Entity\Comment;
 use Drupal\Component\Utility\Xss;
 use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Datetime\DateFormatter;
 use Drupal\Core\Datetime\DrupalDateTime;
@@ -125,6 +126,10 @@ class DiscussionController extends ControllerBase {
     $text = Xss::filter($content['text']);
     $tagged_users = $content['taggedUsers'] ?? NULL;
     $parent_id = $content['parentId'];
+
+    if ($node = Node::load($discussion_id)) {
+      Cache::invalidateTags($node->getCacheTags());
+    }
 
     $comment = Comment::create([
       'status' => CommentInterface::PUBLISHED,
@@ -340,6 +345,10 @@ class DiscussionController extends ControllerBase {
 
     if (!$comment instanceof CommentInterface) {
       return new JsonResponse('Cannot find comment entity', Response::HTTP_BAD_REQUEST);
+    }
+
+    if ($node = Node::load($discussion_id)) {
+      Cache::invalidateTags($node->getCacheTags());
     }
 
     try {

--- a/lib/modules/eic_statistics/eic_statistics.services.yml
+++ b/lib/modules/eic_statistics/eic_statistics.services.yml
@@ -14,4 +14,4 @@ services:
     calls:
       - [ setFileDownloadCounter, [ '@?eic_media_statistics.entity_file_download_count' ] ]
       - [ setGroupsHelper, [ '@?eic_groups.helper' ] ]
-    arguments: [ '@eic_statistics.storage', '@statistics.storage.node', '@flag', '@eic_comments.helper', '@eic_user.helper' ]
+    arguments: [ '@eic_statistics.storage', '@statistics.storage.node', '@flag', '@eic_comments.helper', '@eic_user.helper', '@flag.count' ]

--- a/lib/modules/eic_statistics/src/NodeStatisticsDatabaseStorage.php
+++ b/lib/modules/eic_statistics/src/NodeStatisticsDatabaseStorage.php
@@ -6,6 +6,7 @@ use Drupal\Core\Cache\Cache;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\State\StateInterface;
 use Drupal\eic_statistics\Event\PageViewCountUpdate;
+use Drupal\node\Entity\Node;
 use Drupal\statistics\NodeStatisticsDatabaseStorage as CoreNodeStatisticsDatabaseStorage;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -65,6 +66,9 @@ class NodeStatisticsDatabaseStorage extends CoreNodeStatisticsDatabaseStorage {
     $this->eventDispatcher->dispatch($event, PageViewCountUpdate::EVENT_NAME);
     // On each stat update we invalidate the stat cache for the given node and all nodes (this one isn't used for the moment)
     Cache::invalidateTags(["eic_statistics:node:$id"]);
+    if ($node = Node::load($id)) {
+      Cache::invalidateTags($node->getCacheTags());
+    }
 
     return $page_views;
   }

--- a/lib/modules/eic_statistics/src/StatisticsHelper.php
+++ b/lib/modules/eic_statistics/src/StatisticsHelper.php
@@ -9,6 +9,7 @@ use Drupal\eic_groups\EICGroupsHelper;
 use Drupal\eic_media_statistics\EntityFileDownloadCount;
 use Drupal\eic_topics\Constants\Topics;
 use Drupal\eic_user\UserHelper;
+use Drupal\flag\FlagCountManagerInterface;
 use Drupal\flag\FlagService;
 use Drupal\statistics\NodeStatisticsDatabaseStorage;
 
@@ -50,21 +51,28 @@ class StatisticsHelper {
    *
    * @var \Drupal\eic_comments\CommentsHelper
    */
-  protected $commentsHelper;
+  protected CommentsHelper $commentsHelper;
 
   /**
    * The eic_user.helper service.
    *
    * @var \Drupal\eic_user\UserHelper
    */
-  protected $userHelper;
+  protected UserHelper $userHelper;
 
   /**
    * The eic_user.helper service.
    *
    * @var \Drupal\eic_groups\EICGroupsHelper
    */
-  protected $groupsHelper;
+  protected EICGroupsHelper $groupsHelper;
+
+  /**
+   * The flag count manager service.
+   *
+   * @var FlagCountManagerInterface $flagCountManager
+   */
+  protected FlagCountManagerInterface $flagCountManager;
 
   /**
    * @param \Drupal\eic_statistics\StatisticsStorage $statistics_storage
@@ -72,19 +80,22 @@ class StatisticsHelper {
    * @param \Drupal\flag\FlagService $flag_service
    * @param \Drupal\eic_comments\CommentsHelper $comments_helper
    * @param \Drupal\eic_user\UserHelper $user_helper
+   * @param FlagCountManagerInterface $flag_count_manager
    */
   public function __construct(
     StatisticsStorage $statistics_storage,
     NodeStatisticsDatabaseStorage $node_statistics_storage,
     FlagService $flag_service,
     CommentsHelper $comments_helper,
-    UserHelper $user_helper
+    UserHelper $user_helper,
+    FlagCountManagerInterface $flag_count_manager
   ) {
     $this->statisticsStorage = $statistics_storage;
     $this->nodeStatisticsDatabaseStorage = $node_statistics_storage;
     $this->flagService = $flag_service;
     $this->commentsHelper = $comments_helper;
     $this->userHelper = $user_helper;
+    $this->flagCountManager = $flag_count_manager;
   }
 
   /**
@@ -149,7 +160,7 @@ class StatisticsHelper {
       if (!in_array($flag->id(), $countable_flags)) {
         continue;
       }
-      $result[$flag->id()] = count($this->flagService->getAllEntityFlaggings($entity));
+      $result[$flag->id()] = $this->flagCountManager->getEntityFlagCounts($entity)[$flag->id()];
     }
 
     // Downloads statistics.

--- a/lib/themes/eic_community/includes/preprocess/common.inc
+++ b/lib/themes/eic_community/includes/preprocess/common.inc
@@ -7,6 +7,7 @@
 
 use Drupal\comment\CommentInterface;
 use Drupal\comment\Entity\Comment;
+use Drupal\comment\Plugin\Field\FieldType\CommentItemInterface;
 use Drupal\Component\Serialization\Json;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Render\Markup;
@@ -233,8 +234,21 @@ function _eic_community_get_entity_stats(EntityInterface $entity, array $stat_ty
     }
 
     $item['icon']['type'] = 'custom';
-    $item['value'] = $value;
+    $item['value'] = $value ?: 0;
     $stats[$stat] = $item;
+  }
+
+  // If comment system is not open on the entity, do not show comments stats.
+  if (
+    array_key_exists('comments', $stats) &&
+    $entity->hasField('field_comments')
+  ) {
+    $field_comments = $entity->get('field_comments')->first()->getValue();
+    $status = intval($field_comments['status']);
+
+    if ($status !== CommentItemInterface::OPEN) {
+      unset($stats['comments']);
+    }
   }
 
   return $stats;
@@ -253,7 +267,11 @@ function _eic_community_get_entity_stats(EntityInterface $entity, array $stat_ty
  * @return \Drupal\comment\CommentInterface|null
  *   The comment object of NULL if not found.
  */
-function _eic_community_get_entity_last_comment(EntityInterface $entity, $first_level_only = TRUE, $published_only = TRUE) {
+function _eic_community_get_entity_last_comment(
+  EntityInterface $entity,
+  $first_level_only = TRUE,
+  $published_only = TRUE
+) {
   $query = \Drupal::entityQuery('comment')
     ->condition('entity_id', $entity->id())
     ->condition('entity_type', $entity->getEntityTypeId());
@@ -318,7 +336,11 @@ function _eic_community_process_term_parents_tree(TermInterface $term, array $te
   }
 
   if (!empty($loaded_parents)) {
-    $terms[$parent->id()]['items'] = _eic_community_process_term_parents_tree($term, $terms[$parent->id()]['items'], $loaded_parents);
+    $terms[$parent->id()]['items'] = _eic_community_process_term_parents_tree(
+      $term,
+      $terms[$parent->id()]['items'],
+      $loaded_parents
+    );
   }
   else {
     $terms[$parent->id()]['items'][$term->id()]['term'] = $term;


### PR DESCRIPTION
How to test:

- [x] Go to organisation detail
- [x] Add news and open comments
- [x] Go to organisation detail and check the news block
- [x] Check if you have views, likes and comment stats as 0 (or 1 for view)
- [x] Like the content, get back to the block news in organisation and verify it correctly increased (without rebuild cache)
- [x] Now try to comment, do the same check
- [x] Close the comments in news and verify the stats dissapeared