### PR TITLE
[EICNET-2179]feat: Set correct topic name field in solr to prefilter on

### DIFF
--- a/lib/modules/eic_topics/eic_topics.module
+++ b/lib/modules/eic_topics/eic_topics.module
@@ -87,7 +87,7 @@ function eic_topics_views_pre_render(ViewExecutable $view) {
     case 'groups':
       $route = 'eic_search.groups';
       $params = [
-        'ss_group_topic_name' => $term->label(),
+        'sm_group_topic_name' => $term->label(),
       ];
       break;
 


### PR DESCRIPTION
How to test:

- [x] Go to a topic detail page
- [x] Click on show more in related groups
- [x] You should have the list of groups prefiltered by topic