### PR TITLE
[EICNET]chore: add access test for organisation/s, people, 404

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,8 @@ services:
     #  2. any change that the developer applies to Cypress files on the host
     #     machine immediately takes effect within the e2e container (no docker
     #     rebuild required).
+    env_file:
+      - .env
 
   mailhog:
     image: mailhog/mailhog

--- a/e2e/cypress/integration/global/access-page-check.spec.js
+++ b/e2e/cypress/integration/global/access-page-check.spec.js
@@ -1,0 +1,30 @@
+const notAuthorizedText = 'You are not authorized to access this page.';
+const notFoundText = 'The requested page could not be found.';
+
+context('Organisation - Anonymous access', () => {
+// Organisation detail page - anonymous user
+  specify('Visiting organisation detail page as an anonymous user should return - you are not authorized to access this page.', () => {
+    validateBannerText('/organisations/cypress-do-not-edit-organisation', notAuthorizedText)
+  })
+// Organisation overview page - anonymous user
+  specify('Visiting organisation overview page as an anonymous user should return - you are not authorized to access this page.', () => {
+    validateBannerText('/organisations', notAuthorizedText)
+  })
+// Test above can quickly get extended by subpage content, just by changing the URL, cause it should throw a "not authorized" on all of those pages.
+// Member overview page - anonymous user (This test will fail cause the overview is vieuwable, but the people itself not)
+  specify('Visiting member overview page as an anonymous user should return - you are not authorized to access this page.', () => {
+    validateBannerText('/people', notAuthorizedText)
+  })
+// 404 banner present?
+  specify('Visiting a random non existing page should return 404 with correct banner', () => {
+    validateBannerText('/03cd37ff5b0b47b3b9ff5d728b823045', notFoundText)
+  })
+})
+
+const validateBannerText = (visitUrl, expectedResult) => {
+  cy.visit({
+    url: visitUrl,
+    failOnStatusCode: false
+  })
+  cy.get('.ecl-state-banner__title').contains(expectedResult)
+}


### PR DESCRIPTION
How to test:

- [x] make ssh_cypress
- [x] npx cypress run
- [x] You should have results of different tests

PS: /people is a bug at the moment