### PR TITLE
EICNET-2135: TU cannot view comments of content in public groups

### DIFF
--- a/lib/modules/eic_deploy/eic_deploy.install
+++ b/lib/modules/eic_deploy/eic_deploy.install
@@ -193,3 +193,19 @@ function eic_deploy_update_9004(&$sandbox) {
     $groupPermissions->save();
   }
 }
+
+/**
+ * Adds group permission 'view comments' to group outsiders.
+ */
+function eic_deploy_update_9005(&$sandbox) {
+  $new_permissions = [
+    'view comments',
+  ];
+
+  $roles = [
+    'group-outsider',
+    'event-outsider',
+  ];
+
+  eic_deploy_add_group_permissions_to_role($new_permissions, $roles);
+}

--- a/lib/modules/eic_deploy/eic_deploy.module
+++ b/lib/modules/eic_deploy/eic_deploy.module
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * @file
+ * Primary module hooks for EIC Deploy module.
+ */
+
+use Drupal\group_permissions\Entity\GroupPermission;
+
+/**
+ * Adds group permissions to a group role.
+ */
+function eic_deploy_add_group_permissions_to_role(array $new_permissions = [], array $roles = [], array $group_visibilities = ['public']) {
+  if (empty($roles) || empty($new_permissions)) {
+    return;
+  }
+
+  $group_permissions = \Drupal::entityQuery('group_permission')->execute();
+
+  $group_permissions = GroupPermission::loadMultiple($group_permissions);
+
+  $group_visibility_storage = \Drupal::service('oec_group_flex.group_visibility.storage');
+
+  /** @var \Drupal\group_permissions\Entity\GroupPermission $group_permission */
+  foreach ($group_permissions as &$group_permission) {
+    $permissions = $group_permission->getPermissions();
+
+    /** @var \Drupal\group\Entity\GroupInterface $group */
+    $group = $group_permission->getGroup();
+
+    $group_visibility = $group_visibility_storage->load($group->id());
+
+    if (
+      !in_array($group->getGroupType()->id(), ['group', 'event']) ||
+      empty($permissions) ||
+      !in_array($group_visibility->getType(), $group_visibilities)
+    ) {
+      continue;
+    }
+
+    foreach ($permissions as $key => &$permission) {
+      if (!in_array($key, $roles)) {
+        continue;
+      }
+
+      foreach ($new_permissions as &$new_permission) {
+        if (in_array($new_permission, $permission)) {
+          continue;
+        }
+
+        $permission[] = $new_permission;
+      }
+    }
+
+    $group_permission->setPermissions($permissions);
+    $group_permission->setNewRevision();
+    $group_permission->setRevisionUserId(1);
+    $group_permission->setRevisionCreationTime(time());
+    $group_permission->setRevisionLogMessage(t('Set default permissions for outsiders.'));
+
+    if (count($group_permission->validate()) > 0) {
+      continue;
+    }
+
+    $group_permission->save();
+
+    // Save the group entity to reset the cache tags.
+    $group->save();
+  }
+}

--- a/lib/modules/oec_group_flex/src/Plugin/GroupVisibility/PublicVisibility.php
+++ b/lib/modules/oec_group_flex/src/Plugin/GroupVisibility/PublicVisibility.php
@@ -36,6 +36,10 @@ class PublicVisibility extends PublicVisibilityBase {
     if ($groupType->getAnonymousRole()->hasPermission('view group')) {
       $anonymousPermissions = [$groupType->getAnonymousRoleId() => $group_view_permissions];
     }
+
+    // Add view comments permission to outsiders and group members.
+    $group_view_permissions[] = 'view comments';
+
     return array_merge($anonymousPermissions, [
       $groupType->getOutsiderRoleId() => $group_view_permissions,
       $groupType->getMemberRoleId() => $group_view_permissions,

--- a/lib/themes/eic_community/sass/compositions/_comment-overview.scss
+++ b/lib/themes/eic_community/sass/compositions/_comment-overview.scss
@@ -1,7 +1,7 @@
 .ecl-comment-overview {
   $node: &;
 
-  @include ecl-media-breakpoint-down('xs') {
+  @include ecl-media-breakpoint-down("xs") {
     .ecl-container {
       padding: 0;
     }
@@ -12,17 +12,15 @@
     transition: padding 200ms ease-in-out;
 
     #{$node}--is-pending & {
-      padding-bottom: #{map-get($ecl-media, '4xs') * 3};
+      padding-bottom: #{map-get($ecl-media, "4xs") * 3};
     }
   }
-
-
 
   &__form-wrapper,
   &__items,
   &__item {
     padding-top: 0;
-    //margin: map-get($ecl-spacing, 'xl') 0;
+    margin: map-get($ecl-spacing, "xl") 0 0;
     transition: opacity 200ms ease-in-out;
 
     &:first-child {
@@ -40,15 +38,15 @@
 
   &__form-wrapper,
   &__item {
-    padding: map-get($ecl-spacing, 'xl') ;
-    margin: map-get($ecl-spacing, 'xl') 0;
-    background-color: map-get($ecl-colors, 'white');
+    padding: map-get($ecl-spacing, "xl");
+    margin: map-get($ecl-spacing, "xl") 0 0;
+    background-color: map-get($ecl-colors, "white");
   }
 
   &__form-wrapper {
-    padding: map-get($ecl-spacing, 'xl');
-    @include ecl-media-breakpoint-down('md') {
-      padding: map-get($ecl-spacing, 'l');
+    padding: map-get($ecl-spacing, "xl");
+    @include ecl-media-breakpoint-down("md") {
+      padding: map-get($ecl-spacing, "l");
       & .ecl-comment__author {
         display: none;
       }
@@ -71,15 +69,11 @@
     left: 50%;
     bottom: 0;
     transform: translateX(-50%);
-    width: map-get($ecl-media, '4xs');
-    height: map-get($ecl-media, '4xs');
+    width: map-get($ecl-media, "4xs");
+    height: map-get($ecl-media, "4xs");
     opacity: 0;
     visibility: hidden;
-    transition:
-      bottom 200ms ease-in-out 0ms,
-      opacity 200ms ease-in-out 0ms,
-      visibility 0ms ease-in-out 200ms
-    ;
+    transition: bottom 200ms ease-in-out 0ms, opacity 200ms ease-in-out 0ms, visibility 0ms ease-in-out 200ms;
 
     &::before,
     &::after {
@@ -91,30 +85,27 @@
       height: 100%;
       left: 50%;
       border-radius: 50%;
-      margin-left: #{0 - map-get($ecl-media, '4xs') / 2};
-      margin-top: #{0 - map-get($ecl-media, '4xs') / 2};
-      animation: scale-up-and-down 1.0s infinite ease-in-out;
+      margin-left: #{0 - map-get($ecl-media, "4xs") / 2};
+      margin-top: #{0 - map-get($ecl-media, "4xs") / 2};
+      animation: scale-up-and-down 1s infinite ease-in-out;
     }
 
     &::before {
       opacity: 0.5;
-      background-color: map-get($ecl-colors, 'blue-100');
+      background-color: map-get($ecl-colors, "blue-100");
     }
 
     &::after {
       opacity: 0.5;
-      background-color: map-get($ecl-colors, 'blue-50');
+      background-color: map-get($ecl-colors, "blue-50");
       animation-delay: -0.5s;
     }
 
     #{$node}--is-pending & {
       opacity: 1;
       visibility: visible;
-      bottom: map-get($ecl-media, '4xs');
-      transition:
-        bottom 200ms ease-in-out 0ms,
-        opacity 200ms ease-in-out 0ms,
-        visibility 0ms ease-in-out 0ms;
+      bottom: map-get($ecl-media, "4xs");
+      transition: bottom 200ms ease-in-out 0ms, opacity 200ms ease-in-out 0ms, visibility 0ms ease-in-out 0ms;
     }
   }
 
@@ -122,12 +113,12 @@
   &__no-items {
     text-align: center;
     font-weight: $ecl-font-weight-bold;
-    @include ecl-responsive-font('introduction');
-    margin: map-get($ecl-spacing, 'xl') 0;
-    color: ecl-typography('color', 'meta');
+    @include ecl-responsive-font("introduction");
+    margin: map-get($ecl-spacing, "xl") 0;
+    color: ecl-typography("color", "meta");
 
-    @include ecl-media-breakpoint-up('md') {
-      margin: map-get($ecl-spacing, '2xl') 0;
+    @include ecl-media-breakpoint-up("md") {
+      margin: map-get($ecl-spacing, "2xl") 0;
     }
 
     &:first-child {
@@ -143,7 +134,7 @@
     @extend .ecl-u-type-heading-3;
 
     margin-top: 0;
-    @include ecl-media-breakpoint-down('md') {
+    @include ecl-media-breakpoint-down("md") {
       padding-left: 1rem;
     }
   }


### PR DESCRIPTION
### Fixes

- Adds "view comments" permission to outsiders in public groups;
- Create hook_update to update all existing groups.

### Tests

- [x] As TU (non-member), go to a discussion of a public group
- [x] Make sure you can see the comments but you can't post new comments or reply

### Todo

- [x] We need to add a bit more margin between the "Replies" title and the list of comments

### Remarks

- As TU you will still see the reply button in the comments but that will be fixed in PR #1288