### PR TITLE
[EICNET-2174]feat: Always allow access for latest activity

### DIFF
--- a/config/sync/group.role.group-anonymous.yml
+++ b/config/sync/group.role.group-anonymous.yml
@@ -12,4 +12,5 @@ audience: anonymous
 group_type: group
 permissions_ui: true
 permissions:
+  - 'access latest activity stream'
   - 'view group'

--- a/lib/modules/eic_search/src/Plugin/Block/ActivityStreamBlock.php
+++ b/lib/modules/eic_search/src/Plugin/Block/ActivityStreamBlock.php
@@ -126,7 +126,7 @@ class ActivityStreamBlock extends BlockBase implements ContainerFactoryPluginInt
    * {@inheritdoc}
    */
   public function access(AccountInterface $account, $return_as_object = FALSE) {
-    return AccessResult::allowedIfHasPermission($account, 'access topics activity stream');
+    return AccessResult::allowed();
   }
 
   /**


### PR DESCRIPTION
How to test:

- [x] Go as anonymous user to a public group and check that you can see the activity stream