### PR TITLE
EICNET-1317: Node 'News' migration (phase 2)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2740,7 +2740,8 @@
                     "3007424 - Multiple usages of FieldPluginBase::getEntity do not check for NULL, leading to WSOD": "https://www.drupal.org/files/issues/2021-01-06/3007424-108.patch",
                     "2973863 - ValidReferenceConstraintValidator should not try to enforce data integrity on pre-existing references": "https://www.drupal.org/files/issues/2018-11-04/2973863-24.patch",
                     "2918537 - Cannot save unpublished versions of published content for users without manage book privileges": "https://www.drupal.org/files/issues/2021-11-16/2918537-68.patch",
-                    "2473873 - Views entity operations lack cacheability support, resulting in incorrect dropbuttons": "https://www.drupal.org/files/issues/2021-11-23/2473873-97.patch"
+                    "2473873 - Views entity operations lack cacheability support, resulting in incorrect dropbuttons": "https://www.drupal.org/files/issues/2021-11-23/2473873-97.patch",
+                    "2760983 - array_flip(): Can only flip STRING and INTEGER values! EntityStorageBase.php:227": "https://www.drupal.org/files/issues/2020-02-06/2760983-8.patch"
                 }
             },
             "autoload": {

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -4,7 +4,8 @@
       "3007424 - Multiple usages of FieldPluginBase::getEntity do not check for NULL, leading to WSOD": "https://www.drupal.org/files/issues/2021-01-06/3007424-108.patch",
       "2973863 - ValidReferenceConstraintValidator should not try to enforce data integrity on pre-existing references": "https://www.drupal.org/files/issues/2018-11-04/2973863-24.patch",
       "2918537 - Cannot save unpublished versions of published content for users without manage book privileges": "https://www.drupal.org/files/issues/2021-11-16/2918537-68.patch",
-      "2473873 - Views entity operations lack cacheability support, resulting in incorrect dropbuttons": "https://www.drupal.org/files/issues/2021-11-23/2473873-97.patch"
+      "2473873 - Views entity operations lack cacheability support, resulting in incorrect dropbuttons": "https://www.drupal.org/files/issues/2021-11-23/2473873-97.patch",
+      "2760983 - array_flip(): Can only flip STRING and INTEGER values! EntityStorageBase.php:227": "https://www.drupal.org/files/issues/2020-02-06/2760983-8.patch"
     },
     "drupal/address": {
       "2812659 - Integrate Address with Search API (adds a Search API processor to convert country code to full country name)": "https://www.drupal.org/files/issues/2021-06-14/integrate-address-searchapi-2812659-57_0.patch"

--- a/config/sync/migrate_plus.migration.upgrade_d7_node_complete_news.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_node_complete_news.yml
@@ -68,17 +68,7 @@ process:
   revision_timestamp: timestamp
   content_translation_source: source_langcode
   node_comment/0/status: comment
-  field_body/0/format:
-    -
-      plugin: static_map
-      source: c4m_body/0/format
-      default_value: filtered_html
-      map:
-        full_html: full_html
-        filtered_html: filtered_html
-        plain_text: plain_text
-        mail: basic_text
-  field_body/0/value:
+  field_body:
     -
       plugin: eic_media_wysiwyg_filter
       source: c4m_body

--- a/config/sync/migrate_plus.migration.upgrade_d7_node_complete_news.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_node_complete_news.yml
@@ -1,4 +1,4 @@
-uuid: dabd1681-2a8c-4175-a650-e73460a346fa
+uuid: 7d7942ec-2dd0-4fda-a80e-60476b293b5e
 langcode: en
 status: true
 dependencies: {  }
@@ -49,9 +49,10 @@ process:
     -
       plugin: static_map
       source: status
+      default: published
       map:
-        - draft
-        - published
+        0: draft
+        1: published
   created: created
   changed: timestamp
   published_at: timestamp
@@ -67,7 +68,17 @@ process:
   revision_timestamp: timestamp
   content_translation_source: source_langcode
   node_comment/0/status: comment
-  field_body:
+  field_body/0/format:
+    -
+      plugin: static_map
+      source: c4m_body/0/format
+      default_value: filtered_html
+      map:
+        full_html: full_html
+        filtered_html: filtered_html
+        plain_text: plain_text
+        mail: basic_text
+  field_body/0/value:
     -
       plugin: eic_media_wysiwyg_filter
       source: c4m_body
@@ -77,21 +88,21 @@ process:
         - upgrade_d7_file_image_to_media
         - upgrade_d7_file_undefined_to_media
         - upgrade_d7_file_video_to_media
-  field_document_media:
+  # field_document_media:
+  #   -
+  #     plugin: sub_process
+  #     source: c4m_related_document
+  #     process:
+  #       target_id:
+  #         -
+  #           plugin: migration_lookup
+  #           source: target_id
+  #           migration:
+  #             - upgrade_d7_file_document_to_media
+  field_vocab_geo:
     -
       plugin: sub_process
-      source: c4m_related_document
-      process:
-        target_id:
-          -
-            plugin: migration_lookup
-            source: target_id
-            migration:
-              - upgrade_d7_file_document_to_media
-  field_vocab_languages:
-    -
-      plugin: sub_process
-      source: c4m_vocab_language
+      source: c4m_vocab_geo
       process:
         target_id:
           -
@@ -99,7 +110,8 @@ process:
             source: smed_id
             no_stub: true
             migration:
-              - smed_spoken_languages
+              - smed_regions_countries_lvl1
+              - smed_regions_countries_lvl2
   field_vocab_topics:
     -
       plugin: sub_process
@@ -130,4 +142,6 @@ migration_dependencies:
     - smed_thematics_topics_lvl1
     - smed_thematics_topics_lvl2
     - smed_thematics_topics_lvl3
+    - smed_regions_countries_lvl1
+    - smed_regions_countries_lvl2
   optional: {  }

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_news.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_news.yml
@@ -78,28 +78,28 @@ process:
             source: target_id
             migration:
               - upgrade_d7_file_document_to_media
-  # TODO: Implement when Regions & countries SMED migration is done.
-#  field_vocab_geo:
-#    - plugin: sub_process
-#      source: c4m_vocab_geo
-#      process:
-#        target_id:
-#          - plugin: migration_lookup
-#            source: smed_id
-#            no_stub: true
-#            migration:
-#              - smed_TODO
-  # TODO: Validate implementation when field_vocab_languages is added to CT News.
-  field_vocab_languages:
+  field_vocab_geo:
     - plugin: sub_process
-      source: c4m_vocab_language
+      source: c4m_vocab_geo
       process:
         target_id:
           - plugin: migration_lookup
             source: smed_id
             no_stub: true
             migration:
-              - smed_spoken_languages
+              - smed_regions_countries_lvl1
+              - smed_regions_countries_lvl2
+  # TODO: Validate implementation when field_vocab_languages is added to CT News.
+  # field_language:
+  #   - plugin: sub_process
+  #     source: c4m_vocab_language
+  #     process:
+  #       target_id:
+  #         - plugin: migration_lookup
+  #           source: smed_id
+  #           no_stub: true
+  #           migration:
+  #             - smed_spoken_languages
   field_vocab_topics:
     - plugin: sub_process
       source: c4m_vocab_topic

--- a/lib/modules/eic_migrate/src/Plugin/migrate/process/MediaWysiwygFilter.php
+++ b/lib/modules/eic_migrate/src/Plugin/migrate/process/MediaWysiwygFilter.php
@@ -154,6 +154,18 @@ class MediaWysiwygFilter extends ProcessPluginBase implements ConfigurableInterf
   ];
 
   /**
+   * Text format mappings.
+   *
+   * @var string[]
+   */
+  protected const TEXT_FORMAT_MAPPINGS = [
+    'full_html' => 'full_html',
+    'filtered_html' => 'filtered_html',
+    'plain_text' => 'plain_text',
+    'mail' => 'basic_text',
+  ];
+
+  /**
    * The migration entity.
    *
    * @var \Drupal\migrate\Plugin\MigrationInterface
@@ -287,6 +299,8 @@ class MediaWysiwygFilter extends ProcessPluginBase implements ConfigurableInterf
       throw new MigrateException("The embed token's destination filter plugin ID is invalid.");
     }
 
+    // Update format with the one defined in the mappings.
+    $value['format'] = self::TEXT_FORMAT_MAPPINGS[$value['format']];
     $pattern = '/\[\[\s*(?<tag_info>\{.+\})\s*\]\]/sU';
     $decoder = new JsonDecode(TRUE);
     $entity_type_id = explode(':', $this->migration->getDestinationConfiguration()['plugin'])[1];


### PR DESCRIPTION
### Improvements

- Migrate regions and countries
- Fix migration of field body
- Apply patch that fixes issue with migrations + content moderation

### Todo:

- [ ] Update FA -> https://citnet.tech.ec.europa.eu/CITnet/confluence/display/EICNET/05+-+Node+migration

### Test

- [ ] Run `drush mim upgrade_d7_node_complete_news --execute_dependencies` -> **72 migrated news (112 revisions)**