### PR TITLE
[EICNET-2232]fix: Add correct user link to contact in the email

### DIFF
--- a/config/sync/language/en/message.template.notify_contact_user.yml
+++ b/config/sync/language/en/message.template.notify_contact_user.yml
@@ -3,5 +3,5 @@ text:
     value: "<p>[message:field_subject]</p>\r\n"
     format: full_html
   -
-    value: "<p>Dear <u><a href=\"[message:author:url:absolute]\">[message:author:display-name]</a></u>,<br />\r\n<br />\r\n<a href=\"[message:field_sender:entity:url]\">[message:field_sender:entity:display-name]</a>&nbsp;sent you a message on the European Innovation Council platform:<br />\r\n[message:field_body]<br />\r\n<br />\r\nYou can reply to <u><a href=\"[message:field_sender:entity:url]\">[message:field_sender:entity:display-name]</a></u>&nbsp;by&nbsp;<a href=\"[message:author:url:absolute]/contact\"><u>clicking here</u></a>.<br />\r\n<br />\r\nThe EIC Community team</p>\r\n"
+    value: "<p>Dear <u><a href=\"[message:author:url:absolute]\">[message:author:display-name]</a></u>,<br />\r\n<br />\r\n<a href=\"[message:field_sender:entity:url]\">[message:field_sender:entity:display-name]</a>&nbsp;sent you a message on the European Innovation Council platform:<br />\r\n[message:field_body]<br />\r\n<br />\r\nYou can reply to <u><a href=\"[message:field_sender:entity:url]\">[message:field_sender:entity:display-name]</a></u>&nbsp;by&nbsp;<a href=\"[message:field_sender:entity:url:absolute]/contact\"><u>clicking here</u></a>.<br />\r\n<br />\r\nThe EIC Community team</p>\r\n"
     format: full_html

--- a/config/sync/message.template.notify_contact_user.yml
+++ b/config/sync/message.template.notify_contact_user.yml
@@ -17,7 +17,7 @@ text:
     value: "<p>[message:field_subject]</p>\r\n"
     format: full_html
   -
-    value: "<p>Dear <u><a href=\"[message:author:url:absolute]\">[message:author:display-name]</a></u>,<br />\r\n<br />\r\n<a href=\"[message:field_sender:entity:url]\">[message:field_sender:entity:display-name]</a>&nbsp;sent you a message on the European Innovation Council platform:<br />\r\n[message:field_body]<br />\r\n<br />\r\nYou can reply to <u><a href=\"[message:field_sender:entity:url]\">[message:field_sender:entity:display-name]</a></u>&nbsp;by&nbsp;<a href=\"[message:author:url:absolute]/contact\"><u>clicking here</u></a>.<br />\r\n<br />\r\nThe EIC Community team</p>\r\n"
+    value: "<p>Dear <u><a href=\"[message:author:url:absolute]\">[message:author:display-name]</a></u>,<br />\r\n<br />\r\n<a href=\"[message:field_sender:entity:url]\">[message:field_sender:entity:display-name]</a>&nbsp;sent you a message on the European Innovation Council platform:<br />\r\n[message:field_body]<br />\r\n<br />\r\nYou can reply to <u><a href=\"[message:field_sender:entity:url]\">[message:field_sender:entity:display-name]</a></u>&nbsp;by&nbsp;<a href=\"[message:field_sender:entity:url:absolute]/contact\"><u>clicking here</u></a>.<br />\r\n<br />\r\nThe EIC Community team</p>\r\n"
     format: full_html
 settings:
   'token options':


### PR DESCRIPTION
How to test:

- [ ] Go to a user /user/USER_ID/contact
- [ ] Send the message
- [ ] Run cron
- [ ] Check your email, you will find "contact XXX by clicking here", verify it's redirecting to the correct user