### PR TITLE
[EICNET]fix: remove view unpublished group permission from TU

### DIFF
--- a/config/sync/group.role.organisation-dcb2f93df.yml
+++ b/config/sync/group.role.organisation-dcb2f93df.yml
@@ -28,7 +28,6 @@ permissions:
   - 'access wiki overview'
   - 'join group'
   - 'share content between groups'
-  - 'view any unpublished group'
   - 'view comments'
   - 'view group'
   - 'view group_membership content'

--- a/config/sync/workflows.workflow.groups.yml
+++ b/config/sync/workflows.workflow.groups.yml
@@ -16,7 +16,7 @@ type_settings:
     archived:
       label: Archived
       weight: 3
-      published: true
+      published: false
       default_revision: true
     blocked:
       label: Blocked


### PR DESCRIPTION
## To Test

- [x] Send an archival request for an organisation & accept it
- [x] AS TU you should not be able to view its page
- [x] It should not be displayed in the overview page