### PR TITLE
[EICNET-2105]fix: Do not render empty content_after region

### DIFF
--- a/lib/modules/eic_groups/templates/eic-group-comments-from-discussion.html.twig
+++ b/lib/modules/eic_groups/templates/eic-group-comments-from-discussion.html.twig
@@ -7,7 +7,7 @@
         <div class="ecl-container">
           <div class="ecl-editorial-article__wrapper">
             <div class="ecl-editorial-article__content">
-              <div id="comments-discussion" data-highlighted-comment="{{ highlighted_comment}}" data-discussion-id="{{ discussion_id }}"></div>
+              <div id="comments-discussion" data-highlighted-comment="{{ highlighted_comment}}" data-discussion-id="{{ discussion_id }}">{{ 'Comments' | t }}</div>
             </div>
             <aside class="ecl-editorial-article__aside">
               <div class="ecl-editorial-article__aside-wrapper">

--- a/lib/themes/eic_community/patterns/layout/base.html.twig
+++ b/lib/themes/eic_community/patterns/layout/base.html.twig
@@ -90,7 +90,7 @@
         {% endif %}
       </div>
 
-      {% if output_content_after %}
+      {% if output_content_after|render|striptags|trim is not empty %}
         <div class="ecl-base-layout__content-after">
           {{ output_content_after }}
         </div>


### PR DESCRIPTION
## To Test

- [x] Go to a news page as anonymous
- [x] You shouldn't have a space between the the comments block and the footer