### PR TITLE
Feature/eicnet 1538 organisations migration

### DIFF
--- a/config/sync/core.entity_form_display.group.organisation.default.yml
+++ b/config/sync/core.entity_form_display.group.organisation.default.yml
@@ -20,6 +20,7 @@ dependencies:
     - field.field.group.organisation.field_social_links
     - field.field.group.organisation.field_team_members
     - field.field.group.organisation.field_thumbnail
+    - field.field.group.organisation.field_vocab_geo_selling
     - field.field.group.organisation.field_vocab_services_products
     - field.field.group.organisation.field_vocab_target_markets
     - field.field.group.organisation.field_vocab_topics
@@ -99,6 +100,7 @@ third_party_settings:
         - field_vocab_services_products
         - field_vocab_target_markets
         - field_vocab_topics
+        - field_vocab_geo_selling
       label: Taxonomies
       region: content
       parent_name: group_organisation
@@ -218,7 +220,7 @@ content:
     third_party_settings: {  }
   field_locations:
     type: entity_reference_paragraphs
-    weight: 29
+    weight: 27
     region: content
     settings:
       title: Paragraph
@@ -291,7 +293,7 @@ content:
     third_party_settings: {  }
   field_social_links:
     type: social_links
-    weight: 27
+    weight: 26
     region: content
     settings:
       select_social: false
@@ -316,6 +318,24 @@ content:
     settings:
       media_types: {  }
     third_party_settings: {  }
+  field_vocab_geo_selling:
+    type: entity_tree
+    weight: 8
+    region: content
+    settings:
+      match_top_level_limit: '0'
+      load_all: '1'
+      items_to_load: '25'
+      selected_terms_label: 'Your selected values'
+      search_label: 'Select a value'
+      search_placeholder: Search
+      auto_select_parents: '1'
+      disable_top_choices: 0
+      can_create_tag: 0
+      ignore_current_user: 0
+      target_bundles: {  }
+      is_required: false
+    third_party_settings: {  }
   field_vocab_services_products:
     type: entity_tree
     weight: 5
@@ -327,6 +347,12 @@ content:
       load_all: 0
       auto_select_parents: 0
       ignore_current_user: 0
+      target_bundles: {  }
+      is_required: false
+      can_create_tag: false
+      search_label: 'Select a value'
+      search_placeholder: Search
+      selected_terms_label: 'Your selected values'
     third_party_settings: {  }
   field_vocab_target_markets:
     type: entity_tree
@@ -339,6 +365,12 @@ content:
       load_all: 0
       auto_select_parents: 0
       ignore_current_user: 0
+      target_bundles: {  }
+      is_required: false
+      can_create_tag: false
+      search_label: 'Select a value'
+      search_placeholder: Search
+      selected_terms_label: 'Your selected values'
     third_party_settings: {  }
   field_vocab_topics:
     type: entity_tree
@@ -351,6 +383,12 @@ content:
       load_all: 0
       auto_select_parents: 0
       ignore_current_user: 0
+      target_bundles: {  }
+      is_required: false
+      can_create_tag: false
+      search_label: 'Select a value'
+      search_placeholder: Search
+      selected_terms_label: 'Your selected values'
     third_party_settings: {  }
   label:
     type: string_textfield

--- a/config/sync/core.entity_view_display.group.organisation.default.yml
+++ b/config/sync/core.entity_view_display.group.organisation.default.yml
@@ -20,6 +20,7 @@ dependencies:
     - field.field.group.organisation.field_social_links
     - field.field.group.organisation.field_team_members
     - field.field.group.organisation.field_thumbnail
+    - field.field.group.organisation.field_vocab_geo_selling
     - field.field.group.organisation.field_vocab_services_products
     - field.field.group.organisation.field_vocab_target_markets
     - field.field.group.organisation.field_vocab_topics
@@ -102,6 +103,14 @@ content:
       link: true
     third_party_settings: {  }
     weight: 8
+    region: content
+  field_vocab_geo_selling:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 11
     region: content
   flag_follow_group:
     settings: {  }

--- a/config/sync/field.field.group.organisation.field_vocab_geo_selling.yml
+++ b/config/sync/field.field.group.organisation.field_vocab_geo_selling.yml
@@ -1,0 +1,29 @@
+uuid: b936d108-add6-4bc5-95dc-35b951373eb6
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.group.field_vocab_geo_selling
+    - group.type.organisation
+    - taxonomy.vocabulary.geo
+id: group.organisation.field_vocab_geo_selling
+field_name: field_vocab_geo_selling
+entity_type: group
+bundle: organisation
+label: 'Country(ies) the organisation is selling to'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      geo: geo
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.storage.group.field_vocab_geo_selling.yml
+++ b/config/sync/field.storage.group.field_vocab_geo_selling.yml
@@ -1,0 +1,20 @@
+uuid: 7fbb3574-0b7a-447f-b156-a9cb95f16b84
+langcode: en
+status: true
+dependencies:
+  module:
+    - group
+    - taxonomy
+id: group.field_vocab_geo_selling
+field_name: field_vocab_geo_selling
+entity_type: group
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/migrate_plus.migration.upgrade_d7_node_complete_group.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_node_complete_group.yml
@@ -117,6 +117,7 @@ process:
   features:
     -
       plugin: eic_group_features
+      group_bundle: group
 destination:
   plugin: 'entity_complete:group'
   default_bundle: group
@@ -125,6 +126,7 @@ migration_dependencies:
   required:
     - upgrade_d7_user
     - upgrade_d7_file_image_to_media
+    - upgrade_d7_node_complete_organisation
     - smed_regions_countries_lvl1
     - smed_regions_countries_lvl2
     - smed_thematics_topics_lvl1

--- a/config/sync/migrate_plus.migration.upgrade_d7_node_complete_organisation.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_node_complete_organisation.yml
@@ -1,0 +1,228 @@
+uuid: 5de8730e-4791-4a5b-8da9-da912cbbdc68
+langcode: en
+status: true
+dependencies: {  }
+id: upgrade_d7_node_complete_organisation
+class: Drupal\node\Plugin\migrate\D7NodeTranslation
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags:
+  - 'Drupal 7'
+  - Content
+migration_group: migrate_drupal_7
+label: 'Node complete (Organisation)'
+source:
+  plugin: eic_d7_node_complete_with_smed_ids
+  node_type: organisation
+  track_changes: true
+  smed_taxonomy_fields:
+    - c4m_vocab_geo
+    - c4m_vocab_geo_selling
+    - c4m_vocab_topic
+  constants:
+    FACEBOOK_LINK_TYPE: facebook
+    LINKEDIN_LINK_TYPE: linkedin
+    TWITTER_LINK_TYPE: twitter
+process:
+  id:
+    -
+      plugin: migration_lookup
+      migration: upgrade_d7_node_complete_organisation
+      source: tnid
+    -
+      plugin: node_complete_node_lookup
+  revision_id:
+    -
+      plugin: get
+      source: vid
+  langcode:
+    -
+      plugin: default_value
+      default_value: en
+  label: title
+  uid:
+    -
+      plugin: migration_lookup
+      source: node_uid
+      migration:
+        - upgrade_d7_user
+  status: status
+  moderation_state:
+    -
+      plugin: static_map
+      source: c4m_og_status
+      map:
+        pending: pending
+        draft: draft
+        published: published
+        archived: archived
+        deleted: archived
+  created: created
+  changed: changed
+  revision_user:
+    -
+      plugin: migration_lookup
+      source: revision_uid
+      migration:
+        - upgrade_d7_user
+  revision_log_message: log
+  revision_created: revision_timestamp
+  features:
+    -
+      plugin: eic_group_features
+      group_bundle: organisation
+  field_address:
+    -
+      plugin: addressfield
+      source: c4m_location_address
+  field_header_visual:
+    -
+      plugin: sub_process
+      source: c4m_banner
+      process:
+        target_id:
+          -
+            plugin: migration_lookup
+            source: fid
+            migration:
+              - upgrade_d7_file_image_to_media
+  field_date_establishement:
+    -
+      plugin: format_date
+      from_format: 'Y-m-d H:i:s'
+      to_format: 'Y'
+      source: c4m_date_est/0/value
+  field_body:
+    -
+      plugin: eic_media_wysiwyg_filter
+      source: field_c4m_about_us
+      media_migrations:
+        - upgrade_d7_file_audio_to_media
+        - upgrade_d7_file_document_to_media
+        - upgrade_d7_file_image_to_media
+        - upgrade_d7_file_undefined_to_media
+        - upgrade_d7_file_video_to_media
+        - upgrade_d7_file_youtube_video_to_media
+  field_body/0/format:
+    -
+      plugin: static_map
+      source: field_c4m_about_us/0/format
+      bypass: true
+      map:
+        full_html: full_html
+        filtered_html: filtered_html
+        plain_text: plain_text
+    -
+      plugin: default_value
+      default_value: filtered_html
+  field_email: c4m_email
+  field_organisation_link: c4m_link
+  field_smed_id: c4m_organisation_dashboard_id
+  field_vocab_geo_selling:
+    -
+      plugin: sub_process
+      source: c4m_vocab_geo_selling
+      process:
+        target_id:
+          -
+            plugin: migration_lookup
+            source: smed_id
+            no_stub: true
+            migration:
+              - smed_regions_countries_lvl1
+              - smed_regions_countries_lvl2
+  field_thumbnail:
+    -
+      plugin: sub_process
+      source: c4m_media
+      process:
+        target_id:
+          -
+            plugin: migration_lookup
+            source: fid
+            migration:
+              - upgrade_d7_file_image_to_media
+  field_vocab_topics:
+    -
+      plugin: sub_process
+      source: c4m_vocab_topic
+      process:
+        target_id:
+          -
+            plugin: migration_lookup
+            source: smed_id
+            no_stub: true
+            migration:
+              - smed_thematics_topics_lvl1
+              - smed_thematics_topics_lvl2
+              - smed_thematics_topics_lvl3
+  field_organisation_type:
+    -
+      plugin: sub_process
+      source: c4m_organisations_type
+      process:
+        target_id:
+          -
+            plugin: migration_lookup
+            source: tid
+            no_stub: true
+            migration:
+              - upgrade_d7_taxonomy_term_c4m_vocab_organisation_types
+  _social_link_facebook:
+    -
+      plugin: get
+      source:
+        - constants/FACEBOOK_LINK_TYPE
+        - c4m_facebook/0/url
+  _social_link_linkedin:
+    -
+      plugin: get
+      source:
+        - constants/LINKEDIN_LINK_TYPE
+        - c4m_linkedin/0/url
+  _social_link_twitter:
+    -
+      plugin: get
+      source:
+        - constants/TWITTER_LINK_TYPE
+        - c4m_twitter/0/url
+  _field_social_links:
+    -
+      plugin: get
+      source:
+        - '@_social_link_facebook'
+        - '@_social_link_linkedin'
+        - '@_social_link_twitter'
+  field_social_links:
+    -
+      plugin: sub_process
+      source: '@_field_social_links'
+      process:
+        social:
+          -
+            plugin: get
+            source: '0'
+        link:
+          -
+            plugin: str_replace
+            source: '1'
+            regex: true
+            search: '/^((https?:\/\/)?(www\.)?([a-zA-Z-]+\.)?(facebook|linkedin|kedin|linkediin|twitter)(\.com)?\/)/'
+            replace: ''
+destination:
+  plugin: 'entity_complete:group'
+  default_bundle: organisation
+  translations: true
+migration_dependencies:
+  required:
+    - upgrade_d7_user
+    - upgrade_d7_file_audio_to_media
+    - upgrade_d7_file_document_to_media
+    - upgrade_d7_file_image_to_media
+    - upgrade_d7_file_undefined_to_media
+    - upgrade_d7_file_video_to_media
+    - upgrade_d7_file_youtube_video_to_media
+    - upgrade_d7_taxonomy_term_c4m_vocab_organisation_types
+    - smed_regions_countries_lvl1
+    - smed_regions_countries_lvl2
+  optional: {  }

--- a/config/sync/migrate_plus.migration.upgrade_d7_taxonomy_term_c4m_vocab_organisation_types.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_taxonomy_term_c4m_vocab_organisation_types.yml
@@ -1,0 +1,45 @@
+uuid: 69c90a1d-a443-405d-a47b-7aa1b3a77990
+langcode: en
+status: true
+dependencies: {  }
+id: upgrade_d7_taxonomy_term_c4m_vocab_organisation_types
+class: Drupal\migrate\Plugin\Migration
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags:
+  - 'Drupal 7'
+  - Content
+migration_group: migrate_drupal_7
+label: 'Taxonomy terms (Organisation Types)'
+source:
+  plugin: d7_taxonomy_term
+  bundle: c4m_vocab_organisation_types
+  track_changes: true
+process:
+  name: name
+  description/value: description
+  description/format: format
+  weight: weight
+  parent_id:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: parent
+    -
+      plugin: migration_lookup
+      migration:
+        - upgrade_d7_taxonomy_term_c4m_vocab_organisation_types
+  parent:
+    -
+      plugin: default_value
+      default_value: 0
+      source: '@parent_id'
+  forum_container: is_container
+  changed: timestamp
+  langcode: language
+destination:
+  plugin: 'entity:taxonomy_term'
+  default_bundle: organisation_types
+migration_dependencies:
+  required: {  }
+  optional: {  }

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_group.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_group.yml
@@ -140,6 +140,7 @@ migration_dependencies:
   required:
     - upgrade_d7_user
     - upgrade_d7_file_image_to_media
+    - upgrade_d7_node_complete_organisation
     - smed_regions_countries_lvl1
     - smed_regions_countries_lvl2
     - smed_thematics_topics_lvl1

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_group.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_group.yml
@@ -127,6 +127,7 @@ process:
   field_message_to_site_admin: field_message_to_site_admin
   features:
     - plugin: eic_group_features
+      group_bundle: group
   # TODO
 #  group_group:
 #    - plugin: get

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_organisation.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_organisation.yml
@@ -1,0 +1,201 @@
+langcode: en
+status: true
+dependencies: { }
+id: upgrade_d7_node_complete_organisation
+class: Drupal\node\Plugin\migrate\D7NodeTranslation
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags:
+  - 'Drupal 7'
+  - Content
+migration_group: migrate_drupal_7
+label: 'Node complete (Organisation)'
+source:
+  plugin: eic_d7_node_complete_with_smed_ids
+  node_type: organisation
+  track_changes: true
+  smed_taxonomy_fields:
+    - c4m_vocab_geo
+    - c4m_vocab_geo_selling
+    - c4m_vocab_topic
+  constants:
+    FACEBOOK_LINK_TYPE: 'facebook'
+    LINKEDIN_LINK_TYPE: 'linkedin'
+    TWITTER_LINK_TYPE: 'twitter'
+process:
+  id:
+    - plugin: migration_lookup
+      migration: upgrade_d7_node_complete_organisation
+      source: tnid
+    - plugin: node_complete_node_lookup
+  revision_id:
+    - plugin: get
+      source: vid
+  langcode:
+    - plugin: default_value
+      default_value: en
+  label: title
+  uid:
+    - plugin: migration_lookup
+      source: node_uid
+      migration:
+        - upgrade_d7_user
+  status: status
+  moderation_state:
+    - plugin: static_map
+      source: c4m_og_status
+      map:
+        pending: pending
+        draft: draft
+        published: published
+        archived: archived
+        # TODO: what should we do with (soft) deleted groups?
+        deleted: archived
+  created: created
+  changed: changed
+  revision_user:
+    - plugin: migration_lookup
+      source: revision_uid
+      migration:
+        - upgrade_d7_user
+  revision_log_message: log
+  revision_created: revision_timestamp
+  features:
+    - plugin: eic_group_features
+      group_bundle: organisation
+  field_address:
+    - plugin: addressfield
+      source: c4m_location_address
+  field_header_visual:
+    - plugin: sub_process
+      source: c4m_banner
+      process:
+        target_id:
+          - plugin: migration_lookup
+            source: fid
+            migration:
+              - upgrade_d7_file_image_to_media
+  field_date_establishement:
+    - plugin: format_date
+      from_format: 'Y-m-d H:i:s'
+      to_format: 'Y'
+      source: c4m_date_est/0/value
+  field_body:
+    - plugin: eic_media_wysiwyg_filter
+      source: field_c4m_about_us
+      media_migrations:
+        - upgrade_d7_file_audio_to_media
+        - upgrade_d7_file_document_to_media
+        - upgrade_d7_file_image_to_media
+        - upgrade_d7_file_undefined_to_media
+        - upgrade_d7_file_video_to_media
+        - upgrade_d7_file_youtube_video_to_media
+  field_body/0/format:
+    - plugin: static_map
+      source: field_c4m_about_us/0/format
+      bypass: true
+      map:
+        full_html: full_html
+        filtered_html: filtered_html
+        plain_text: plain_text
+    - plugin: default_value
+      default_value: filtered_html
+  field_email: c4m_email
+  field_organisation_link: c4m_link
+  #field_vocab_services_products:
+  field_smed_id: c4m_organisation_dashboard_id
+  #field_vocab_target_markets:
+  field_vocab_geo_selling:
+    - plugin: sub_process
+      source: c4m_vocab_geo_selling
+      process:
+        target_id:
+          - plugin: migration_lookup
+            source: smed_id
+            no_stub: true
+            migration:
+              - smed_regions_countries_lvl1
+              - smed_regions_countries_lvl2
+  field_thumbnail:
+    - plugin: sub_process
+      source: c4m_media
+      process:
+        target_id:
+          - plugin: migration_lookup
+            source: fid
+            migration:
+              - upgrade_d7_file_image_to_media
+  field_vocab_topics:
+    - plugin: sub_process
+      source: c4m_vocab_topic
+      process:
+        target_id:
+          - plugin: migration_lookup
+            source: smed_id
+            no_stub: true
+            migration:
+              - smed_thematics_topics_lvl1
+              - smed_thematics_topics_lvl2
+              - smed_thematics_topics_lvl3
+  field_organisation_type:
+    - plugin: sub_process
+      source: c4m_organisations_type
+      process:
+        target_id:
+          - plugin: migration_lookup
+            source: tid
+            no_stub: true
+            migration:
+              - upgrade_d7_taxonomy_term_c4m_vocab_organisation_types
+  _social_link_facebook:
+    - plugin: get
+      source:
+        - constants/FACEBOOK_LINK_TYPE
+        - c4m_facebook/0/url
+  _social_link_linkedin:
+    - plugin: get
+      source:
+        - constants/LINKEDIN_LINK_TYPE
+        - c4m_linkedin/0/url
+  _social_link_twitter:
+    - plugin: get
+      source:
+        - constants/TWITTER_LINK_TYPE
+        - c4m_twitter/0/url
+  _field_social_links:
+    - plugin: get
+      source:
+        - '@_social_link_facebook'
+        - '@_social_link_linkedin'
+        - '@_social_link_twitter'
+  field_social_links:
+    - plugin: sub_process
+      source: '@_field_social_links'
+      process:
+        social:
+          - plugin: get
+            source: '0'
+        link:
+          - plugin: str_replace
+            source: '1'
+            regex: true
+            search: "/^((https?:\\/\\/)?(www\\.)?([a-zA-Z-]+\\.)?(facebook|linkedin|kedin|linkediin|twitter)(\\.com)?\\/)/"
+            replace: ""
+
+destination:
+  plugin: 'entity_complete:group'
+  default_bundle: organisation
+  translations: true
+migration_dependencies:
+  required:
+    - upgrade_d7_user
+    - upgrade_d7_file_audio_to_media
+    - upgrade_d7_file_document_to_media
+    - upgrade_d7_file_image_to_media
+    - upgrade_d7_file_undefined_to_media
+    - upgrade_d7_file_video_to_media
+    - upgrade_d7_file_youtube_video_to_media
+    - upgrade_d7_taxonomy_term_c4m_vocab_organisation_types
+    - smed_regions_countries_lvl1
+    - smed_regions_countries_lvl2
+  optional: { }

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_taxonomy_term_c4m_vocab_organisation_types.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_taxonomy_term_c4m_vocab_organisation_types.yml
@@ -1,0 +1,50 @@
+langcode: en
+status: true
+dependencies: {  }
+id: upgrade_d7_taxonomy_term_c4m_vocab_organisation_types
+class: Drupal\migrate\Plugin\Migration
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags:
+  - 'Drupal 7'
+  - Content
+migration_group: migrate_drupal_7
+label: 'Taxonomy terms (Organisation Types)'
+source:
+  plugin: d7_taxonomy_term
+  bundle: c4m_vocab_organisation_types
+  track_changes: true
+process:
+  # Ignore Term ID. A new one will be generated.
+#  tid:
+#    - plugin: get
+#      source: tid
+  # Ignore Vocabulary ID. It will be automatically filled by the default_bundle on the destination.
+#  vid:
+#    - plugin: migration_lookup
+#      migration: upgrade_d7_taxonomy_vocabulary
+#      source: vid
+  name: name
+  description/value: description
+  description/format: format
+  weight: weight
+  parent_id:
+    - plugin: skip_on_empty
+      method: process
+      source: parent
+    - plugin: migration_lookup
+      migration:
+        - upgrade_d7_taxonomy_term_c4m_vocab_organisation_types
+  parent:
+    - plugin: default_value
+      default_value: 0
+      source: '@parent_id'
+  forum_container: is_container
+  changed: timestamp
+  langcode: language
+destination:
+  plugin: 'entity:taxonomy_term'
+  default_bundle: organisation_types
+migration_dependencies:
+  required: { }
+  optional: { }

--- a/lib/modules/eic_migrate/src/EventSubscriber/PostMigrationSubscriber.php
+++ b/lib/modules/eic_migrate/src/EventSubscriber/PostMigrationSubscriber.php
@@ -415,10 +415,10 @@ class PostMigrationSubscriber implements EventSubscriberInterface {
   protected function findOrganisationIds(array $names = []) {
     $results = [];
     foreach ($names as $name) {
-      if ($group = $this->entityTypeManager->getStorage('group')->loadByProperties([
+      foreach ($this->entityTypeManager->getStorage('group')->loadByProperties([
         'label' => $name,
         'type' => Organisations::GROUP_ORGANISATION_BUNDLE,
-      ])) {
+      ]) as $group) {
         $results[] = $group->id();
       }
     }

--- a/lib/modules/eic_migrate/src/Plugin/migrate/process/GroupFeatures.php
+++ b/lib/modules/eic_migrate/src/Plugin/migrate/process/GroupFeatures.php
@@ -3,9 +3,13 @@
 namespace Drupal\eic_migrate\Plugin\migrate\process;
 
 use Drupal\Core\Database\Database;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\Plugin\MigrationInterface;
 use Drupal\migrate\ProcessPluginBase;
 use Drupal\migrate\Row;
+use Drupal\oec_group_features\GroupFeatureHelper;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides an eic_group_features plugin.
@@ -18,13 +22,14 @@ use Drupal\migrate\Row;
  * process:
  *   foo:
  *     plugin: eic_group_features
+ *     group_bundle: bar
  * @endcode
  *
  * @MigrateProcessPlugin(
  *   id = "eic_group_features"
  * )
  */
-class GroupFeatures extends ProcessPluginBase {
+class GroupFeatures extends ProcessPluginBase implements ContainerFactoryPluginInterface {
 
   /**
    * Maps the old group features names to the new ones.
@@ -32,14 +37,22 @@ class GroupFeatures extends ProcessPluginBase {
    * @var array
    */
   const GROUP_FEATURES_MAPPING = [
-    'c4m_features_og_discussions' => 'eic_groups_discussions',
-    'c4m_features_og_documents' => 'eic_groups_files',
-    'c4m_features_og_events' => 'eic_groups_group_events',
-    'c4m_features_og_highlights' => NULL,
-    'c4m_features_og_media' => 'eic_groups_files',
-    'c4m_features_og_members' => 'eic_groups_members',
-    'c4m_features_og_news' => 'eic_groups_news',
-    'c4m_features_og_wiki' => 'eic_groups_wiki',
+    'group' => [
+      'c4m_features_og_discussions' => 'eic_groups_discussions',
+      'c4m_features_og_documents' => 'eic_groups_files',
+      'c4m_features_og_events' => 'eic_groups_group_events',
+      'c4m_features_og_highlights' => NULL,
+      'c4m_features_og_media' => 'eic_groups_files',
+      'c4m_features_og_members' => 'eic_groups_members',
+      'c4m_features_og_news' => 'eic_groups_news',
+      'c4m_features_og_wiki' => 'eic_groups_wiki',
+    ],
+    'organisation' => [
+      'c4m_features_og_events' => 'eic_groups_anchor_group_events',
+      'c4m_features_og_media' => NULL,
+      'c4m_features_og_members' => 'eic_groups_anchor_members',
+      'c4m_features_og_news' => 'eic_groups_anchor_news',
+    ],
   ];
 
   /**
@@ -52,9 +65,60 @@ class GroupFeatures extends ProcessPluginBase {
   ];
 
   /**
+   * The OEC Group feature helper.
+   *
+   * @var \Drupal\oec_group_features\GroupFeatureHelper
+   */
+  protected $groupFeatureHelper;
+
+  /**
+   * GroupFeatures constructor.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin ID.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\oec_group_features\GroupFeatureHelper $group_feature_helper
+   *   The entity storage.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, GroupFeatureHelper $group_feature_helper) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->groupFeatureHelper = $group_feature_helper;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition, MigrationInterface $migration = NULL) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('oec_group_features.helper')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration(): array {
+    return [
+      'group_bundle' => '',
+    ];
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    if (empty($this->configuration['group_bundle'])) {
+      return NULL;
+    }
+
+    $group_bundle = $this->configuration['group_bundle'];
+
     $nid = $row->getSourceIdValues()['nid'];
     $enabled_features = [];
 
@@ -74,14 +138,24 @@ class GroupFeatures extends ProcessPluginBase {
       // Add features that are enabled din the D7.
       foreach ($features as $old_feature_name => $enabled) {
         if ($enabled === $old_feature_name) {
-          $enabled_features[] = self::GROUP_FEATURES_MAPPING[$old_feature_name];
+          $enabled_features[] = self::GROUP_FEATURES_MAPPING[$group_bundle][$old_feature_name];
         }
       }
     }
     else {
       // If there is no record this means that all features are enabled by
       // default.
-      $enabled_features = array_merge($enabled_features, array_values(self::GROUP_FEATURES_MAPPING));
+      $enabled_features = array_merge($enabled_features, array_values(self::GROUP_FEATURES_MAPPING[$group_bundle]));
+    }
+
+    // Filter out feature that are not available for this group type.
+    $group_type_allowed_features = array_keys($this->groupFeatureHelper->getGroupTypeAvailableFeatures(
+      $this->configuration['group_bundle'])
+    );
+    foreach ($enabled_features as $index => $enabled_feature) {
+      if (!in_array($enabled_feature, $group_type_allowed_features)) {
+        unset($enabled_features[$index]);
+      }
     }
 
     // Add features that should be enabled by default and return result.

--- a/lib/modules/eic_migrate/src/Plugin/migrate/source/FieldValue.php
+++ b/lib/modules/eic_migrate/src/Plugin/migrate/source/FieldValue.php
@@ -13,7 +13,8 @@ use Drupal\migrate\Plugin\migrate\source\SqlBase;
  * source:
  *   plugin: eic_d7_field_value
  *   field_name: some_field_name
- *   bundle: some_bundle
+ *   entity_type: (optional) some_entity_type
+ *   bundle: (optional) some_bundle
  *   ids:
  *     some_db_column:
  *       type: integer
@@ -30,8 +31,14 @@ class FieldValue extends SqlBase {
    * {@inheritdoc}
    */
   public function query() {
-    $query = $this->select('field_revision_'.$this->configuration['field_name'], 'fr')
+    $query = $this->select('field_revision_' . $this->configuration['field_name'], 'fr')
       ->fields('fr');
+    if (!empty($this->configuration['entity_type'])) {
+      $query->condition('entity_type', $this->configuration['entity_type']);
+    }
+    if (!empty($this->configuration['bundle'])) {
+      $query->condition('bundle', $this->configuration['bundle']);
+    }
     return $query;
   }
 


### PR DESCRIPTION
### Improvements

- Added `field_vocab_geo_selling` to organisation type
- Groups migration: this is now taking into account the organisation visibility (custom restricted)
- Added organisation types migration

### Tests

- Run `drush mim upgrade_d7_node_complete_organisation`
- You should have 6524 organisations (6695 revisionsà