### PR TITLE
EICNET-2315: GO can not access Members Pending page

### DIFF
--- a/lib/modules/eic_groups/eic_groups.install
+++ b/lib/modules/eic_groups/eic_groups.install
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\eic_groups\Constants\NodeProperty;
+use Drupal\eic_groups\EICGroupsHelper;
 use Drupal\group_content_menu\GroupContentMenuInterface;
 use Drupal\group_permissions\Entity\GroupPermission;
 
@@ -182,6 +183,90 @@ function eic_groups_update_9003(&$sandbox) {
         /** @var \Drupal\menu_link_content\Entity\MenuLinkContent $menu_item_people */
         $menu_item_people = reset($items);
         $menu_item_people->delete();
+      }
+    }
+  }
+}
+
+/**
+ * Add "administer membership requests" permission to group owner role.
+ */
+function eic_groups_update_9004(&$sandbox) {
+
+  $group_permissions = \Drupal::entityQuery('group_permission')
+    ->execute();
+
+  $group_permissions = GroupPermission::loadMultiple();
+
+  foreach ($group_permissions as &$group_permission) {
+    $permissions = $group_permission->getPermissions();
+
+    if (empty($permissions)) {
+      continue;
+    }
+
+    /** @var \Drupal\group\Entity\GroupInterface $group */
+    $group = $group_permission->getGroup();
+
+    $joining_methods = \Drupal::service('oec_group_flex.helper')->getGroupJoiningMethod($group);
+
+    if (!$joining_methods) {
+      continue;
+    }
+
+    $isMembershipRequestEnabled = TRUE;
+    foreach ($joining_methods as $joining_method) {
+      if (
+        in_array(
+          $joining_method['plugin_id'],
+          [
+            'open_method',
+            'tu_open_method',
+          ]
+        )
+      ) {
+        $isMembershipRequestEnabled = FALSE;
+        break;
+      }
+    }
+
+    if (!$isMembershipRequestEnabled) {
+      continue;
+    }
+
+    foreach ($joining_methods as $joining_method) {
+      if (
+        in_array(
+          $joining_method['plugin_id'],
+          [
+            'group_membership_request',
+            'tu_group_membership_request',
+          ]
+        )
+      ) {
+        $group_type = $group->getGroupType()->id();
+
+        $ownerGroupRoleId = EICGroupsHelper::getGroupTypeRole($group_type, 'owner');
+        \Drupal::service('eic_groups.helper')->addRolePermissionsToGroup(
+          $group_permission,
+          $ownerGroupRoleId,
+          ['administer membership requests']
+        );
+
+        $group_permission->setNewRevision();
+        $group_permission->setRevisionUserId(1);
+        $group_permission->setRevisionCreationTime(time());
+        $group_permission->setRevisionLogMessage(t('Add "administer membership requests" permission to group owner role.'));
+
+        if (count($group_permission->validate()) > 0) {
+          break;
+        }
+
+        $group_permission->save();
+
+        // Save the group entity to reset the cache tags.
+        $group->save();
+        break;
       }
     }
   }

--- a/lib/modules/eic_groups/eic_groups.install
+++ b/lib/modules/eic_groups/eic_groups.install
@@ -253,10 +253,17 @@ function eic_groups_update_9004(&$sandbox) {
           ['administer membership requests']
         );
 
+        $adminGroupRoleId = EICGroupsHelper::getGroupTypeRole($group_type, 'admin');
+        \Drupal::service('eic_groups.helper')->addRolePermissionsToGroup(
+          $group_permission,
+          $adminGroupRoleId,
+          ['administer membership requests']
+        );
+
         $group_permission->setNewRevision();
         $group_permission->setRevisionUserId(1);
         $group_permission->setRevisionCreationTime(time());
-        $group_permission->setRevisionLogMessage(t('Add "administer membership requests" permission to group owner role.'));
+        $group_permission->setRevisionLogMessage(t('Add "administer membership requests" permission to group owner and admin roles.'));
 
         if (count($group_permission->validate()) > 0) {
           break;

--- a/lib/modules/oec_group_flex/src/OECGroupFlexHelper.php
+++ b/lib/modules/oec_group_flex/src/OECGroupFlexHelper.php
@@ -13,6 +13,12 @@ use Drupal\oec_group_flex\Plugin\CustomRestrictedVisibilityManager;
  */
 class OECGroupFlexHelper {
 
+  const GROUP_TYPE_OWNER_ROLE = 'owner';
+
+  const GROUP_TYPE_ADMINISTRATOR_ROLE = 'admin';
+
+  const GROUP_TYPE_MEMBER_ROLE = 'member';
+
   /**
    * The group_flex group service.
    *
@@ -190,6 +196,25 @@ class OECGroupFlexHelper {
       }
     }
     return $settings;
+  }
+
+  /**
+   * Returns the correct role machine name for the given group type and role.
+   *
+   * @param string $group_type
+   *   The group type ID.
+   * @param string $role
+   *   The role to check. Can be either "admin", "owner" or "member".
+   *
+   * @return string|null
+   *   The group role machine name or NULL if not found.
+   */
+  public static function getGroupTypeRole(string $group_type, string $role) {
+    return in_array($role, [
+      self::GROUP_TYPE_ADMINISTRATOR_ROLE,
+      self::GROUP_TYPE_OWNER_ROLE,
+      self::GROUP_TYPE_MEMBER_ROLE,
+    ]) ? $group_type . '-' . $role : NULL;
   }
 
 }

--- a/lib/modules/oec_group_flex/src/Plugin/GroupJoiningMethod/TuGroupMembershipRequest.php
+++ b/lib/modules/oec_group_flex/src/Plugin/GroupJoiningMethod/TuGroupMembershipRequest.php
@@ -3,11 +3,11 @@
 namespace Drupal\oec_group_flex\Plugin\GroupJoiningMethod;
 
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\eic_groups\EICGroupsHelper;
 use Drupal\group\Entity\GroupInterface;
 use Drupal\group\Entity\GroupTypeInterface;
 use Drupal\group\GroupRoleSynchronizer;
 use Drupal\group_flex\Plugin\GroupJoiningMethodBase;
+use Drupal\oec_group_flex\OECGroupFlexHelper;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -81,7 +81,7 @@ class TuGroupMembershipRequest extends GroupJoiningMethodBase implements Contain
 
     $tuGroupRoleId = $this->getTrustedUserRoleId($groupType);
 
-    $ownerGroupRoleId = EICGroupsHelper::getGroupTypeRole($groupType->id(), 'owner');
+    $ownerGroupRoleId = OECGroupFlexHelper::getGroupTypeRole($groupType->id(), 'owner');
 
     $mappedPerm = [
       $ownerGroupRoleId => [
@@ -99,7 +99,7 @@ class TuGroupMembershipRequest extends GroupJoiningMethodBase implements Contain
    */
   public function disableGroupType(GroupTypeInterface $groupType) {
     $tuGroupRoleId = $this->getTrustedUserRoleId($groupType);
-    $ownerGroupRoleId = EICGroupsHelper::getGroupTypeRole($groupType->id(), 'owner');
+    $ownerGroupRoleId = OECGroupFlexHelper::getGroupTypeRole($groupType->id(), 'owner');
     $mappedPerm = [
       $ownerGroupRoleId => [
         'administer membership requests' => FALSE,
@@ -116,7 +116,7 @@ class TuGroupMembershipRequest extends GroupJoiningMethodBase implements Contain
    */
   public function getGroupPermissions(GroupInterface $group): array {
     $tuGroupRoleId = $this->getTrustedUserRoleId($group->getGroupType());
-    $ownerGroupRoleId = EICGroupsHelper::getGroupTypeRole($group->bundle(), 'owner');
+    $ownerGroupRoleId = OECGroupFlexHelper::getGroupTypeRole($group->bundle(), 'owner');
     return [
       $ownerGroupRoleId => ['administer membership requests'],
       $tuGroupRoleId => ['request group membership'],
@@ -128,7 +128,7 @@ class TuGroupMembershipRequest extends GroupJoiningMethodBase implements Contain
    */
   public function getDisallowedGroupPermissions(GroupInterface $group): array {
     $tuGroupRoleId = $this->getTrustedUserRoleId($group->getGroupType());
-    $ownerGroupRoleId = EICGroupsHelper::getGroupTypeRole($group->bundle(), 'owner');
+    $ownerGroupRoleId = OECGroupFlexHelper::getGroupTypeRole($group->bundle(), 'owner');
     return [
       $ownerGroupRoleId => ['administer membership requests'],
       $tuGroupRoleId => ['request group membership'],

--- a/lib/modules/oec_group_flex/src/Plugin/GroupJoiningMethod/TuGroupMembershipRequest.php
+++ b/lib/modules/oec_group_flex/src/Plugin/GroupJoiningMethod/TuGroupMembershipRequest.php
@@ -3,6 +3,7 @@
 namespace Drupal\oec_group_flex\Plugin\GroupJoiningMethod;
 
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\eic_groups\EICGroupsHelper;
 use Drupal\group\Entity\GroupInterface;
 use Drupal\group\Entity\GroupTypeInterface;
 use Drupal\group\GroupRoleSynchronizer;
@@ -80,7 +81,16 @@ class TuGroupMembershipRequest extends GroupJoiningMethodBase implements Contain
 
     $tuGroupRoleId = $this->getTrustedUserRoleId($groupType);
 
-    $mappedPerm = [$tuGroupRoleId => ['request group membership' => TRUE]];
+    $ownerGroupRoleId = EICGroupsHelper::getGroupTypeRole($groupType->id(), 'owner');
+
+    $mappedPerm = [
+      $ownerGroupRoleId => [
+        'administer membership requests' => TRUE,
+      ],
+      $tuGroupRoleId => [
+        'request group membership' => TRUE,
+      ],
+    ];
     $this->saveMappedPerm($mappedPerm, $groupType);
   }
 
@@ -89,8 +99,15 @@ class TuGroupMembershipRequest extends GroupJoiningMethodBase implements Contain
    */
   public function disableGroupType(GroupTypeInterface $groupType) {
     $tuGroupRoleId = $this->getTrustedUserRoleId($groupType);
-
-    $mappedPerm = [$tuGroupRoleId => ['request group membership' => FALSE]];
+    $ownerGroupRoleId = EICGroupsHelper::getGroupTypeRole($groupType->id(), 'owner');
+    $mappedPerm = [
+      $ownerGroupRoleId => [
+        'administer membership requests' => FALSE,
+      ],
+      $tuGroupRoleId => [
+        'request group membership' => FALSE,
+      ],
+    ];
     $this->saveMappedPerm($mappedPerm, $groupType);
   }
 
@@ -99,7 +116,9 @@ class TuGroupMembershipRequest extends GroupJoiningMethodBase implements Contain
    */
   public function getGroupPermissions(GroupInterface $group): array {
     $tuGroupRoleId = $this->getTrustedUserRoleId($group->getGroupType());
+    $ownerGroupRoleId = EICGroupsHelper::getGroupTypeRole($group->bundle(), 'owner');
     return [
+      $ownerGroupRoleId => ['administer membership requests'],
       $tuGroupRoleId => ['request group membership'],
     ];
   }
@@ -109,7 +128,9 @@ class TuGroupMembershipRequest extends GroupJoiningMethodBase implements Contain
    */
   public function getDisallowedGroupPermissions(GroupInterface $group): array {
     $tuGroupRoleId = $this->getTrustedUserRoleId($group->getGroupType());
+    $ownerGroupRoleId = EICGroupsHelper::getGroupTypeRole($group->bundle(), 'owner');
     return [
+      $ownerGroupRoleId => ['administer membership requests'],
       $tuGroupRoleId => ['request group membership'],
     ];
   }


### PR DESCRIPTION
### Improvements

- Add permission to administer membership request when joining method is set to "tu_group_membership_request";
- Create hook_update to update group permissions for old groups.

### Test

Using QA DB:

- [ ] Run `drush updb`
- [ ] Make sure the following the GO can access the group membership requests page (joining method set to **Request**) -> `/groups/test-private-group/members-pending`
- [ ] Make GO cannot access the group membership requests page for the following group (joining method set to **Open**) -> `/groups/edegem-v2/members-pending`

On a fresh install:

- [x] As TU, create a new group and set the joining method to "Request"
- [x] Make sure the user can access the group membership requests page -> `/groups/<group-name>/members-pending`