### PR TITLE
Feature/eicnet 1828 organisation type access

### DIFF
--- a/lib/modules/eic_groups/src/Access/GroupContentNodeAccessControlHandler.php
+++ b/lib/modules/eic_groups/src/Access/GroupContentNodeAccessControlHandler.php
@@ -23,11 +23,8 @@ class GroupContentNodeAccessControlHandler extends GroupContentAccessControlHand
   public function entityAccess(EntityInterface $entity, $operation, AccountInterface $account, $return_as_object = FALSE) {
     $access = parent::entityAccess($entity, $operation, $account, $return_as_object);
 
-    /** @var \Drupal\group\Entity\Storage\GroupContentStorageInterface $storage */
-    $storage = $this->entityTypeManager->getStorage('group_content');
-    $group_contents = $storage->loadByEntity($entity);
-
-    if (empty($group_contents)) {
+    /** @var \Drupal\group\Entity\GroupInterface $group */
+    if (empty($group = \Drupal::service('eic_groups.helper')->getOwnerGroupByEntity($entity))) {
       return $access;
     }
 
@@ -44,12 +41,10 @@ class GroupContentNodeAccessControlHandler extends GroupContentAccessControlHand
           break;
         }
 
-        $group_content = reset($group_contents);
-        $group = $group_content->getGroup();
         $membership = $group->getMember($account);
         $moderation_state = $group->get('moderation_state')->value;
 
-        // User is a group admin, so we allow access.
+        // If user is a group admin, we allow access.
         if ($membership && EICGroupsHelper::userIsGroupAdmin($group, $account, $membership)) {
           $access = GroupAccessResult::allowed()
             ->addCacheableDependency($account)
@@ -58,8 +53,17 @@ class GroupContentNodeAccessControlHandler extends GroupContentAccessControlHand
           break;
         }
 
+        // Check if user has access to the group, if not we deny access to the
+        // node.
+        if (!$group->access('view')) {
+          $access = AccessResult::forbidden()
+            ->addCacheableDependency($account)
+            ->addCacheableDependency($membership)
+            ->addCacheableDependency($entity);
+        }
+
         // At this point it means the user is not a poweruser neither a group
-        // admin. Therefore, If group is blocked no user other can view the its
+        // admin. Therefore, if group is blocked no user other can view its
         // content besides powerusers or group admins.
         if ($moderation_state !== GroupsModerationHelper::GROUP_PUBLISHED_STATE) {
           $access = AccessResult::forbidden()
@@ -86,23 +90,19 @@ class GroupContentNodeAccessControlHandler extends GroupContentAccessControlHand
           break;
         }
 
-        // We check if the user is a member of a group where this node is
+        // We check if the user is a member of the group where this node is
         // referenced and if so, we allow access to edit the node if the owner
         // allowed members to do so via "member_content_edit_access" property.
-        foreach ($group_contents as $group_content) {
-          $group = $group_content->getGroup();
+        $editable_by_members = $entity->get(NodeProperty::MEMBER_CONTENT_EDIT_ACCESS)->value;
 
-          $editable_by_members = $entity->get(NodeProperty::MEMBER_CONTENT_EDIT_ACCESS)->value;
+        if ($editable_by_members) {
+          $membership = $group->getMember($account);
 
-          if ($editable_by_members) {
-            $membership = $group->getMember($account);
-
-            $access = AccessResult::allowedIf($membership)
-              ->addCacheableDependency($account)
-              ->addCacheableDependency($membership)
-              ->addCacheableDependency($entity);
-            break;
-          }
+          $access = AccessResult::allowedIf($membership)
+            ->addCacheableDependency($account)
+            ->addCacheableDependency($membership)
+            ->addCacheableDependency($entity);
+          break;
         }
         break;
 

--- a/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorVisibility.php
+++ b/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorVisibility.php
@@ -162,8 +162,8 @@ class ProcessorVisibility extends DocumentProcessor {
 
             $term_ids = $option[GroupVisibilityType::GROUP_VISIBILITY_OPTION_ORGANISATION_TYPES . '_conf'];
             $terms = array_map(function ($term_id) {
-              if (!empty($term_id)) {
-                $term = Term::load($term_id);
+              if (!empty($term_id['target_id'])) {
+                $term = Term::load($term_id['target_id']);
                 if (!$term) {
                   return -1;
                 }


### PR DESCRIPTION
### Tests

- [x] Create an organisation with a specific type
- [x] Create a published group with custom visibility => organisation type (the same that you used in the organisation)
- [x] Create a node inside the group and publish it
- [x] As TU (non-member of the organisation) make sure you can't find the group in the overviews/search nor the content and you can't access the group page or the node page
- [x] Now add the TU as GM of the organisation
- [x] Check that you can find the group and the content in the overviews, and check that you can access th detail pages