### PR TITLE
[EICNET-2061] Notification fixes related to group & group contents

### DIFF
--- a/lib/modules/eic_messages/src/Service/GroupContentMessageCreator.php
+++ b/lib/modules/eic_messages/src/Service/GroupContentMessageCreator.php
@@ -66,6 +66,10 @@ class GroupContentMessageCreator implements ContainerInjectionInterface {
       $relatedUser = $entity->getEntity();
       $relatedGroup = $entity->getGroup();
 
+      if ($relatedUser->id() === $relatedGroup->getOwnerId()) {
+        return;
+      }
+      
       $this->messageBus->dispatch([
         'template' => 'notify_new_member_joined',
         'uid' => $relatedGroup->getOwnerId(),


### PR DESCRIPTION
## To test

- [x] Create a discussion as draft, publish it afterwards: When published, a new group content email should be sent
- [x] As TU create a group, run cron: No new member e-mail should be sent to TU