### PR TITLE
EICNET-1313: Node 'Photo' migration (improvements)

### DIFF
--- a/config/sync/migrate_plus.migration.upgrade_d7_node_complete_photoalbum.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_node_complete_photoalbum.yml
@@ -70,6 +70,20 @@ process:
         - upgrade_d7_file_image_to_media
         - upgrade_d7_file_undefined_to_media
         - upgrade_d7_file_video_to_media
+        - upgrade_d7_node_photo_to_media
+  field_vocab_geo:
+    -
+      plugin: sub_process
+      source: c4m_vocab_geo
+      process:
+        target_id:
+          -
+            plugin: migration_lookup
+            source: smed_id
+            no_stub: true
+            migration:
+              - smed_regions_countries_lvl1
+              - smed_regions_countries_lvl2
   field_language:
     -
       plugin: sub_process
@@ -119,8 +133,12 @@ migration_dependencies:
     - upgrade_d7_file_image_to_media
     - upgrade_d7_file_undefined_to_media
     - upgrade_d7_file_video_to_media
+    - upgrade_d7_node_photo_to_media
     - smed_spoken_languages
     - smed_thematics_topics_lvl1
     - smed_thematics_topics_lvl2
     - smed_thematics_topics_lvl3
+    - smed_regions_countries_lvl1
+    - smed_regions_countries_lvl2
+    - upgrade_d7_node_complete_photoalbum_gallery_slides_paragraph
   optional: {  }

--- a/config/sync/migrate_plus.migration.upgrade_d7_node_photo_to_media.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_node_photo_to_media.yml
@@ -40,7 +40,7 @@ process:
               - upgrade_d7_file_private
 destination:
   plugin: 'entity:media'
-  default_bundle: photo
+  default_bundle: image
 migration_dependencies:
   required:
     - upgrade_d7_user

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_photoalbum.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_photoalbum.yml
@@ -62,18 +62,17 @@ process:
         - upgrade_d7_file_image_to_media
         - upgrade_d7_file_undefined_to_media
         - upgrade_d7_file_video_to_media
-  # TODO: Implement when Regions & countries SMED migration is done.
-#  field_vocab_geo:
-#    - plugin: sub_process
-#      source: c4m_vocab_geo
-#      process:
-#        target_id:
-#          - plugin: migration_lookup
-#            source: smed_id
-#            no_stub: true
-#            migration:
-#              - smed_TODO
-  # TODO: Validate implementation when field_vocab_languages is added to CT News.
+  field_vocab_geo:
+    - plugin: sub_process
+      source: c4m_vocab_geo
+      process:
+        target_id:
+          - plugin: migration_lookup
+            source: smed_id
+            no_stub: true
+            migration:
+              - smed_regions_countries_lvl1
+              - smed_regions_countries_lvl2
   field_language:
     - plugin: sub_process
       source: c4m_vocab_language
@@ -128,4 +127,7 @@ migration_dependencies:
     - smed_thematics_topics_lvl1
     - smed_thematics_topics_lvl2
     - smed_thematics_topics_lvl3
+    - smed_regions_countries_lvl1
+    - smed_regions_countries_lvl2
+    - upgrade_d7_node_complete_photoalbum_gallery_slides_paragraph
   optional: { }

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_photo_to_media.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_photo_to_media.yml
@@ -58,7 +58,7 @@ process:
 #      source: og_vocabulary
 destination:
   plugin: 'entity:media'
-  default_bundle: photo
+  default_bundle: image
 migration_dependencies:
   required:
     - upgrade_d7_user


### PR DESCRIPTION
### Improvements

- Fix field regions and countries in Photo album migration + migrate Photo nodes into media type image.

### Tests

- [x] Run `drush mim upgrade_d7_node_complete_photoalbum --execute-dependencies --force`

### Remarks

- There is a field "Document type" in CType gallery which doesn't exist in D7. What should we do?