### PR TITLE
Feature/eicnet 237 smed taxonomy regions countries

### DIFF
--- a/config/sync/core.entity_form_display.taxonomy_term.target_markets.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.target_markets.default.yml
@@ -1,0 +1,60 @@
+uuid: 9b245a3d-75eb-47af-8c46-31ab3d926887
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.target_markets.field_smed_id
+    - taxonomy.vocabulary.target_markets
+  module:
+    - path
+    - text
+id: taxonomy_term.target_markets.default
+targetEntityType: taxonomy_term
+bundle: target_markets
+mode: default
+content:
+  description:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_smed_id:
+    type: string_textfield
+    weight: 3
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 4
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 5
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+hidden: {  }

--- a/config/sync/core.entity_view_display.taxonomy_term.target_markets.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.target_markets.default.yml
@@ -1,0 +1,32 @@
+uuid: 269dc930-8d4c-4552-80b4-081b963d44ab
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.target_markets.field_smed_id
+    - taxonomy.vocabulary.target_markets
+  module:
+    - text
+id: taxonomy_term.target_markets.default
+targetEntityType: taxonomy_term
+bundle: target_markets
+mode: default
+content:
+  description:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_smed_id:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  langcode: true
+  search_api_excerpt: true

--- a/config/sync/field.field.taxonomy_term.target_markets.field_smed_id.yml
+++ b/config/sync/field.field.taxonomy_term.target_markets.field_smed_id.yml
@@ -1,0 +1,19 @@
+uuid: 2c249ff2-9429-4ced-bc85-adeec1d9b790
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_smed_id
+    - taxonomy.vocabulary.target_markets
+id: taxonomy_term.target_markets.field_smed_id
+field_name: field_smed_id
+entity_type: taxonomy_term
+bundle: target_markets
+label: 'SME Dashboard ID'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/migrate_plus.migration.smed_regions_countries_lvl1.yml
+++ b/config/sync/migrate_plus.migration.smed_regions_countries_lvl1.yml
@@ -1,0 +1,52 @@
+uuid: 45fc67c0-c20f-4894-91a2-4c4044c75bb9
+langcode: en
+status: true
+dependencies: {  }
+id: smed_regions_countries_lvl1
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags:
+  - eic_smed_api_authentication
+migration_group: eic_smed_taxonomy
+label: 'SMED - Regions and Countries'
+source:
+  plugin: eic_smed_url
+  taxonomy_vocabulary_smed_id: GeographicalMarkets
+  authentication:
+    plugin: basic
+    username: xxx
+    password: xxx
+  data_fetcher_plugin: eic_http_smed_taxonomy_post
+  data_parser_plugin: jsonpath
+  include_raw_data: true
+  track_changes: true
+  urls: {  }
+  item_selector: '$.Taxonomy.Group[*]'
+  ids:
+    id:
+      type: string
+  fields:
+    -
+      name: id
+      label: ID
+      selector: Value
+    -
+      name: name
+      label: Name
+      selector: Name
+process:
+  name:
+    -
+      plugin: get
+      source: name
+  field_smed_id:
+    -
+      plugin: get
+      source: id
+destination:
+  plugin: 'entity:taxonomy_term'
+  default_bundle: geo
+migration_dependencies:
+  required: {  }
+  optional: {  }

--- a/config/sync/migrate_plus.migration.smed_regions_countries_lvl2.yml
+++ b/config/sync/migrate_plus.migration.smed_regions_countries_lvl2.yml
@@ -1,0 +1,64 @@
+uuid: 3d331c23-359e-43b0-b282-189d71618885
+langcode: en
+status: true
+dependencies: {  }
+id: smed_regions_countries_lvl2
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags:
+  - eic_smed_api_authentication
+migration_group: eic_smed_taxonomy
+label: 'SMED - Regions and Countries'
+source:
+  plugin: eic_smed_url
+  taxonomy_vocabulary_smed_id: GeographicalMarkets
+  authentication:
+    plugin: basic
+    username: xxx
+    password: xxx
+  data_fetcher_plugin: eic_http_smed_taxonomy_post
+  data_parser_plugin: jsonpath
+  include_raw_data: true
+  track_changes: true
+  urls: {  }
+  item_selector: '$.Taxonomy.Group[*].Selector.Option[*]'
+  ids:
+    id:
+      type: string
+  fields:
+    -
+      name: id
+      label: ID
+      selector: Value
+    -
+      name: name
+      label: Name
+      selector: Name
+    -
+      name: parent
+      label: Parent
+      selector: Parent
+process:
+  name:
+    -
+      plugin: get
+      source: name
+  field_smed_id:
+    -
+      plugin: get
+      source: id
+  parent:
+    -
+      plugin: get
+      source: parent
+    -
+      plugin: migration_lookup
+      migration: smed_regions_countries_lvl1
+destination:
+  plugin: 'entity:taxonomy_term'
+  default_bundle: geo
+migration_dependencies:
+  required:
+    - smed_regions_countries_lvl1
+  optional: {  }

--- a/lib/modules/eic_webservices/config/install/migrate_plus.migration.smed_regions_countries_lvl1.yml
+++ b/lib/modules/eic_webservices/config/install/migrate_plus.migration.smed_regions_countries_lvl1.yml
@@ -1,0 +1,47 @@
+id: smed_regions_countries_lvl1
+label: SMED - Regions and Countries
+migration_group: eic_smed_taxonomy
+migration_tags:
+  - eic_smed_api_authentication
+source:
+  plugin: eic_smed_url
+  taxonomy_vocabulary_smed_id: GeographicalMarkets
+  authentication:
+    plugin: basic
+    # Username and password will be set automatically by the eic_smed_url plugin
+    # we just keep them here with dummy data for reference.
+    username: xxx
+    password: xxx
+  data_fetcher_plugin: eic_http_smed_taxonomy_post
+  data_parser_plugin: jsonpath
+  include_raw_data: true
+  track_changes: true
+  # The URL will be set automatically by the eic_smed_url plugin, we just keep
+  # it here with dummy data for reference.
+  urls: { }
+  item_selector: '$.Taxonomy.Group[*]'
+  ids:
+    id:
+      type: string
+  fields:
+    -
+      name: id
+      label: 'ID'
+      selector: Value
+    -
+      name: name
+      label: 'Name'
+      selector: Name
+process:
+  name:
+    - plugin: get
+      source: name
+  field_smed_id:
+    - plugin: get
+      source: id
+destination:
+  plugin: entity:taxonomy_term
+  default_bundle: geo
+migration_dependencies:
+  required: { }
+  optional: { }

--- a/lib/modules/eic_webservices/config/install/migrate_plus.migration.smed_regions_countries_lvl2.yml
+++ b/lib/modules/eic_webservices/config/install/migrate_plus.migration.smed_regions_countries_lvl2.yml
@@ -1,0 +1,57 @@
+id: smed_regions_countries_lvl2
+label: SMED - Regions and Countries
+migration_group: eic_smed_taxonomy
+migration_tags:
+  - eic_smed_api_authentication
+source:
+  plugin: eic_smed_url
+  taxonomy_vocabulary_smed_id: GeographicalMarkets
+  authentication:
+    plugin: basic
+    # Username and password will be set automatically by the eic_smed_url plugin
+    # we just keep them here with dummy data for reference.
+    username: xxx
+    password: xxx
+  data_fetcher_plugin: eic_http_smed_taxonomy_post
+  data_parser_plugin: jsonpath
+  include_raw_data: true
+  track_changes: true
+  # The URL will be set automatically by the eic_smed_url plugin, we just keep
+  # it here with dummy data for reference.
+  urls: { }
+  item_selector: '$.Taxonomy.Group[*].Selector.Option[*]'
+  ids:
+    id:
+      type: string
+  fields:
+    -
+      name: id
+      label: 'ID'
+      selector: Value
+    -
+      name: name
+      label: 'Name'
+      selector: Name
+    -
+      name: parent
+      label: 'Parent'
+      selector: Parent
+process:
+  name:
+    - plugin: get
+      source: name
+  field_smed_id:
+    - plugin: get
+      source: id
+  parent:
+    - plugin: get
+      source: parent
+    - plugin: migration_lookup
+      migration: smed_regions_countries_lvl1
+destination:
+  plugin: entity:taxonomy_term
+  default_bundle: geo
+migration_dependencies:
+  required:
+    - smed_regions_countries_lvl1
+  optional: { }


### PR DESCRIPTION
### Tests

- [x] Run `drush mim smed_regions_countries_lvl1 && drush mim smed_regions_countries_lvl2`
- [x] Go to `/admin/structure/taxonomy/manage/geo/overview`
- [x] Make sure you have items there (2 levels)
- [x] Edit the items, make sure they have a value in the SME Dashboard ID field

### Remarks

- To configure the connection to the SMED Taxonomy webservice, please refer to 
  - https://github.com/EIC-EA/EIC-community-D8/blob/develop/lib/modules/eic_webservices/README.md
  - And https://citnet.tech.ec.europa.eu/CITnet/confluence/display/EICNET/WS+-+Taxonomy+webservice#WSTaxonomywebservice-Introduction to get the credentials
