### PR TITLE
[EICNET]fix: Set default order for news in organisation by created date

### DIFF
--- a/config/sync/views.view.organisation_content.yml
+++ b/config/sync/views.view.organisation_content.yml
@@ -543,6 +543,22 @@ display:
     display_plugin: block
     position: 1
     display_options:
+      sorts:
+        content_created:
+          id: content_created
+          table: search_api_index_global
+          field: content_created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+      defaults:
+        sorts: false
       display_description: ''
       display_extenders: {  }
     cache_metadata:


### PR DESCRIPTION
How to test it:

- [x] Go to organisation detail
- [x] Add news
- [x] Verify it's ordered by created date DESC