### PR TITLE
[EICNET-1990]fix: Use entity reference autocomplete widget for file document topics

### DIFF
--- a/config/sync/core.entity_form_display.media.eic_document.default.yml
+++ b/config/sync/core.entity_form_display.media.eic_document.default.yml
@@ -45,10 +45,14 @@ content:
       progress_indicator: throbber
     third_party_settings: {  }
   field_vocab_topics:
-    type: options_select
+    type: entity_reference_autocomplete
     weight: 3
     region: content
-    settings: {  }
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   langcode:
     type: language_select


### PR DESCRIPTION
How to test it:

- [x] Create a document content type and add file
- [x] Check if you can select multiple topics