### PR TITLE
Feature/eicnet 1303 smed taxonomy organisation size

### DIFF
--- a/config/sync/core.entity_form_display.taxonomy_term.organisation_sizes.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.organisation_sizes.default.yml
@@ -1,0 +1,60 @@
+uuid: 22b84cda-99a0-41dd-bd11-48790e4675d1
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.organisation_sizes.field_smed_id
+    - taxonomy.vocabulary.organisation_sizes
+  module:
+    - path
+    - text
+id: taxonomy_term.organisation_sizes.default
+targetEntityType: taxonomy_term
+bundle: organisation_sizes
+mode: default
+content:
+  description:
+    type: text_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_smed_id:
+    type: string_textfield
+    weight: 101
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 100
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+hidden: {  }

--- a/config/sync/core.entity_view_display.taxonomy_term.organisation_sizes.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.organisation_sizes.default.yml
@@ -1,0 +1,32 @@
+uuid: df8264a9-eb96-4b5d-a801-48b360711eec
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.organisation_sizes.field_smed_id
+    - taxonomy.vocabulary.organisation_sizes
+  module:
+    - text
+id: taxonomy_term.organisation_sizes.default
+targetEntityType: taxonomy_term
+bundle: organisation_sizes
+mode: default
+content:
+  description:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_smed_id:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  langcode: true
+  search_api_excerpt: true

--- a/config/sync/field.field.taxonomy_term.organisation_sizes.field_smed_id.yml
+++ b/config/sync/field.field.taxonomy_term.organisation_sizes.field_smed_id.yml
@@ -1,0 +1,19 @@
+uuid: 28c1f922-dfc4-4d71-b79c-a6a5febc49a2
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_smed_id
+    - taxonomy.vocabulary.organisation_sizes
+id: taxonomy_term.organisation_sizes.field_smed_id
+field_name: field_smed_id
+entity_type: taxonomy_term
+bundle: organisation_sizes
+label: 'SME Dashboard ID'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/language.content_settings.taxonomy_term.organisation_sizes.yml
+++ b/config/sync/language.content_settings.taxonomy_term.organisation_sizes.yml
@@ -1,0 +1,11 @@
+uuid: 158bdfbb-981a-4fd4-b293-48d0f05b5080
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.organisation_sizes
+id: taxonomy_term.organisation_sizes
+target_entity_type_id: taxonomy_term
+target_bundle: organisation_sizes
+default_langcode: site_default
+language_alterable: false

--- a/config/sync/migrate_plus.migration.smed_organisation_sizes.yml
+++ b/config/sync/migrate_plus.migration.smed_organisation_sizes.yml
@@ -1,0 +1,52 @@
+uuid: 49eb7697-e636-47e7-b89e-b3f52f9c9bd9
+langcode: en
+status: true
+dependencies: {  }
+id: smed_organisation_sizes
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags:
+  - eic_smed_api_authentication
+migration_group: eic_smed_taxonomy
+label: 'SMED - Organisation sizes'
+source:
+  plugin: eic_smed_url
+  authentication:
+    plugin: basic
+    username: xxx
+    password: xxx
+  urls: {  }
+  data_fetcher_plugin: eic_http_smed_taxonomy_post
+  taxonomy_vocabulary_smed_id: Sizes
+  data_parser_plugin: json
+  include_raw_data: true
+  track_changes: true
+  item_selector: Taxonomy/Option
+  ids:
+    value:
+      type: string
+  fields:
+    -
+      name: name
+      label: Name
+      selector: Name
+    -
+      name: value
+      label: Value
+      selector: Value
+process:
+  name:
+    -
+      plugin: get
+      source: name
+  field_smed_id:
+    -
+      plugin: get
+      source: value
+destination:
+  plugin: 'entity:taxonomy_term'
+  default_bundle: organisation_sizes
+migration_dependencies:
+  required: {  }
+  optional: {  }

--- a/config/sync/taxonomy.vocabulary.organisation_sizes.yml
+++ b/config/sync/taxonomy.vocabulary.organisation_sizes.yml
@@ -1,0 +1,8 @@
+uuid: 19c5728f-32c8-4872-9885-50b2cf44895a
+langcode: en
+status: true
+dependencies: {  }
+name: 'Organisation sizes'
+vid: organisation_sizes
+description: ''
+weight: 0

--- a/lib/modules/eic_webservices/config/install/migrate_plus.migration.smed_organisation_sizes.yml
+++ b/lib/modules/eic_webservices/config/install/migrate_plus.migration.smed_organisation_sizes.yml
@@ -1,0 +1,47 @@
+id: smed_organisation_sizes
+label: SMED - Organisation sizes
+migration_group: eic_smed_taxonomy
+migration_tags:
+  - eic_smed_api_authentication
+source:
+  plugin: eic_smed_url
+  authentication:
+    plugin: basic
+    # Username and password will be set automatically by the eic_smed_url plugin
+    # we just keep them here with dummy data for reference.
+    username: xxx
+    password: xxx
+  # The URL will be set automatically by the eic_smed_url plugin, we just keep
+  # it here with dummy data for reference.
+  urls: { }
+  data_fetcher_plugin: eic_http_smed_taxonomy_post
+  taxonomy_vocabulary_smed_id: Sizes
+  data_parser_plugin: json
+  include_raw_data: true
+  track_changes: true
+  item_selector: 'Taxonomy/Option'
+  ids:
+    value:
+      type: string
+  fields:
+    -
+      name: name
+      label: 'Name'
+      selector: Name
+    -
+      name: value
+      label: 'Value'
+      selector: Value
+process:
+  name:
+    - plugin: get
+      source: name
+  field_smed_id:
+    - plugin: get
+      source: value
+destination:
+  plugin: entity:taxonomy_term
+  default_bundle: organisation_sizes
+migration_dependencies:
+  required: { }
+  optional: { }


### PR DESCRIPTION
### Tests

- [x] Run `drush mim smed_organisation_sizes`
- [x] Go to `/admin/structure/taxonomy/manage/organisation_sizes/overview`
- [x] Make sure you have items there (should be 5 items)
- [x] Edit the items, make sure they have a value in the SME Dashboard ID field


### Remarks

- To configure the connection to the SMED Taxonomy webservice, please refer to 
  - https://github.com/EIC-EA/EIC-community-D8/blob/develop/lib/modules/eic_webservices/README.md
  - And https://citnet.tech.ec.europa.eu/CITnet/confluence/display/EICNET/WS+-+Taxonomy+webservice#WSTaxonomywebservice-Introduction to get the credentials