### PR TITLE
EICNET-1445: File download counter migration

### DIFF
--- a/config/sync/migrate_plus.migration.upgrade_d7_file_download_counter.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_file_download_counter.yml
@@ -1,0 +1,50 @@
+uuid: 2624d990-ef66-4a43-9626-19f16107e974
+langcode: en
+status: true
+dependencies: {  }
+id: upgrade_d7_file_download_counter
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags:
+  - 'Drupal 7'
+  - Content
+migration_group: migrate_drupal_7
+label: 'File download counter'
+source:
+  plugin: eic_d7_file_download_counter
+  track_changes: true
+process:
+  fid:
+    -
+      plugin: migration_lookup
+      source: fid
+      migration:
+        - upgrade_d7_file
+        - upgrade_d7_file_private
+    -
+      plugin: skip_on_empty
+      method: row
+  totalcount: download_count
+  daycount:
+    -
+      plugin: default_value
+      default_value: 0
+  timestamp: download_timestamp
+destination:
+  plugin: table
+  table_name: file_counter
+  id_fields:
+    fid:
+      type: integer
+      use_auto_increment: false
+  fields:
+    fid: fid
+    totalcount: totalcount
+    daycount: daycount
+    timestamp: timestamp
+migration_dependencies:
+  required:
+    - upgrade_d7_file
+    - upgrade_d7_file_private
+  optional: {  }

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_file_download_counter.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_file_download_counter.yml
@@ -1,0 +1,46 @@
+langcode: en
+status: true
+dependencies: {  }
+id: upgrade_d7_file_download_counter
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags:
+  - 'Drupal 7'
+  - Content
+migration_group: migrate_drupal_7
+label: 'File download counter'
+source:
+  plugin: eic_d7_file_download_counter
+  track_changes: true
+process:
+  fid:
+    - plugin: migration_lookup
+      source: fid
+      migration:
+        - upgrade_d7_file
+        - upgrade_d7_file_private
+    - plugin: skip_on_empty
+      method: row
+  totalcount: download_count
+  daycount:
+    - plugin: default_value
+      default_value: 0
+  timestamp: download_timestamp
+destination:
+  plugin: table
+  table_name: file_counter
+  id_fields:
+    fid:
+      type: integer
+      use_auto_increment: false
+  fields:
+    fid: fid
+    totalcount: totalcount
+    daycount: daycount
+    timestamp: timestamp
+migration_dependencies:
+  required:
+    - upgrade_d7_file
+    - upgrade_d7_file_private
+  optional: {  }

--- a/lib/modules/eic_migrate/src/Plugin/migrate/source/FileDownloadCounter.php
+++ b/lib/modules/eic_migrate/src/Plugin/migrate/source/FileDownloadCounter.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Drupal\eic_migrate\Plugin\migrate\source;
+
+use Drupal\migrate\Plugin\migrate\source\SqlBase;
+
+/**
+ * Drupal 7 file download counter source from database.
+ *
+ * @MigrateSource(
+ *   id = "eic_d7_file_download_counter",
+ *   source_module = "eic_migrate"
+ * )
+ */
+class FileDownloadCounter extends SqlBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    // Source data is queried from 'file_download_count' table.
+    $query = $this->select('file_download_count', 'f');
+    $query->fields('f', [
+      'fid',
+    ]);
+    // Counts the number of downloads per file.
+    $query->addExpression('COUNT(fid)', 'download_count');
+    // Gets the timestamp of the latest download.
+    $query->addExpression('MAX(timestamp)', 'download_timestamp');
+    $query->groupBy('f.fid');
+    return $query;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function fields() {
+    $fields = [
+      'fid' => $this->t('File ID'),
+      'download_count' => $this->t('File download count'),
+      'download_timestamp' => $this->t('Timestamp of the latest download'),
+    ];
+    return $fields;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getIds() {
+    return [
+      'fid' => [
+        'type' => 'integer',
+        'alias' => 'f',
+      ],
+    ];
+  }
+
+}


### PR DESCRIPTION
### Features

- Implement file download counter migration.

### Test

- [x] Run `drush mim upgrade_d7_file_download_counter --execute-dependencies --force` -> 907 items (895 created, 0 updated, 0 failed, 12 ignored)