### PR TITLE
EICNET-2034: Group type notification - group deleted

### DIFF
--- a/config/sync/core.entity_form_display.message.notify_group_deleted.default.yml
+++ b/config/sync/core.entity_form_display.message.notify_group_deleted.default.yml
@@ -1,0 +1,41 @@
+uuid: c5fb5f67-0ef5-4e9f-8d22-5ac9c98fa1ee
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.message.notify_group_deleted.field_entity_type
+    - field.field.message.notify_group_deleted.field_event_executing_user
+    - field.field.message.notify_group_deleted.field_referenced_entity_label
+    - message.template.notify_group_deleted
+id: message.notify_group_deleted.default
+targetEntityType: message
+bundle: notify_group_deleted
+mode: default
+content:
+  field_entity_type:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_event_executing_user:
+    type: entity_reference_autocomplete
+    weight: 1
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_referenced_entity_label:
+    type: string_textfield
+    weight: 2
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/config/sync/core.entity_view_display.message.notify_group_deleted.default.yml
+++ b/config/sync/core.entity_view_display.message.notify_group_deleted.default.yml
@@ -1,0 +1,50 @@
+uuid: 07b2ecfe-24ca-4c15-9084-53b7a97e7e52
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.message.notify_group_deleted.field_entity_type
+    - field.field.message.notify_group_deleted.field_event_executing_user
+    - field.field.message.notify_group_deleted.field_referenced_entity_label
+    - message.template.notify_group_deleted
+id: message.notify_group_deleted.default
+targetEntityType: message
+bundle: notify_group_deleted
+mode: default
+content:
+  field_entity_type:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_event_executing_user:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_referenced_entity_label:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  partial_0:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  partial_1:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.notify_group_deleted.mail_body.yml
+++ b/config/sync/core.entity_view_display.message.notify_group_deleted.mail_body.yml
@@ -1,0 +1,24 @@
+uuid: 1eccbbc2-df33-4e21-96eb-465c1fcca1a3
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.message.mail_body
+    - field.field.message.notify_group_deleted.field_entity_type
+    - field.field.message.notify_group_deleted.field_event_executing_user
+    - field.field.message.notify_group_deleted.field_referenced_entity_label
+    - message.template.notify_group_deleted
+id: message.notify_group_deleted.mail_body
+targetEntityType: message
+bundle: notify_group_deleted
+mode: mail_body
+content:
+  partial_1:
+    weight: 0
+    region: content
+hidden:
+  field_entity_type: true
+  field_event_executing_user: true
+  field_referenced_entity_label: true
+  partial_0: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.notify_group_deleted.mail_subject.yml
+++ b/config/sync/core.entity_view_display.message.notify_group_deleted.mail_subject.yml
@@ -1,0 +1,24 @@
+uuid: 5639aaea-dfd9-4dc7-881c-6fbe164bf0c6
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.message.mail_subject
+    - field.field.message.notify_group_deleted.field_entity_type
+    - field.field.message.notify_group_deleted.field_event_executing_user
+    - field.field.message.notify_group_deleted.field_referenced_entity_label
+    - message.template.notify_group_deleted
+id: message.notify_group_deleted.mail_subject
+targetEntityType: message
+bundle: notify_group_deleted
+mode: mail_subject
+content:
+  partial_0:
+    weight: 0
+    region: content
+hidden:
+  field_entity_type: true
+  field_event_executing_user: true
+  field_referenced_entity_label: true
+  partial_1: true
+  search_api_excerpt: true

--- a/config/sync/field.field.message.notify_group_deleted.field_entity_type.yml
+++ b/config/sync/field.field.message.notify_group_deleted.field_entity_type.yml
@@ -1,0 +1,19 @@
+uuid: 32859326-f7d9-43bb-8db4-755ef12709a2
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_entity_type
+    - message.template.notify_group_deleted
+id: message.notify_group_deleted.field_entity_type
+field_name: field_entity_type
+entity_type: message
+bundle: notify_group_deleted
+label: 'Group type'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.message.notify_group_deleted.field_event_executing_user.yml
+++ b/config/sync/field.field.message.notify_group_deleted.field_event_executing_user.yml
@@ -1,0 +1,26 @@
+uuid: 840f6938-5c41-4497-ac5a-5fcfaea32faa
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_event_executing_user
+    - message.template.notify_group_deleted
+id: message.notify_group_deleted.field_event_executing_user
+field_name: field_event_executing_user
+entity_type: message
+bundle: notify_group_deleted
+label: 'Event executing user'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:group_membership'
+  handler_settings:
+    target_bundles: null
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+field_type: entity_reference

--- a/config/sync/field.field.message.notify_group_deleted.field_referenced_entity_label.yml
+++ b/config/sync/field.field.message.notify_group_deleted.field_referenced_entity_label.yml
@@ -1,0 +1,19 @@
+uuid: 4f7c27bb-b939-4c2d-ab9b-b0bec3cf874e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_referenced_entity_label
+    - message.template.notify_group_deleted
+id: message.notify_group_deleted.field_referenced_entity_label
+field_name: field_referenced_entity_label
+entity_type: message
+bundle: notify_group_deleted
+label: 'Group label'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/language/en/message.template.notify_group_deleted.yml
+++ b/config/sync/language/en/message.template.notify_group_deleted.yml
@@ -1,0 +1,7 @@
+text:
+  -
+    value: "<p>The [message:field_entity_type:value] [message:field_referenced_entity_label:value] was deleted</p>\r\n"
+    format: full_html
+  -
+    value: "<p>Dear [message:author:display-name],</p>\r\n\r\n<p>[message:field_event_executing_user:entity:display-name] deleted [message:field_entity_type:value] [message:field_referenced_entity_label:value] and its content.</p>\r\n\r\n<p>The EIC Community team</p>\r\n"
+    format: full_html

--- a/config/sync/message.template.notify_group_deleted.yml
+++ b/config/sync/message.template.notify_group_deleted.yml
@@ -1,0 +1,27 @@
+uuid: d290f33d-7abc-43d3-8fcd-a4e7cdaa0296
+langcode: en
+status: true
+dependencies:
+  config:
+    - filter.format.full_html
+  module:
+    - eic_messages
+third_party_settings:
+  eic_messages:
+    message_template_type: notification
+template: notify_group_deleted
+label: 'NOTIFY :: MT32 :: Group deleted'
+description: 'Notifies the group owner, SA and SCM users that a group has been deleted'
+text:
+  -
+    value: "<p>The [message:field_entity_type:value] [message:field_referenced_entity_label:value] was deleted</p>\r\n"
+    format: full_html
+  -
+    value: "<p>Dear [message:author:display-name],</p>\r\n\r\n<p>[message:field_event_executing_user:entity:display-name] deleted [message:field_entity_type:value] [message:field_referenced_entity_label:value] and its content.</p>\r\n\r\n<p>The EIC Community team</p>\r\n"
+    format: full_html
+settings:
+  'token options':
+    clear: true
+    'token replace': true
+  purge_override: false
+  purge_methods: {  }

--- a/lib/modules/eic_groups/eic_groups.api.php
+++ b/lib/modules/eic_groups/eic_groups.api.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @file
+ * Hooks provided by the eic_groups module.
+ */
+
+/**
+ * @addtogroup hooks
+ * @{
+ */
+
+/**
+ * Responds to group predelete before removing all group content.
+ *
+ * @param \Drupal\group\Entity\GroupInterface[] $entities
+ *   Array of group entities to delete.
+ */
+function hook_eic_groups_group_predelete(array $entities) {
+  // Log message before the deleting all groups.
+  foreach ($entities as $group) {
+    \Drupal::logger('eic_groups')->notice('Group ' . $group->label() . ' is about to be deleted.');
+  }
+}
+
+/**
+ * @} End of "addtogroup hooks".
+ */

--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -23,6 +23,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use Drupal\eic_groups\Constants\NodeProperty;
 use Drupal\eic_groups\EICGroupsHelper;
+use Drupal\eic_groups\Entity\Group;
 use Drupal\eic_groups\GroupsModerationHelper;
 use Drupal\eic_groups\Hooks\CronOperations;
 use Drupal\eic_groups\Hooks\EntityOperations;
@@ -680,6 +681,7 @@ function eic_groups_entity_predelete(EntityInterface $entity) {
  * Implements hook_entity_type_alter().
  */
 function eic_groups_entity_type_alter(array &$entity_types) {
+  /** @var \Drupal\Core\Entity\EntityTypeInterface[] $entity_types */
   if (!isset($entity_types['group']) && !isset($entity_types['group_content'])) {
     return;
   }
@@ -687,6 +689,9 @@ function eic_groups_entity_type_alter(array &$entity_types) {
   // Add custom group membership validation constraint to the group_content
   // entity.
   $entity_types['group_content']->addConstraint('EICGroupMembership');
+
+  // Overrides entity group class.
+  $entity_types['group']->setClass(Group::class);
 }
 
 /**

--- a/lib/modules/eic_groups/src/Entity/Group.php
+++ b/lib/modules/eic_groups/src/Entity/Group.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\eic_groups\Entity;
+
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\group\Entity\Group as GroupBase;
+
+/**
+ * Overrides the Group entity.
+ *
+ * @ingroup group
+ */
+class Group extends GroupBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function preDelete(EntityStorageInterface $storage, array $entities) {
+    // Invoke custom hook to run before delete all the group content.
+    \Drupal::moduleHandler()->invokeAll('eic_groups_group_predelete', [$entities]);
+    parent::preDelete($storage, $entities);
+  }
+
+}

--- a/lib/modules/eic_messages/eic_messages.module
+++ b/lib/modules/eic_messages/eic_messages.module
@@ -299,3 +299,12 @@ function eic_messages_group_flex_visibility_save(
       ->save();
   }
 }
+
+/**
+ * Implements hook_eic_groups_group_predelete().
+ */
+function eic_messages_eic_groups_group_predelete(array $entities) {
+  /** @var Drupal\eic_messages\Service\GroupMessageCreator $class */
+  $class = \Drupal::classResolver(GroupMessageCreator::class);
+  $class->groupPredelete($entities);
+}

--- a/lib/modules/eic_messages/src/Service/GroupMessageCreator.php
+++ b/lib/modules/eic_messages/src/Service/GroupMessageCreator.php
@@ -158,8 +158,9 @@ class GroupMessageCreator implements ContainerInjectionInterface {
    * Sends out message notifications upon group deletion.
    */
   public function groupPredelete(array $entities) {
+    $power_users = $this->userHelper->getSitePowerUsers();
     foreach ($entities as $group) {
-      $send_to = $this->userHelper->getSitePowerUsers();
+      $send_to = $power_users;
       if ($group_owner = EICGroupsHelper::getGroupOwner($group)) {
         $send_to[] = $group_owner->id();
       }

--- a/lib/modules/eic_messages/src/Service/GroupMessageCreator.php
+++ b/lib/modules/eic_messages/src/Service/GroupMessageCreator.php
@@ -6,8 +6,10 @@ use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\eic_groups\EICGroupsHelper;
 use Drupal\eic_groups\GroupsModerationHelper;
 use Drupal\eic_messages\Util\LogMessageTemplates;
+use Drupal\eic_messages\Util\NotificationMessageTemplates;
 use Drupal\eic_user\UserHelper;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -148,6 +150,29 @@ class GroupMessageCreator implements ContainerInjectionInterface {
         'uid' => $this->currentUser->id(),
       ])
       ->save();
+  }
+
+  /**
+   * Implements hook_eic_groups_group_predelete().
+   *
+   * Sends out message notifications upon group deletion.
+   */
+  public function groupPredelete(array $entities) {
+    foreach ($entities as $group) {
+      $send_to = $this->userHelper->getSitePowerUsers();
+      if ($group_owner = EICGroupsHelper::getGroupOwner($group)) {
+        $send_to[] = $group_owner->id();
+      }
+      foreach ($send_to as $uid) {
+        $this->messageBus->dispatch([
+          'template' => NotificationMessageTemplates::GROUP_DELETE,
+          'field_entity_type' => ['target_id' => $group->getEntityTypeId()],
+          'field_referenced_entity_label' => $group->label(),
+          'field_event_executing_user' => $this->currentUser->id(),
+          'uid' => $uid,
+        ]);
+      }
+    }
   }
 
 }

--- a/lib/modules/eic_messages/src/Util/NotificationMessageTemplates.php
+++ b/lib/modules/eic_messages/src/Util/NotificationMessageTemplates.php
@@ -27,6 +27,11 @@ final class NotificationMessageTemplates implements MessageIdentifierInterface {
   const GROUP_VISIBILITY_CHANGE = 'notify_group_access_change';
 
   /**
+   * Message template for notifying group visibility changes.
+   */
+  const GROUP_DELETE = 'notify_group_deleted';
+
+  /**
    * {@inheritdoc}
    */
   public static function getMessageTemplatePrimaryKeys(MessageTemplateInterface $message_template) {


### PR DESCRIPTION
### Features

- Create message notification to send to GO/SA/SCM users when a group is deleted
- Override group entity class since we need to create the message notifications before deleting all the group content
- create custom hook to act before group predelete.

### Test

1st test
- [x] As GO/GM, make a delete request
- [x] As SA/SCM accept the request
- [x] Run cron
- [x] Make sure GO and all SA/SCM users receive a notification (**NOTIFY :: MT32 :: Group deleted**) about the group deletion. **Do not make confusion with the notification about the request accepted.**

2nd test

- [x] As SA/SCM, try to delete a group
- [x] Run cron
- [x] Make sure GO and all SA/SCM users receive a notification (**NOTIFY :: MT32 :: Group deleted**) about the group deletion.