### PR TITLE
[EICNET-2274]fix: Add correct group id to highlight content from

### DIFF
--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/DiscussionResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/DiscussionResultItem.js
@@ -71,7 +71,7 @@ class DiscussionResultItem extends React.Component {
                 <HighlightLink
                   updateHighlight={this.updateHighlight}
                   isHighlighted={isHighlighted}
-                  currentGroupId={this.props.result.ss_global_group_parent_id}
+                  currentGroupId={this.props.result.its_global_group_parent_id}
                   nodeId={this.props.result.its_content_nid}
                   translation={this.props.translations}
                 />


### PR DESCRIPTION
How to test:

- [x] Go to a group discussions overview
- [x] Highlight a content
- [x] Verify it's highlighted by refreshing the page