### PR TITLE
EICNET-2078: Migration of comments (phase 2)

### DIFF
--- a/config/sync/migrate_plus.migration.upgrade_d7_comment.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_comment.yml
@@ -37,6 +37,8 @@ process:
         - upgrade_d7_node_complete_document
         - upgrade_d7_node_complete_news
         - upgrade_d7_node_complete_wiki_page
+        - upgrade_d7_node_complete_event
+        - upgrade_d7_node_complete_photoalbum
     -
       plugin: node_complete_node_lookup
     -
@@ -70,29 +72,27 @@ process:
   changed: changed
   status: status
   thread: thread
-  comment_body:
+  'comment_body/value':
     -
-      plugin: eic_media_wysiwyg_filter
+      plugin: extract
       source: comment_body
-      media_migrations:
-        - upgrade_d7_file_audio_to_media
-        - upgrade_d7_file_document_to_media
-        - upgrade_d7_file_image_to_media
-        - upgrade_d7_file_undefined_to_media
-        - upgrade_d7_file_video_to_media
+      index:
+        - 0
+        - value
+  'comment_body/format':
+    -
+      plugin: default_value
+      default_value: 'basic_text'
 destination:
   plugin: 'entity:comment'
 migration_dependencies:
   required:
     - upgrade_d7_user
-    - upgrade_d7_file_audio_to_media
-    - upgrade_d7_file_document_to_media
-    - upgrade_d7_file_image_to_media
-    - upgrade_d7_file_undefined_to_media
-    - upgrade_d7_file_video_to_media
     - upgrade_d7_node_complete_article
     - upgrade_d7_node_complete_discussion
     - upgrade_d7_node_complete_document
     - upgrade_d7_node_complete_news
     - upgrade_d7_node_complete_wiki_page
+    - upgrade_d7_node_complete_event
+    - upgrade_d7_node_complete_photoalbum
   optional: {  }

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_comment.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_comment.yml
@@ -36,7 +36,7 @@ process:
         - upgrade_d7_node_complete_document
         - upgrade_d7_node_complete_news
         - upgrade_d7_node_complete_wiki_page
-#        - upgrade_d7_node_complete_event
+        - upgrade_d7_node_complete_event
     - plugin: node_complete_node_lookup
     - plugin: skip_on_empty
       method: row
@@ -65,28 +65,24 @@ process:
   changed: changed
   status: status
   thread: thread
-  comment_body:
-    - plugin: eic_media_wysiwyg_filter
-      source: comment_body
-      media_migrations:
-        - upgrade_d7_file_audio_to_media
-        - upgrade_d7_file_document_to_media
-        - upgrade_d7_file_image_to_media
-        - upgrade_d7_file_undefined_to_media
-        - upgrade_d7_file_video_to_media
+  'comment_body/value':
+    plugin: extract
+    source: comment_body
+    index:
+      - 0
+      - value
+  'comment_body/format':
+    plugin: default_value
+    default_value: 'basic_text'
 destination:
   plugin: 'entity:comment'
 migration_dependencies:
   required:
     - upgrade_d7_user
-    - upgrade_d7_file_audio_to_media
-    - upgrade_d7_file_document_to_media
-    - upgrade_d7_file_image_to_media
-    - upgrade_d7_file_undefined_to_media
-    - upgrade_d7_file_video_to_media
     - upgrade_d7_node_complete_article
     - upgrade_d7_node_complete_discussion
     - upgrade_d7_node_complete_document
     - upgrade_d7_node_complete_news
     - upgrade_d7_node_complete_wiki_page
+    - upgrade_d7_node_complete_event
   optional: { }


### PR DESCRIPTION
### Improvements

- Improve comment migration.

### Tests

- [x] Run `drush mim upgrade_d7_comment --execute-dependencies --force`

### Remarks

- Some comments have html tags that are not properly decoded when viewing the comments