### PR TITLE
EICNET-2034: Group type notification - group deleted (rework 2)

### DIFF
--- a/config/sync/language/en/message.template.notify_delete_request_accepted.yml
+++ b/config/sync/language/en/message.template.notify_delete_request_accepted.yml
@@ -1,6 +1,6 @@
 text:
   -
-    value: "<p>Dear <a href=\"[message:author:url]\">[message:author:field_first_name:value]&nbsp;[message:author:field_last_name:value]</a>,</p>\r\n\r\n<p><a href=\"[message:field_referenced_flag:entity:field_request_moderator:entity:url]\">[message:field_referenced_flag:entity:field_request_moderator:entity:field_first_name:value] [message:field_referenced_flag:entity:field_request_moderator:entity:field_last_name:value]</a> has deleted [message:field_referenced_flag:entity:target_entity:title].</p>\r\n\r\n<p>The EIC Community team</p>\r\n"
+    value: "<p>Dear <a href=\"[message:author:url]\">[message:author:display-name]</a>,</p>\r\n\r\n<p><a href=\"[message:field_referenced_flag:entity:field_request_moderator:entity:url]\">[message:field_referenced_flag:entity:field_request_moderator:entity:display-name]</a> has deleted [message:field_referenced_flag:entity:target_entity:title].</p>\r\n\r\n<p>The EIC Community team</p>\r\n"
     format: full_html
   -
     value: "<p>[message:raw-value:field_rendered_content]</p>\r\n"

--- a/config/sync/language/en/message.template.notify_group_deleted.yml
+++ b/config/sync/language/en/message.template.notify_group_deleted.yml
@@ -3,5 +3,5 @@ text:
     value: "<p>The [message:field_entity_type:value] [message:field_referenced_entity_label:value] was deleted</p>\r\n"
     format: full_html
   -
-    value: "<p>Dear [message:author:display-name],</p>\r\n\r\n<p>[message:field_event_executing_user:entity:display-name] deleted [message:field_entity_type:value] [message:field_referenced_entity_label:value] and its content.</p>\r\n\r\n<p>The EIC Community team</p>\r\n"
+    value: "<p>Dear [message:author:display-name],</p>\r\n\r\n<p><a href=\"[message:field_event_executing_user:entity:url]\">[message:field_event_executing_user:entity:display-name]</a> deleted [message:field_entity_type:value] [message:field_referenced_entity_label:value] and its content.</p>\r\n\r\n<p>The EIC Community team</p>\r\n"
     format: full_html

--- a/config/sync/message.template.notify_delete_request_accepted.yml
+++ b/config/sync/message.template.notify_delete_request_accepted.yml
@@ -14,7 +14,7 @@ label: 'NOTIFY :: MT40 :: Deletion request - request accepted'
 description: 'Notification sent to the request/author when a delete request is accepted'
 text:
   -
-    value: "<p>Dear <a href=\"[message:author:url]\">[message:author:field_first_name:value]&nbsp;[message:author:field_last_name:value]</a>,</p>\r\n\r\n<p><a href=\"[message:field_referenced_flag:entity:field_request_moderator:entity:url]\">[message:field_referenced_flag:entity:field_request_moderator:entity:field_first_name:value] [message:field_referenced_flag:entity:field_request_moderator:entity:field_last_name:value]</a> has deleted [message:field_referenced_flag:entity:target_entity:title].</p>\r\n\r\n<p>The EIC Community team</p>\r\n"
+    value: "<p>Dear <a href=\"[message:author:url]\">[message:author:display-name]</a>,</p>\r\n\r\n<p><a href=\"[message:field_referenced_flag:entity:field_request_moderator:entity:url]\">[message:field_referenced_flag:entity:field_request_moderator:entity:display-name]</a> has deleted [message:field_referenced_flag:entity:target_entity:title].</p>\r\n\r\n<p>The EIC Community team</p>\r\n"
     format: full_html
   -
     value: "<p>[message:raw-value:field_rendered_content]</p>\r\n"

--- a/config/sync/message.template.notify_group_deleted.yml
+++ b/config/sync/message.template.notify_group_deleted.yml
@@ -17,7 +17,7 @@ text:
     value: "<p>The [message:field_entity_type:value] [message:field_referenced_entity_label:value] was deleted</p>\r\n"
     format: full_html
   -
-    value: "<p>Dear [message:author:display-name],</p>\r\n\r\n<p>[message:field_event_executing_user:entity:display-name] deleted [message:field_entity_type:value] [message:field_referenced_entity_label:value] and its content.</p>\r\n\r\n<p>The EIC Community team</p>\r\n"
+    value: "<p>Dear [message:author:display-name],</p>\r\n\r\n<p><a href=\"[message:field_event_executing_user:entity:url]\">[message:field_event_executing_user:entity:display-name]</a> deleted [message:field_entity_type:value] [message:field_referenced_entity_label:value] and its content.</p>\r\n\r\n<p>The EIC Community team</p>\r\n"
     format: full_html
 settings:
   'token options':

--- a/lib/modules/eic_messages/src/Service/RequestMessageCreator.php
+++ b/lib/modules/eic_messages/src/Service/RequestMessageCreator.php
@@ -227,7 +227,12 @@ class RequestMessageCreator implements ContainerInjectionInterface {
     }
 
     /** @var \Drupal\user\UserInterface[] $to */
-    $to = [$entity_owner, $flagging->getOwner()];
+    $to = [$flagging->getOwner()];
+    // If the user who made the request is not the owner of the entity, we want
+    // to make sure the owner also receives a notification.
+    if ($entity_owner->id() !== $flagging->getOwner()->id()) {
+      $to[] = $entity_owner;
+    }
     $response = $flagging->get('field_request_status')->value;
     $message_name = $handler->getMessageByAction($response);
     if (!$message_name) {
@@ -275,6 +280,7 @@ class RequestMessageCreator implements ContainerInjectionInterface {
     // a group is deleted via request, at that point the group owner has already
     // been deleted.
     if (
+      $entity_owner->id() !== $flagging->getOwner()->id() &&
       $handler->getType() === RequestTypes::DELETE &&
       RequestStatus::ACCEPTED === $response &&
       $entity instanceof GroupInterface


### PR DESCRIPTION
### Improvements

- Prevent entity owner from receiving notification about group deletion twice.

### Test

1st scenario:
- [x] As GO, go to your group and make a request delete
- [x] As SA/SCM, accept the request
- [x] Make sure the GO receives only 1 notification about the request accepted

2nd scenario:
- [x] As GA, go to your group and make a request delete
- [x] As SA/SCM, accept the request
- [x] Make sure the GO and GA receive only 1 notification about the request accepted