### PR TITLE
EICNET-2187: Fix issue with double base path in views more links.

### DIFF
--- a/lib/modules/eic_topics/eic_topics.module
+++ b/lib/modules/eic_topics/eic_topics.module
@@ -140,11 +140,12 @@ function eic_topics_views_pre_render(ViewExecutable $view) {
   $params = SearchHelper::buildSolrQueryParams($params);
 
   if ($route) {
-    $url = Url::fromRoute($route, [], ['query' => $params])->toString();
+    $url = Url::fromRoute($route, [], ['query' => $params, 'absolute' => TRUE])->toString();
     $view->display_handler->setOption('link_url', $url);
   }
   elseif ($url) {
     $url->setOption('query', $params);
+    $url->setAbsolute(TRUE);
     $view->display_handler->setOption('link_url', $url->toString());
   }
 }


### PR DESCRIPTION
### Tests

- [ ] Make sure you are using the site with /community (you can use http://localhost:8081/community/)
- [ ] Go to a Topic page
- [ ] Make sure the more links don't have a double base path (like `/community/community/<link>`)