### PR TITLE
EICNET-899: Migration of users (phase 2)

### DIFF
--- a/config/sync/migrate_plus.migration.upgrade_d7_user.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_user.yml
@@ -12,7 +12,7 @@ migration_tags:
 migration_group: migrate_drupal_7
 label: 'User accounts'
 source:
-  plugin: d7_user
+  plugin: eic_d7_user_with_smed_ids
   track_changes: true
 process:
   name: name
@@ -39,18 +39,7 @@ process:
       source: language
       fallback_to_site_default: true
   init: init
-  roles:
-    -
-      plugin: static_map
-      source: roles
-      default_value: null
-      map:
-        1: anonymous
-        2: authenticated
-        3: piwik_administrator
-        4: service_authentication
-        5: administrator
-        6: content_administrator
+  roles: roles
   field_first_name: c4m_first_name
   field_is_deleted: c4m_is_deleted
   field_is_deleted_anonymous: c4m_is_deleted_anonymous
@@ -64,6 +53,15 @@ process:
   field_is_organisation_user: c4m_is_organisation_user
   field_is_spammer: c4m_is_spammer
   field_last_name: c4m_last_name
+  field_media:
+    - plugin: sub_process
+      source: c4m_media
+      process:
+        target_id:
+          - plugin: migration_lookup
+            source: fid
+            migration:
+              - upgrade_d7_file_image_to_media
   field_smed_id: c4m_user_dashboard_id
   field_message_from_service: c4m_message_from_service
   field_updated_profile_by_service:

--- a/config/sync/migrate_plus.migration.upgrade_d7_user.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_user.yml
@@ -60,6 +60,7 @@ process:
         target_id:
           - plugin: migration_lookup
             source: fid
+            no_stub: true
             migration:
               - upgrade_d7_file_image_to_media
   field_smed_id: c4m_user_dashboard_id

--- a/config/sync/migrate_plus.migration.upgrade_d7_user_to_profile.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_user_to_profile.yml
@@ -12,12 +12,17 @@ migration_tags:
 migration_group: migrate_drupal_7
 label: 'User accounts to User profiles'
 source:
-  plugin: d7_user
+  plugin: eic_d7_user_with_smed_ids
   track_changes: true
   constants:
     FACEBOOK_LINK_TYPE: facebook
     LINKEDIN_LINK_TYPE: linkedin
     TWITTER_LINK_TYPE: twitter
+  smed_taxonomy_fields:
+    - c4m_vocab_geo
+    - c4m_vocab_language
+    - c4m_vocab_topic
+    - c4m_vocab_job_title
 process:
   type:
     -
@@ -78,9 +83,71 @@ process:
     -
       plugin: addressfield
       source: c4m_location_address
+  field_vocab_topic_expertise:
+    - plugin: sub_process
+      source: c4m_vocab_topic
+      process:
+        target_id:
+          - plugin: migration_lookup
+            source: smed_id
+            no_stub: true
+            migration:
+              - smed_thematics_topics_lvl1
+              - smed_thematics_topics_lvl2
+              - smed_thematics_topics_lvl3
+  field_vocab_topic_interest:
+    - plugin: sub_process
+      source: c4m_vocab_topic
+      process:
+        target_id:
+          - plugin: migration_lookup
+            source: smed_id
+            no_stub: true
+            migration:
+              - smed_thematics_topics_lvl1
+              - smed_thematics_topics_lvl2
+              - smed_thematics_topics_lvl3
+  field_vocab_language:
+    - plugin: sub_process
+      source: c4m_vocab_language
+      process:
+        target_id:
+          - plugin: migration_lookup
+            source: smed_id
+            no_stub: true
+            migration:
+              - smed_spoken_languages
+  field_vocab_geo:
+    - plugin: sub_process
+      source: c4m_vocab_geo
+      process:
+        target_id:
+          - plugin: migration_lookup
+            source: smed_id
+            no_stub: true
+            migration:
+              - smed_regions_countries_lvl1
+              - smed_regions_countries_lvl2
+  field_vocab_job_title:
+    - plugin: sub_process
+      source: c4m_vocab_job_title
+      process:
+        target_id:
+          - plugin: migration_lookup
+            source: smed_id
+            no_stub: true
+            migration:
+              - smed_job_titles
 destination:
   plugin: 'entity:profile'
 migration_dependencies:
   required:
     - upgrade_d7_user
+    - smed_thematics_topics_lvl1
+    - smed_thematics_topics_lvl2
+    - smed_thematics_topics_lvl3
+    - smed_regions_countries_lvl1
+    - smed_regions_countries_lvl2
+    - smed_job_titles
+    - smed_spoken_languages
   optional: {  }

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_user.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_user.yml
@@ -11,13 +11,13 @@ migration_tags:
 migration_group: migrate_drupal_7
 label: 'User accounts'
 source:
-  plugin: d7_user
+  plugin: eic_d7_user_with_smed_ids
   track_changes: true
 process:
   # Ignore User ID so migration updates can be ran
-#  uid:
-#    - plugin: get
-#      source: uid
+  # uid:
+  #   - plugin: get
+  #     source: uid
   name: name
   pass: pass
   mail: mail
@@ -39,17 +39,7 @@ process:
       source: language
       fallback_to_site_default: true
   init: init
-  roles:
-    - plugin: static_map
-      source: roles
-      default_value: NULL
-      map:
-        1: anonymous
-        2: authenticated
-        3: piwik_administrator
-        4: service_authentication
-        5: administrator
-        6: content_administrator
+  roles: roles
   field_first_name: c4m_first_name
   field_is_deleted: c4m_is_deleted
   field_is_deleted_anonymous: c4m_is_deleted_anonymous
@@ -62,16 +52,15 @@ process:
   field_is_organisation_user: c4m_is_organisation_user
   field_is_spammer: c4m_is_spammer
   field_last_name: c4m_last_name
-  # TODO: Implement after files and media migrations are finished.
-#  field_media:
-#    - plugin: sub_process
-#      source: c4m_media
-#      process:
-#        target_id: fid
-#        alt: alt
-#        title: title
-#        width: width
-#        height: height
+  field_media:
+    - plugin: sub_process
+      source: c4m_media
+      process:
+        target_id:
+          - plugin: migration_lookup
+            source: fid
+            migration:
+              - upgrade_d7_file_image_to_media
   field_smed_id: c4m_user_dashboard_id
   field_message_from_service: c4m_message_from_service
   field_updated_profile_by_service:
@@ -98,9 +87,9 @@ process:
             to_format: U
   field_user_status: c4m_user_status
   # TODO: Implement after groups migration.
-#  og_user_node:
-#    - plugin: get
-#      source: og_user_node
+  # og_user_node:
+  #   - plugin: get
+  #     source: og_user_node
 destination:
   plugin: 'entity:user'
 migration_dependencies:

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_user.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_user.yml
@@ -59,6 +59,7 @@ process:
         target_id:
           - plugin: migration_lookup
             source: fid
+            no_stub: true
             migration:
               - upgrade_d7_file_image_to_media
   field_smed_id: c4m_user_dashboard_id

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_user_to_profile.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_user_to_profile.yml
@@ -11,12 +11,17 @@ migration_tags:
 migration_group: migrate_drupal_7
 label: 'User accounts to User profiles'
 source:
-  plugin: d7_user
+  plugin: eic_d7_user_with_smed_ids
   track_changes: true
   constants:
     FACEBOOK_LINK_TYPE: 'facebook'
     LINKEDIN_LINK_TYPE: 'linkedin'
     TWITTER_LINK_TYPE: 'twitter'
+  smed_taxonomy_fields:
+    - c4m_vocab_geo
+    - c4m_vocab_language
+    - c4m_vocab_topic
+    - c4m_vocab_job_title
 process:
   type:
     - plugin: default_value
@@ -66,49 +71,82 @@ process:
   field_location_address:
     - plugin: addressfield
       source: c4m_location_address
+  field_vocab_topic_expertise:
+    - plugin: sub_process
+      source: c4m_vocab_topic
+      process:
+        target_id:
+          - plugin: migration_lookup
+            source: smed_id
+            no_stub: true
+            migration:
+              - smed_thematics_topics_lvl1
+              - smed_thematics_topics_lvl2
+              - smed_thematics_topics_lvl3
+  field_vocab_topic_interest:
+    - plugin: sub_process
+      source: c4m_vocab_topic
+      process:
+        target_id:
+          - plugin: migration_lookup
+            source: smed_id
+            no_stub: true
+            migration:
+              - smed_thematics_topics_lvl1
+              - smed_thematics_topics_lvl2
+              - smed_thematics_topics_lvl3
+  field_vocab_language:
+    - plugin: sub_process
+      source: c4m_vocab_language
+      process:
+        target_id:
+          - plugin: migration_lookup
+            source: smed_id
+            no_stub: true
+            migration:
+              - smed_spoken_languages
+  field_vocab_geo:
+    - plugin: sub_process
+      source: c4m_vocab_geo
+      process:
+        target_id:
+          - plugin: migration_lookup
+            source: smed_id
+            no_stub: true
+            migration:
+              - smed_regions_countries_lvl1
+              - smed_regions_countries_lvl2
+  field_vocab_job_title:
+    - plugin: sub_process
+      source: c4m_vocab_job_title
+      process:
+        target_id:
+          - plugin: migration_lookup
+            source: smed_id
+            no_stub: true
+            migration:
+              - smed_job_titles
   # TODO: Implement after taxonomy vocabulary is coming from SMED.
-#  c4m_user_types:
-#    - plugin: sub_process
-#      source: c4m_user_types
-#      process:
-#        target_id: tid
-  # TODO: Implement after taxonomy vocabulary is coming from SMED.
-#  c4m_vocab_geo:
-#    - plugin: sub_process
-#      source: c4m_vocab_geo
-#      process:
-#        target_id: tid
-  # TODO: Implement after taxonomy vocabulary is coming from SMED.
-#  c4m_vocab_language:
-#    - plugin: sub_process
-#      source: c4m_vocab_language
-#      process:
-#        target_id: tid
-  # TODO: Implement after taxonomy vocabulary is coming from SMED.
-#  c4m_vocab_topic:
-#    - plugin: sub_process
-#      source: c4m_vocab_topic
-#      process:
-#        target_id: tid
-  # TODO: Implement after taxonomy vocabulary is coming from SMED.
-#  c4m_vocab_topic_expertise:
-#    - plugin: sub_process
-#      source: c4m_vocab_topic_expertise
-#      process:
-#        target_id: tid
-  # TODO: Implement after taxonomy vocabulary is coming from SMED.
-#  c4m_vocab_job_title:
-#    - plugin: sub_process
-#      source: c4m_vocab_job_title
-#      process:
-#        target_id: tid
-  # TODO: Implement after groups migration.
-#  og_user_node:
-#    - plugin: get
-#      source: og_user_node
+  # field_user_type:
+  #   - plugin: sub_process
+  #     source: c4m_user_types
+  #     process:
+  #       target_id:
+  #         - plugin: migration_lookup
+  #           source: smed_id
+  #           no_stub: true
+  #           migration:
+  #             - smed_user_types
 destination:
   plugin: 'entity:profile'
 migration_dependencies:
   required:
     - upgrade_d7_user
+    - smed_thematics_topics_lvl1
+    - smed_thematics_topics_lvl2
+    - smed_thematics_topics_lvl3
+    - smed_regions_countries_lvl1
+    - smed_regions_countries_lvl2
+    - smed_job_titles
+    - smed_spoken_languages
   optional: { }

--- a/lib/modules/eic_migrate/src/Plugin/migrate/source/UserWithSMEDIds.php
+++ b/lib/modules/eic_migrate/src/Plugin/migrate/source/UserWithSMEDIds.php
@@ -25,6 +25,13 @@ use Drupal\user\Plugin\migrate\source\d7\User;
  */
 class UserWithSMEDIds extends User {
 
+  const MAP_USER_ROLES = [
+    3 => 'trusted_user',
+    4 => 'service_authentication',
+    5 => 'administrator',
+    6 => 'content_administrator',
+  ];
+
   /**
    * The SMED taxonomy reference fields.
    *
@@ -53,6 +60,20 @@ class UserWithSMEDIds extends User {
         $row->setSourceProperty($field, $this->getTaxonomyFieldValuesWithSmedIds($fieldValues));
       }
     }
+
+    $roles = [];
+    foreach ($row->getSourceProperty('roles') as $rid) {
+      $roles[] = self::MAP_USER_ROLES[$rid];
+    }
+
+    // Adds trusted_user role to all users.
+    if (empty($row->getSourceProperty('roles'))) {
+      $roles = [
+        'trusted_user',
+      ];
+    }
+
+    $row->setSourceProperty('roles', $roles);
 
     return $result;
   }

--- a/lib/modules/eic_migrate/src/Plugin/migrate/source/UserWithSMEDIds.php
+++ b/lib/modules/eic_migrate/src/Plugin/migrate/source/UserWithSMEDIds.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Drupal\eic_migrate\Plugin\migrate\source;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\State\StateInterface;
+use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\migrate\Row;
+use Drupal\user\Plugin\migrate\source\d7\User;
+
+/**
+ * Drupal 7 user source from database.
+ *
+ * Also includes SMED IDs for taxonomy term references.
+ *
+ * For available configuration keys, refer to the parent classes.
+ *
+ * @see \Drupal\migrate\Plugin\migrate\source\SqlBase
+ * @see \Drupal\migrate\Plugin\migrate\source\SourcePluginBase
+ *
+ * @MigrateSource(
+ *   id = "eic_d7_user_with_smed_ids",
+ *   source_module = "user"
+ * )
+ */
+class UserWithSMEDIds extends User {
+
+  /**
+   * The SMED taxonomy reference fields.
+   *
+   * @var array
+   */
+  protected $smedTaxonomyFields;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, MigrationInterface $migration, StateInterface $state, EntityTypeManagerInterface $entity_type_manager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $migration, $state, $entity_type_manager);
+
+    $this->smedTaxonomyFields = !empty($configuration['smed_taxonomy_fields']) ? $configuration['smed_taxonomy_fields'] : [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function prepareRow(Row $row) {
+    $result = parent::prepareRow($row);
+
+    foreach ($this->smedTaxonomyFields as $field) {
+      $fieldValues = $row->getSourceProperty($field);
+      if (!empty($fieldValues)) {
+        $row->setSourceProperty($field, $this->getTaxonomyFieldValuesWithSmedIds($fieldValues));
+      }
+    }
+
+    return $result;
+  }
+
+  /**
+   * Returns the given field values with their SMED ID, if found.
+   *
+   * @param array $fieldValues
+   *   The array of source field values. Should include taxonomy tid.
+   *
+   * @return array
+   *   The array of new source field values. Includes SMED ids if present.
+   */
+  protected function getTaxonomyFieldValuesWithSmedIds(array $fieldValues): array {
+    foreach ($fieldValues as $key => $fieldValue) {
+      $dashboardKeyValues = $this->getFieldValues('taxonomy_term', 'c4m_dashboard_key', $fieldValue['tid']);
+      if (isset($dashboardKeyValues[0]['value'])) {
+        $fieldValue['smed_id'] = $dashboardKeyValues[0]['value'];
+      }
+      $fieldValues[$key] = $fieldValue;
+    }
+
+    return $fieldValues;
+  }
+
+}


### PR DESCRIPTION
### Improvements

- Migrate missing user profile taxonomy term fields coming from SMED: **Topics of expertise**, **Topics of interest**, **Regions and Countries**, **Spoken languages** and **Job titles**.
- Fix user roles migration.

### Tests

- Run a fresh install (**NOTE: DO NOT IMPORT CONTENT FROM FIXTURES**)
- Run `drush mim upgrade_d7_file_image_to_media --execute-dependencies`
- Run `drush mim upgrade_d7_user --update` (15932 should be migrated) -> this migration needs to run twice because we need to update the user profile picture after the files have been migrated. 
- Run `drush mim upgrade_d7_user_to_profile` (15932 should be migrated)

### Remarks

- There is still one remaining taxonomy term field to be migrated in the user profile: **User type**
- There is no piwik administrator role in D9, and therefore all users with that role will become trusted_users after the migration