### PR TITLE
[EICNET-2277]fix: If no fields ID define in source, ignore search

### DIFF
--- a/lib/modules/eic_search/src/Service/SolrSearchManager.php
+++ b/lib/modules/eic_search/src/Service/SolrSearchManager.php
@@ -162,6 +162,11 @@ class SolrSearchManager {
     $spell_check->setQuery($search_value);
 
     $search_fields_id = $this->source ? $this->source->getSearchFieldsId() : NULL;
+
+    if (!$search_fields_id) {
+      return;
+    }
+
     $search_query_value = $search_value ? "*$search_value*" : '*';
 
     $query_fields = [];


### PR DESCRIPTION
How to test it:

- [ ] Go to activities stream of a group
- [ ] Verify that you have results (be sure to have activities on it)