### PR TITLE
EICNET-2196: Update book page URL pattern and add missing variables to the Theme

### DIFF
--- a/config/sync/pathauto.pattern.books.yml
+++ b/config/sync/pathauto.pattern.books.yml
@@ -7,12 +7,12 @@ dependencies:
 id: books
 label: 'Node - Books'
 type: 'canonical_entities:node'
-pattern: '[node:title]'
+pattern: '[node:node_book_parent_url]/[node:title]'
 selection_criteria:
-  8884be28-c3f4-45e4-b523-2133eb766027:
+  843c6cb1-7ffb-477a-9375-d7b4ea045943:
     id: node_type
     negate: false
-    uuid: 8884be28-c3f4-45e4-b523-2133eb766027
+    uuid: 843c6cb1-7ffb-477a-9375-d7b4ea045943
     context_mapping:
       node: node
     bundles:

--- a/lib/themes/eic_community/includes/preprocess/blocks/block--eic-content-book-navigation.inc
+++ b/lib/themes/eic_community/includes/preprocess/blocks/block--eic-content-book-navigation.inc
@@ -5,6 +5,9 @@
  * Contains preprocessor for block__eic_content_book_navigation.
  */
 
+use Drupal\node\Entity\Node;
+use Drupal\node\NodeInterface;
+
 /**
  * Implements hook_preprocess_block__eic_content_book_navigation().
  */
@@ -12,63 +15,25 @@ function eic_community_preprocess_block__eic_content_book_navigation(&$variables
   $title = '';
   $node = \Drupal::routeMatch()->getParameter('node');
 
-  if ($node instanceof Drupal\node\NodeInterface) {
-    $parent = Drupal\node\Entity\Node::load($node->book['bid']);
+  if ($node instanceof NodeInterface) {
+    $parent = Node::load($node->book['bid']);
     $title = $parent->getTitle();
   }
 
   $variables['title'] = $title;
-  // Create hierarchical list of links maximum 3 levels deep.
-  $items = [];
+
   $links = array_filter($variables['content'], function ($value, $key) {
     return is_int($key);
   }, ARRAY_FILTER_USE_BOTH);
-  $current_path = \Drupal::service('path.current')->getPath();
-  $path_alias = \Drupal::service('path_alias.manager')->getAliasByPath($current_path);
 
+  // Get trail urls related to the current path.
+  $trail_urls = \Drupal::service('menu_trail_by_path.path_helper')->getUrls();
+
+  // Create hierarchical list of links maximum 3 levels deep.
+  $items = [];
   foreach ($links as $link) {
-    foreach ($link['#items'] as $link_item) {
-      $sub_items = [];
-
-      if (count($link_item['below']) > 0) {
-        foreach ($link_item['below'] as $sub_item) {
-          $sub_sub_items = [];
-
-          foreach ($sub_item['below'] as $sub_sub_item) {
-            $sub_sub_items[] = [
-              'link' => [
-                'label' => $sub_sub_item['title'],
-                'path' => $sub_sub_item['url'],
-              ],
-            ];
-          }
-
-          $sub_items[] = [
-            'link' => [
-              'label' => $sub_item['title'],
-              'path' => $sub_item['url'],
-            ],
-            'items' => $sub_sub_items,
-          ];
-        }
-      }
-
-      $item = [
-        'link' => [
-          'label' => $link_item['title'],
-          'path' => $link_item['url'],
-        ],
-        'items' => $sub_items,
-      ];
-
-      if (is_int(strpos($path_alias, $link_item['url']->toString()))) {
-        $item['is_active'] = TRUE;
-      }
-
-      $items[] = $item;
-    }
+    $items = $items + eic_wiki_book_navigation_format_item($link['#items'], $trail_urls);
   }
 
   $variables['items'] = $items;
-
 }


### PR DESCRIPTION
### Improvements

- Update URL pattern for Book pages;
- Fix book navigation preprocess in order to re-use the logic of wiki page book navigation.

### Test

- [x] As SA/SCM, create a new book page and assign a book in the book outline tab of the edit form
- [x] Create some child book pages
- [x] Check if the navigation is showing according to the design

### Notes for FE devs

- The help and guidance book navigation should have the same structure as seen on wiki pages.