### PR TITLE
Feature/eicnet 1291 smed taxonomy event types

### DIFF
--- a/config/sync/core.entity_form_display.taxonomy_term.global_event_type.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.global_event_type.default.yml
@@ -1,0 +1,68 @@
+uuid: bd8c198f-5cff-4678-89d7-6c9f7fb933a5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.global_event_type.field_display_to_users
+    - field.field.taxonomy_term.global_event_type.field_smed_id
+    - taxonomy.vocabulary.global_event_type
+  module:
+    - path
+    - text
+id: taxonomy_term.global_event_type.default
+targetEntityType: taxonomy_term
+bundle: global_event_type
+mode: default
+content:
+  description:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_display_to_users:
+    type: boolean_checkbox
+    weight: 4
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_smed_id:
+    type: string_textfield
+    weight: 3
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 6
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+hidden: {  }

--- a/config/sync/core.entity_view_display.taxonomy_term.global_event_type.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.global_event_type.default.yml
@@ -1,0 +1,43 @@
+uuid: f8306de3-2d71-4c2c-bac4-977db58bad26
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.global_event_type.field_display_to_users
+    - field.field.taxonomy_term.global_event_type.field_smed_id
+    - taxonomy.vocabulary.global_event_type
+  module:
+    - text
+id: taxonomy_term.global_event_type.default
+targetEntityType: taxonomy_term
+bundle: global_event_type
+mode: default
+content:
+  description:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_display_to_users:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_smed_id:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  langcode: true
+  search_api_excerpt: true

--- a/config/sync/field.field.group.event.field_vocab_event_type.yml
+++ b/config/sync/field.field.group.event.field_vocab_event_type.yml
@@ -5,7 +5,7 @@ dependencies:
   config:
     - field.storage.group.field_vocab_event_type
     - group.type.event
-    - taxonomy.vocabulary.event_type
+    - taxonomy.vocabulary.global_event_type
 id: group.event.field_vocab_event_type
 field_name: field_vocab_event_type
 entity_type: group
@@ -20,7 +20,7 @@ settings:
   handler: 'default:taxonomy_term'
   handler_settings:
     target_bundles:
-      event_type: event_type
+      global_event_type: global_event_type
     sort:
       field: name
       direction: asc

--- a/config/sync/field.field.taxonomy_term.global_event_type.field_display_to_users.yml
+++ b/config/sync/field.field.taxonomy_term.global_event_type.field_display_to_users.yml
@@ -1,0 +1,23 @@
+uuid: b3ecc309-6a1f-4fc8-98a9-5a14ea36c509
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_display_to_users
+    - taxonomy.vocabulary.global_event_type
+id: taxonomy_term.global_event_type.field_display_to_users
+field_name: field_display_to_users
+entity_type: taxonomy_term
+bundle: global_event_type
+label: 'Display to users?'
+description: 'Check this box if you want this term to be displayed and selectable by end users on the form.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.field.taxonomy_term.global_event_type.field_smed_id.yml
+++ b/config/sync/field.field.taxonomy_term.global_event_type.field_smed_id.yml
@@ -1,0 +1,19 @@
+uuid: 6f3a80ed-1511-47bb-adb1-4b80b24d4f2e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_smed_id
+    - taxonomy.vocabulary.global_event_type
+id: taxonomy_term.global_event_type.field_smed_id
+field_name: field_smed_id
+entity_type: taxonomy_term
+bundle: global_event_type
+label: 'SME Dashboard ID'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.taxonomy_term.field_display_to_users.yml
+++ b/config/sync/field.storage.taxonomy_term.field_display_to_users.yml
@@ -1,0 +1,18 @@
+uuid: aaa8b1a5-fec8-4c04-99f7-6060ac3ab5b0
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_display_to_users
+field_name: field_display_to_users
+entity_type: taxonomy_term
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/language.content_settings.taxonomy_term.global_event_type.yml
+++ b/config/sync/language.content_settings.taxonomy_term.global_event_type.yml
@@ -1,0 +1,11 @@
+uuid: 1812afd7-1da8-45af-b219-9f655b2004a8
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.global_event_type
+id: taxonomy_term.global_event_type
+target_entity_type_id: taxonomy_term
+target_bundle: global_event_type
+default_langcode: site_default
+language_alterable: false

--- a/config/sync/migrate_plus.migration.smed_event_types.yml
+++ b/config/sync/migrate_plus.migration.smed_event_types.yml
@@ -1,0 +1,52 @@
+uuid: 276d692b-2923-45f4-93a5-d21473d0e615
+langcode: en
+status: true
+dependencies: {  }
+id: smed_event_types
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags:
+  - eic_smed_api_authentication
+migration_group: eic_smed_taxonomy
+label: 'SMED - Event types'
+source:
+  plugin: eic_smed_url
+  authentication:
+    plugin: basic
+    username: xxx
+    password: xxx
+  urls: {  }
+  data_fetcher_plugin: eic_http_smed_taxonomy_post
+  taxonomy_vocabulary_smed_id: EventSets
+  data_parser_plugin: json
+  include_raw_data: true
+  track_changes: true
+  item_selector: Taxonomy/Group/1/Selector/Option
+  ids:
+    value:
+      type: string
+  fields:
+    -
+      name: name
+      label: Name
+      selector: Name
+    -
+      name: value
+      label: Value
+      selector: Value
+process:
+  name:
+    -
+      plugin: get
+      source: name
+  field_smed_id:
+    -
+      plugin: get
+      source: value
+destination:
+  plugin: 'entity:taxonomy_term'
+  default_bundle: global_event_type
+migration_dependencies:
+  required: {  }
+  optional: {  }

--- a/config/sync/taxonomy.vocabulary.global_event_type.yml
+++ b/config/sync/taxonomy.vocabulary.global_event_type.yml
@@ -1,0 +1,8 @@
+uuid: ecc2b11d-220b-4bd6-b8fc-22cd582b9c64
+langcode: en
+status: true
+dependencies: {  }
+name: 'Global Event type'
+vid: global_event_type
+description: 'This taxonomy is synced from SMED'
+weight: 0

--- a/lib/modules/eic_events/eic_events.module
+++ b/lib/modules/eic_events/eic_events.module
@@ -1,6 +1,13 @@
 <?php
 
+/**
+ * @file
+ * Primary module hooks for EIC Events module.
+ */
+
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\eic_events\Constants\Event;
+use Drupal\eic_events\Hooks\FormOperations;
 
 /**
  * Implements hook_cron().
@@ -19,4 +26,12 @@ function eic_events_cron() {
 
     \Drupal::state()->set(Event::CRON_STATE_ID_LAST_REQUEST_TIME, $now);
   }
+}
+
+/**
+ * Implements hook_form_BASE_FORM_ID_alter().
+ */
+function eic_events_form_group_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  \Drupal::classResolver(FormOperations::class)
+    ->formGroupFormAlter($form, $form_state, $form_id);
 }

--- a/lib/modules/eic_events/src/Constants/Event.php
+++ b/lib/modules/eic_events/src/Constants/Event.php
@@ -40,6 +40,13 @@ final class Event {
   const GROUP_MEMBER_ROLE = 'event-member';
 
   /**
+   * The Group event type vocabulary machine name.
+   *
+   * @var string
+   */
+  const GROUP_EVENT_TYPE_VOCABULARY_NAME = 'global_event_type';
+
+  /**
    * @return array
    */
   public static function getStateLabelsMapping(): array {

--- a/lib/modules/eic_events/src/Hooks/FormOperations.php
+++ b/lib/modules/eic_events/src/Hooks/FormOperations.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Drupal\eic_events\Hooks;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\eic_events\Constants\Event;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class FormAlter.
+ *
+ * Implementations for entity hooks.
+ */
+class FormOperations implements ContainerInjectionInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a new FormOperations object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * Implements hook_form_BASE_FORM_ID_alter().
+   */
+  public function formGroupFormAlter(&$form, FormStateInterface $form_state, $form_id) {
+    $this->handleEventTypeField($form, $form_state, $form_id);
+  }
+
+  /**
+   * Handles the field_vocab_event_type of the form.
+   *
+   * @param array $form
+   *   The form array.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state object.
+   * @param string $form_id
+   *   The form ID.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  protected function handleEventTypeField(array &$form, FormStateInterface $form_state, $form_id) {
+    if (!isset($form['field_vocab_event_type'])) {
+      return;
+    }
+
+    // Get the entity.
+    /** @var \Drupal\Core\Entity\EntityInterface $entity */
+    $entity = $form_state->getFormObject()->getEntity();
+
+    // Check if it is an event.
+    if ($entity->bundle() != 'event') {
+      return;
+    }
+
+    // We need to hide terms that are not to be displayed to end users.
+    $terms = $this->entityTypeManager->getStorage('taxonomy_term')->loadByProperties(
+      ['vid' => Event::GROUP_EVENT_TYPE_VOCABULARY_NAME]
+    );
+    foreach ($terms as $term) {
+      if ($term->field_display_to_users->value != 1) {
+        unset($form['field_vocab_event_type']['widget']['#options'][$term->id()]);
+      }
+    }
+  }
+
+}

--- a/lib/modules/eic_webservices/config/install/migrate_plus.migration.smed_event_types.yml
+++ b/lib/modules/eic_webservices/config/install/migrate_plus.migration.smed_event_types.yml
@@ -1,0 +1,47 @@
+id: smed_event_types
+label: SMED - Event types
+migration_group: eic_smed_taxonomy
+migration_tags:
+  - eic_smed_api_authentication
+source:
+  plugin: eic_smed_url
+  authentication:
+    plugin: basic
+    # Username and password will be set automatically by the eic_smed_url plugin
+    # we just keep them here with dummy data for reference.
+    username: xxx
+    password: xxx
+  # The URL will be set automatically by the eic_smed_url plugin, we just keep
+  # it here with dummy data for reference.
+  urls: { }
+  data_fetcher_plugin: eic_http_smed_taxonomy_post
+  taxonomy_vocabulary_smed_id: EventSets
+  data_parser_plugin: json
+  include_raw_data: true
+  track_changes: true
+  item_selector: 'Taxonomy/Group/1/Selector/Option'
+  ids:
+    value:
+      type: string
+  fields:
+    -
+      name: name
+      label: 'Name'
+      selector: Name
+    -
+      name: value
+      label: 'Value'
+      selector: Value
+process:
+  name:
+    - plugin: get
+      source: name
+  field_smed_id:
+    - plugin: get
+      source: value
+destination:
+  plugin: entity:taxonomy_term
+  default_bundle: global_event_type
+migration_dependencies:
+  required: { }
+  optional: { }


### PR DESCRIPTION
### Tests

- [x] Run `drush mim smed_event_types`
- [x] Go to `/admin/structure/taxonomy/manage/global_event_type/overview`
- [x] Make sure you have items there (should be 14 items)
- [x] Edit the items, make sure they have a value in the SME Dashboard ID field
- [x] Edit some of the terms and check the "Display to users?" checkbox, save
- [x] Edit/create a global event and make sure only the terms you checked with "Display to users?" are displayed

### Remarks

- To configure the connection to the SMED Taxonomy webservice, please refer to 
  - https://github.com/EIC-EA/EIC-community-D8/blob/develop/lib/modules/eic_webservices/README.md
  - And https://citnet.tech.ec.europa.eu/CITnet/confluence/display/EICNET/WS+-+Taxonomy+webservice#WSTaxonomywebservice-Introduction to get the credentials
