### PR TITLE
EICNET-1321: Node 'Wiki page' migration (phase 2)

### DIFF
--- a/config/sync/core.entity_form_display.node.wiki_page.default.yml
+++ b/config/sync/core.entity_form_display.node.wiki_page.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.wiki_page.field_body
+    - field.field.node.wiki_page.field_language
     - field.field.node.wiki_page.field_related_downloads
     - field.field.node.wiki_page.field_related_media
     - field.field.node.wiki_page.field_tags
@@ -27,7 +28,7 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 8
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -39,6 +40,16 @@ content:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
+  field_language:
+    type: entity_reference_autocomplete
+    weight: 5
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_post_activity:
     weight: 22
     region: content
@@ -46,14 +57,14 @@ content:
     third_party_settings: {  }
   field_related_downloads:
     type: media_library_widget
-    weight: 7
+    weight: 8
     region: content
     settings:
       media_types: {  }
     third_party_settings: {  }
   field_related_media:
     type: media_library_widget
-    weight: 6
+    weight: 7
     region: content
     settings:
       media_types: {  }
@@ -65,7 +76,7 @@ content:
     third_party_settings: {  }
   field_tags:
     type: entity_tree
-    weight: 51
+    weight: 25
     region: content
     settings:
       match_top_level_limit: '0'
@@ -103,7 +114,7 @@ content:
     third_party_settings: {  }
   langcode:
     type: language_select
-    weight: 5
+    weight: 6
     region: content
     settings:
       include_locked: true
@@ -117,13 +128,13 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 19
+    weight: 20
     region: content
     settings: {  }
     third_party_settings: {  }
   path:
     type: path
-    weight: 12
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -136,39 +147,39 @@ content:
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 10
+    weight: 11
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 15
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }
   publish_state:
     type: scheduler_moderation
-    weight: 17
+    weight: 18
     region: content
     settings: {  }
     third_party_settings: {  }
   published_at:
     type: publication_date_timestamp
-    weight: 14
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 13
+    weight: 14
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 11
+    weight: 12
     region: content
     settings:
       display_label: true
@@ -183,7 +194,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 9
+    weight: 10
     region: content
     settings:
       match_operator: CONTAINS
@@ -193,18 +204,18 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 18
+    weight: 19
     region: content
     settings: {  }
     third_party_settings: {  }
   unpublish_state:
     type: scheduler_moderation
-    weight: 16
+    weight: 17
     region: content
     settings: {  }
     third_party_settings: {  }
   url_redirects:
-    weight: 50
+    weight: 24
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_view_display.node.wiki_page.default.yml
+++ b/config/sync/core.entity_view_display.node.wiki_page.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.wiki_page.field_body
+    - field.field.node.wiki_page.field_language
     - field.field.node.wiki_page.field_related_downloads
     - field.field.node.wiki_page.field_related_media
     - field.field.node.wiki_page.field_tags
@@ -29,6 +30,14 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 2
+    region: content
+  field_language:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 12
     region: content
   field_related_downloads:
     type: entity_reference_entity_view

--- a/config/sync/core.entity_view_display.node.wiki_page.teaser.yml
+++ b/config/sync/core.entity_view_display.node.wiki_page.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.wiki_page.field_body
+    - field.field.node.wiki_page.field_language
     - field.field.node.wiki_page.field_related_downloads
     - field.field.node.wiki_page.field_related_media
     - field.field.node.wiki_page.field_tags
@@ -56,6 +57,7 @@ content:
 hidden:
   extra_field_eic_theme_helper_short_title_with_fallback: true
   field_body: true
+  field_language: true
   field_related_downloads: true
   field_related_media: true
   field_tags: true

--- a/config/sync/field.field.node.wiki_page.field_language.yml
+++ b/config/sync/field.field.node.wiki_page.field_language.yml
@@ -1,0 +1,29 @@
+uuid: f7a794c9-102b-42a1-801c-1f99ec30630a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_language
+    - node.type.wiki_page
+    - taxonomy.vocabulary.languages
+id: node.wiki_page.field_language
+field_name: field_language
+entity_type: node
+bundle: wiki_page
+label: Language
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      languages: languages
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/migrate_plus.migration.upgrade_d7_node_complete_wiki_page.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_node_complete_wiki_page.yml
@@ -120,18 +120,18 @@ process:
             migration:
               - smed_regions_countries_lvl1
               - smed_regions_countries_lvl2
-  # field_language:
-  #   -
-  #     plugin: sub_process
-  #     source: c4m_vocab_language
-  #     process:
-  #       target_id:
-  #         -
-  #           plugin: migration_lookup
-  #           source: smed_id
-  #           no_stub: true
-  #           migration:
-  #             - smed_spoken_languages
+  field_language:
+    -
+      plugin: sub_process
+      source: c4m_vocab_language
+      process:
+        target_id:
+          -
+            plugin: migration_lookup
+            source: smed_id
+            no_stub: true
+            migration:
+              - smed_spoken_languages
   field_vocab_topics:
     -
       plugin: sub_process

--- a/config/sync/migrate_plus.migration.upgrade_d7_node_complete_wiki_page.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_node_complete_wiki_page.yml
@@ -77,10 +77,39 @@ process:
         - upgrade_d7_file_image_to_media
         - upgrade_d7_file_undefined_to_media
         - upgrade_d7_file_video_to_media
-  field_vocab_languages:
+  member_content_edit_access:
+    -
+      plugin: get
+      source: c4m_edit_by_members
+  field_related_downloads:
     -
       plugin: sub_process
-      source: c4m_vocab_language
+      source: c4m_related_document
+      process:
+        target_id:
+          -
+            plugin: migration_lookup
+            source: target_id
+            no_stub: true
+            migration: upgrade_d7_node_complete_document
+          -
+            plugin: node_complete_node_lookup
+          -
+            plugin: entity_value
+            entity_type: node
+            field_name: field_document_media
+          -
+            plugin: skip_on_empty
+            method: process
+          -
+            plugin: extract
+            index:
+              - 0
+              - target_id
+  field_vocab_geo:
+    -
+      plugin: sub_process
+      source: c4m_vocab_geo
       process:
         target_id:
           -
@@ -88,7 +117,20 @@ process:
             source: smed_id
             no_stub: true
             migration:
-              - smed_spoken_languages
+              - smed_regions_countries_lvl1
+              - smed_regions_countries_lvl2
+  # field_language:
+  #   -
+  #     plugin: sub_process
+  #     source: c4m_vocab_language
+  #     process:
+  #       target_id:
+  #         -
+  #           plugin: migration_lookup
+  #           source: smed_id
+  #           no_stub: true
+  #           migration:
+  #             - smed_spoken_languages
   field_vocab_topics:
     -
       plugin: sub_process
@@ -119,4 +161,7 @@ migration_dependencies:
     - smed_thematics_topics_lvl1
     - smed_thematics_topics_lvl2
     - smed_thematics_topics_lvl3
+    - smed_regions_countries_lvl1
+    - smed_regions_countries_lvl2
+    - upgrade_d7_node_complete_document
   optional: {  }

--- a/config/sync/migrate_plus.migration.upgrade_d7_node_complete_wiki_page.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_node_complete_wiki_page.yml
@@ -49,9 +49,10 @@ process:
     -
       plugin: static_map
       source: status
+      default: published
       map:
-        - draft
-        - published
+        0: draft
+        1: published
   created: created
   changed: timestamp
   published_at: timestamp

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_wiki_page.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_wiki_page.yml
@@ -68,36 +68,50 @@ process:
         - upgrade_d7_file_image_to_media
         - upgrade_d7_file_undefined_to_media
         - upgrade_d7_file_video_to_media
-  # TODO
-#  c4m_edit_by_members:
-#    - plugin: get
-#      source: c4m_edit_by_members
-  # TODO
-#  c4m_related_document:
-#    - plugin: get
-#      source: c4m_related_document
-  # TODO: Implement when Regions & countries SMED migration is done.
-#  field_vocab_geo:
-#    - plugin: sub_process
-#      source: c4m_vocab_geo
-#      process:
-#        target_id:
-#          - plugin: migration_lookup
-#            source: smed_id
-#            no_stub: true
-#            migration:
-#              - smed_TODO
-  # TODO: Validate implementation when field_vocab_languages is added to CT Wiki page.
-  field_vocab_languages:
+  member_content_edit_access:
+    - plugin: get
+      source: c4m_edit_by_members
+  field_related_downloads:
     - plugin: sub_process
-      source: c4m_vocab_language
+      source: c4m_related_document
+      process:
+        target_id:
+          - plugin: migration_lookup
+            source: target_id
+            no_stub: true
+            migration: upgrade_d7_node_complete_document
+          - plugin: node_complete_node_lookup
+          - plugin: entity_value
+            entity_type: node
+            field_name: field_document_media
+          - plugin: skip_on_empty
+            method: process
+          - plugin: extract
+            index:
+              - 0
+              - target_id
+  field_vocab_geo:
+    - plugin: sub_process
+      source: c4m_vocab_geo
       process:
         target_id:
           - plugin: migration_lookup
             source: smed_id
             no_stub: true
             migration:
-              - smed_spoken_languages
+              - smed_regions_countries_lvl1
+              - smed_regions_countries_lvl2
+  # TODO: Validate implementation when field_vocab_languages is added to CT Wiki page.
+  # field_language:
+  #   - plugin: sub_process
+  #     source: c4m_vocab_language
+  #     process:
+  #       target_id:
+  #         - plugin: migration_lookup
+  #           source: smed_id
+  #           no_stub: true
+  #           migration:
+  #             - smed_spoken_languages
   field_vocab_topics:
     - plugin: sub_process
       source: c4m_vocab_topic
@@ -133,4 +147,7 @@ migration_dependencies:
     - smed_thematics_topics_lvl1
     - smed_thematics_topics_lvl2
     - smed_thematics_topics_lvl3
+    - smed_regions_countries_lvl1
+    - smed_regions_countries_lvl2
+    - upgrade_d7_node_complete_document
   optional: { }

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_wiki_page.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_wiki_page.yml
@@ -42,6 +42,7 @@ process:
   moderation_state:
     - plugin: static_map
       source: status
+      default: published
       map:
         0: draft
         1: published

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_wiki_page.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_wiki_page.yml
@@ -102,17 +102,16 @@ process:
             migration:
               - smed_regions_countries_lvl1
               - smed_regions_countries_lvl2
-  # TODO: Validate implementation when field_vocab_languages is added to CT Wiki page.
-  # field_language:
-  #   - plugin: sub_process
-  #     source: c4m_vocab_language
-  #     process:
-  #       target_id:
-  #         - plugin: migration_lookup
-  #           source: smed_id
-  #           no_stub: true
-  #           migration:
-  #             - smed_spoken_languages
+  field_language:
+    - plugin: sub_process
+      source: c4m_vocab_language
+      process:
+        target_id:
+          - plugin: migration_lookup
+            source: smed_id
+            no_stub: true
+            migration:
+              - smed_spoken_languages
   field_vocab_topics:
     - plugin: sub_process
       source: c4m_vocab_topic


### PR DESCRIPTION
### Improvements

- Migrate regions and countries + related downloads from document nodes + node property "Editable by members".
- Create field_language in Wiki pages + add it to the migration.

### Tests

- [ ] Run `drush mim upgrade_d7_node_complete_wiki_page --execute-dependencies` -> 182 migrated nodes (485 revisions)