### PR TITLE
[EICNET-2267] 2nd indent on comments also triggers a message for parent comment which is 2 levels higher

### DIFF
--- a/config/sync/language/en/message.template.sub_new_comment_on_content.yml
+++ b/config/sync/language/en/message.template.sub_new_comment_on_content.yml
@@ -3,8 +3,5 @@ text:
     value: 'MT19 :: New comment on content'
     format: plain_text
   -
-    value: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
-    format: plain_text
-  -
-    value: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
-    format: plain_text
+    value: "<p>New comment from [message:field_event_executing_user:entity:display-name] on content <a href=\"[message:field_referenced_comment:entity:entity:url]\">[message:field_referenced_comment:entity:entity:title]</a></p>\r\n"
+    format: full_html

--- a/config/sync/language/en/message.template.sub_new_comment_reply.yml
+++ b/config/sync/language/en/message.template.sub_new_comment_reply.yml
@@ -3,8 +3,5 @@ text:
     value: 'MT16 :: New comment (reply) after comment'
     format: plain_text
   -
-    value: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
-    format: plain_text
-  -
-    value: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
-    format: plain_text
+    value: "<p>[message:field_event_executing_user:entity:display-name] replied to your comment on content <a href=\"[message:field_referenced_comment:entity:entity:url]\">[message:field_referenced_comment:entity:entity:title]</a></p>\r\n"
+    format: full_html

--- a/config/sync/message.template.sub_new_comment_on_content.yml
+++ b/config/sync/message.template.sub_new_comment_on_content.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - filter.format.full_html
     - filter.format.plain_text
   module:
     - eic_messages
@@ -17,11 +18,8 @@ text:
     value: 'MT19 :: New comment on content'
     format: plain_text
   -
-    value: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
-    format: plain_text
-  -
-    value: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
-    format: plain_text
+    value: "<p>New comment from [message:field_event_executing_user:entity:display-name] on content <a href=\"[message:field_referenced_comment:entity:entity:url]\">[message:field_referenced_comment:entity:entity:title]</a></p>\r\n"
+    format: full_html
 settings:
   'token options':
     clear: false

--- a/config/sync/message.template.sub_new_comment_reply.yml
+++ b/config/sync/message.template.sub_new_comment_reply.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - filter.format.full_html
     - filter.format.plain_text
   module:
     - eic_messages
@@ -17,11 +18,8 @@ text:
     value: 'MT16 :: New comment (reply) after comment'
     format: plain_text
   -
-    value: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
-    format: plain_text
-  -
-    value: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
-    format: plain_text
+    value: "<p>[message:field_event_executing_user:entity:display-name] replied to your comment on content <a href=\"[message:field_referenced_comment:entity:entity:url]\">[message:field_referenced_comment:entity:entity:title]</a></p>\r\n"
+    format: full_html
 settings:
   'token options':
     clear: false

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/eic_message_subscriptions.module
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/eic_message_subscriptions.module
@@ -5,6 +5,7 @@
  * Primary module hooks for EIC Message Notifications module.
  */
 
+use Drupal\comment\CommentInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\eic_message_subscriptions\Hooks\CronOperations;
@@ -95,6 +96,10 @@ function eic_message_subscriptions_message_subscribe_get_subscribers_alter(array
     return;
   }
 
+  if ($message->getTemplate()->id() === MessageSubscriptionTypes::NEW_COMMENT_REPLY) {
+    _eic_subscription_filter_comment_reply_subscribers($uids, $message);
+  }
+
   // Gets the executing user if exists.
   if ($message->hasField('field_event_executing_user')) {
     $executing_user = $message->get('field_event_executing_user')->entity;
@@ -111,6 +116,24 @@ function eic_message_subscriptions_message_subscribe_get_subscribers_alter(array
     $account_id = $delivery_candidate->getAccountId();
     if (!$subscription_message_checker->shouldSend($account_id, $message) && isset($uids[$account_id])) {
       unset($uids[$account_id]);
+    }
+  }
+}
+
+/**
+ * @param \Drupal\message_subscribe\Subscribers\DeliveryCandidateInterface[] $delivery_candidates
+ * @param \Drupal\message\MessageInterface $message
+ */
+function _eic_subscription_filter_comment_reply_subscribers(array &$delivery_candidates, MessageInterface $message) {
+  $comment = $message->get('field_referenced_comment')->entity;
+  if (!$comment instanceof CommentInterface || !$comment->hasParentComment()) {
+    return;
+  }
+
+  $parent_owner_id = (int) $comment->getParentComment()->getOwnerId();
+  foreach ($delivery_candidates as $key => $delivery_candidate) {
+    if ($parent_owner_id !== (int) $delivery_candidate->getAccountId()) {
+      unset($delivery_candidates[$key]);
     }
   }
 }


### PR DESCRIPTION
## To Test

- [x] Comment as user A on a story
- [x] Reply as user B on the previous comment
- [x] Reply with user C tu user B's comment

Results:
- All users following the content should get a notification for user A's top level comment
- Only authors of parent comments should get a reply notification