### PR TITLE
EICNET-1993: Add Drupal default workflow to all content types (Improvements phase 2)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4962,7 +4962,8 @@
                     }
                 },
                 "patches_applied": {
-                    "3086125 - Prevent infinite loop when sending messages with queue": "https://www.drupal.org/files/issues/2021-10-01/3086125-skip-if-we-have-last-item-14.patch"
+                    "3086125 - Prevent infinite loop when sending messages with queue": "https://www.drupal.org/files/issues/2021-10-01/3086125-skip-if-we-have-last-item-14.patch",
+                    "3190511 - Trying to access array offset on value of type bool in Drupal\\message_subscribe\\Subscribers->sendMessage()": "https://www.drupal.org/files/issues/2020-12-31/message_subscribe-Wrong_End_Time_Option-3190511-2-9.x.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -9375,16 +9376,6 @@
             "homepage": "http://github.com/myclabs/php-enum",
             "keywords": [
                 "enum"
-            ],
-            "funding": [
-                {
-                    "url": "https://github.com/mnapoli",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/myclabs/php-enum",
-                    "type": "tidelift"
-                }
             ],
             "time": "2021-07-05T08:18:36+00:00"
         },

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -57,7 +57,8 @@
       "3251270 - Error when trying to send a message to a deleted owner": "https://www.drupal.org/files/issues/2021-11-25/message_notify-check_owner_account-3251270-2.patch"
     },
     "drupal/message_subscribe": {
-      "3086125 - Prevent infinite loop when sending messages with queue": "https://www.drupal.org/files/issues/2021-10-01/3086125-skip-if-we-have-last-item-14.patch"
+      "3086125 - Prevent infinite loop when sending messages with queue": "https://www.drupal.org/files/issues/2021-10-01/3086125-skip-if-we-have-last-item-14.patch",
+      "3190511 - Trying to access array offset on value of type bool in Drupal\\message_subscribe\\Subscribers->sendMessage()": "https://www.drupal.org/files/issues/2020-12-31/message_subscribe-Wrong_End_Time_Option-3190511-2-9.x.patch"
     },
     "drupal/migrate_plus": {
       "3007709 - Add XPath-style filtering ability in JSON data parser plugin" : "https://www.drupal.org/files/issues/2020-11-16/migrate_plus-json-xpath-filtering-3007709-24.patch"

--- a/config/sync/core.entity_form_display.message.stream_event_insert_update.default.yml
+++ b/config/sync/core.entity_form_display.message.stream_event_insert_update.default.yml
@@ -1,4 +1,4 @@
-uuid: 6f9dbc2d-d26a-4017-804c-459db1601c83
+uuid: 1f079aa2-d665-4657-9ed4-5a6aac02083e
 langcode: en
 status: true
 dependencies:
@@ -14,41 +14,39 @@ bundle: stream_event_insert_update
 mode: default
 content:
   field_entity_type:
-    type: string
-    label: above
-    settings:
-      link_to_entity: false
-    third_party_settings: {  }
-    weight: 1
-    region: content
-  field_group_ref:
-    type: entity_reference_label
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    weight: 2
-    region: content
-  field_operation_type:
-    type: string
-    label: above
-    settings:
-      link_to_entity: false
-    third_party_settings: {  }
-    weight: 3
-    region: content
-  field_referenced_node:
-    type: entity_reference_label
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    weight: 4
-    region: content
-  partial_0:
-    settings: {  }
-    third_party_settings: {  }
+    type: string_textfield
     weight: 0
     region: content
-hidden:
-  search_api_excerpt: true
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_group_ref:
+    type: entity_reference_autocomplete
+    weight: 1
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_operation_type:
+    type: string_textfield
+    weight: 2
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_referenced_node:
+    type: entity_reference_autocomplete
+    weight: 3
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/config/sync/field.field.message.stream_event_insert_update.field_entity_type.yml
+++ b/config/sync/field.field.message.stream_event_insert_update.field_entity_type.yml
@@ -1,0 +1,19 @@
+uuid: 38bf80e1-cf46-46d2-837f-8925ca41dca5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_entity_type
+    - message.template.stream_event_insert_update
+id: message.stream_event_insert_update.field_entity_type
+field_name: field_entity_type
+entity_type: message
+bundle: stream_event_insert_update
+label: 'Entity type'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.message.stream_event_insert_update.field_group_ref.yml
+++ b/config/sync/field.field.message.stream_event_insert_update.field_group_ref.yml
@@ -1,0 +1,29 @@
+uuid: acdfa25c-bb19-4482-9bcc-f48cce228122
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_group_ref
+    - group.type.group
+    - message.template.stream_event_insert_update
+id: message.stream_event_insert_update.field_group_ref
+field_name: field_group_ref
+entity_type: message
+bundle: stream_event_insert_update
+label: Group
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:group'
+  handler_settings:
+    target_bundles:
+      group: group
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.message.stream_event_insert_update.field_operation_type.yml
+++ b/config/sync/field.field.message.stream_event_insert_update.field_operation_type.yml
@@ -1,0 +1,19 @@
+uuid: 70d07f32-aa31-4c9f-b47b-1b580c37e8ae
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_operation_type
+    - message.template.stream_event_insert_update
+id: message.stream_event_insert_update.field_operation_type
+field_name: field_operation_type
+entity_type: message
+bundle: stream_event_insert_update
+label: 'Operation type'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.message.stream_event_insert_update.field_referenced_node.yml
+++ b/config/sync/field.field.message.stream_event_insert_update.field_referenced_node.yml
@@ -1,0 +1,29 @@
+uuid: 10b75ac9-60c1-4ad0-8078-45db14c97762
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_referenced_node
+    - message.template.stream_event_insert_update
+    - node.type.event
+id: message.stream_event_insert_update.field_referenced_node
+field_name: field_referenced_node
+entity_type: message
+bundle: stream_event_insert_update
+label: 'Referenced node'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      event: event
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/group.role.event-admin.yml
+++ b/config/sync/group.role.event-admin.yml
@@ -12,6 +12,7 @@ audience: member
 group_type: event
 permissions_ui: true
 permissions:
+  - 'access group_node overview'
   - 'create group_node:discussion entity'
   - 'create group_node:document entity'
   - 'create group_node:gallery entity'

--- a/config/sync/group.role.event-owner.yml
+++ b/config/sync/group.role.event-owner.yml
@@ -14,6 +14,7 @@ permissions_ui: true
 permissions:
   - 'access discussions overview'
   - 'access group search overview'
+  - 'access group_node overview'
   - 'create group_node:discussion entity'
   - 'create group_node:document entity'
   - 'create group_node:gallery entity'

--- a/config/sync/group.role.group-admin.yml
+++ b/config/sync/group.role.group-admin.yml
@@ -13,6 +13,7 @@ group_type: group
 permissions_ui: true
 permissions:
   - 'access group search overview'
+  - 'access group_node overview'
   - 'create group_node:discussion entity'
   - 'create group_node:document entity'
   - 'create group_node:event entity'

--- a/config/sync/group.role.group-owner.yml
+++ b/config/sync/group.role.group-owner.yml
@@ -13,6 +13,7 @@ group_type: group
 permissions_ui: true
 permissions:
   - 'access group search overview'
+  - 'access group_node overview'
   - 'administer members'
   - 'create group_node:discussion entity'
   - 'create group_node:document entity'

--- a/lib/modules/eic_deploy/eic_deploy.install
+++ b/lib/modules/eic_deploy/eic_deploy.install
@@ -209,3 +209,28 @@ function eic_deploy_update_9005(&$sandbox) {
 
   eic_deploy_add_group_permissions_to_role($new_permissions, $roles);
 }
+
+/**
+ * Adds group permission 'access group node overview' to GO/GA.
+ */
+function eic_deploy_update_9006(&$sandbox) {
+  $new_permissions = [
+    'access group_node overview',
+  ];
+
+  $roles = [
+    'group-owner',
+    'group-admin',
+    'event-owner',
+    'event-admin',
+  ];
+
+  $group_visibilities = [
+    'public',
+    'private',
+    'restricted_community_members',
+    'custom_restricted',
+  ];
+
+  eic_deploy_add_group_permissions_to_role($new_permissions, $roles, $group_visibilities);
+}

--- a/lib/modules/eic_messages/src/Util/ActivityStreamMessageTemplates.php
+++ b/lib/modules/eic_messages/src/Util/ActivityStreamMessageTemplates.php
@@ -6,7 +6,6 @@ use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\eic_messages\MessageIdentifierInterface;
 use Drupal\eic_messages\MessageTemplateTypes;
 use Drupal\message\MessageTemplateInterface;
-use InvalidArgumentException;
 
 /**
  * Helper class for activity stream message templates.
@@ -17,6 +16,11 @@ final class ActivityStreamMessageTemplates implements MessageIdentifierInterface
    * Message template for inserted/updated articles.
    */
   const ARTICLE_INSERT_UPDATE = 'stream_article_insert_update';
+
+  /**
+   * Message template for inserted/updated events.
+   */
+  const EVENT_INSERT_UPDATE = 'stream_event_insert_update';
 
   /**
    * Message template for inserted/updated discussions.
@@ -49,7 +53,7 @@ final class ActivityStreamMessageTemplates implements MessageIdentifierInterface
   const COMMENT_INSERT_UPDATE = 'stream_wiki_page_insert_update';
 
   /**
-   * Used for shared content activity items
+   * Used for shared content activity items.
    */
   const SHARE_CONTENT = 'stream_share_content';
 
@@ -61,15 +65,16 @@ final class ActivityStreamMessageTemplates implements MessageIdentifierInterface
   private static $templates = [
     'node' => [
       'article' => self::ARTICLE_INSERT_UPDATE,
+      'event' => self::EVENT_INSERT_UPDATE,
       'discussion' => self::DISCUSSION_INSERT_UPDATE,
       'document' => self::DOCUMENT_INSERT_UPDATE,
       'gallery' => self::GALLERY_INSERT_UPDATE,
       'video' => self::VIDEO_INSERT_UPDATE,
-      'wiki_page' => self::WIKI_INSERT_UPDATE
+      'wiki_page' => self::WIKI_INSERT_UPDATE,
     ],
     'comment' => [
       'node_comment' => self::COMMENT_INSERT_UPDATE,
-    ]
+    ],
   ];
 
   /**
@@ -97,7 +102,7 @@ final class ActivityStreamMessageTemplates implements MessageIdentifierInterface
     try {
       self::getTemplate($entity);
     }
-    catch (InvalidArgumentException $e) {
+    catch (\InvalidArgumentException $e) {
       return FALSE;
     }
 
@@ -115,7 +120,7 @@ final class ActivityStreamMessageTemplates implements MessageIdentifierInterface
    */
   public static function getTemplate(ContentEntityInterface $entity): string {
     if (!isset(self::$templates[$entity->getEntityTypeId()][$entity->bundle()])) {
-      throw new InvalidArgumentException('Invalid entity / bundle provided');
+      throw new \InvalidArgumentException('Invalid entity / bundle provided');
     }
 
     return self::$templates[$entity->getEntityTypeId()][$entity->bundle()];


### PR DESCRIPTION
### Improvements

- Add missing activity stream message template constant for inserted/updated events;
- Update event activity stream message to include mandatory fields that are needed for showing in the activity stream;
- Apply patch to fix notice when trying to load message subscribers (see https://www.drupal.org/project/message_subscribe/issues/3190511).
- Fix coding standards.

### Tests

Test with QA DB:

- [ ] Run drush updb (to update group permission to access group node overview page)
- [ ] Make sure the following the GO/GA group nodes overview page -> /groups/<group-name>/nodes

Test with fresh install or QA DB:

- [x] As SA/SCM, go to a group with 1 or more followers
- [x] Create a new draft Event in the group and check the options "Post message in the activity stream" and "Send notification"
- [x] Make sure there is no message in the activity stream (because the event is in draft)
- [x] Run cron
- [x] Make sure the notification **MT18 :: New group content published** is **NOT** triggered
- [x] Edit the draft event, check the options once again ("Post message in the activity stream" and "Send notification") and change the status from draft to published
- [x] Go to the activity stream and make sure you see the message "<User name> created a new event <Event name>"