### PR TITLE
EICNET-2422: Comments can not be liked

### DIFF
--- a/lib/themes/eic_community/react/components/Block/CommentsDiscussion/Partials/Answer.js
+++ b/lib/themes/eic_community/react/components/Block/CommentsDiscussion/Partials/Answer.js
@@ -109,25 +109,25 @@ class Answer extends React.Component {
                           </CommentAction>
                         </div>
                       )}
-                      <div className="ecl-comment__action">
                         {this.state.canLike && (
-                          <a
-                            style={{ cursor: 'pointer' }}
-                            dangerouslySetInnerHTML={{
-                              __html:
-                                svg('like', 'ecl-icon--xs ecl-teaser__stat-icon') +
-                                (child.likes.hasAccountLike ? 'Unlike' : 'Like'),
-                            }}
-                            onClick={(e) =>
-                              this.props.flagComment(
-                                child.comment_id,
-                                child.likes.hasAccountLike ? 'unflag' : 'flag',
-                                'like_comment'
-                              )
-                            }
-                          />
+                          <div className="ecl-comment__action">
+                            <a
+                              style={{ cursor: 'pointer' }}
+                              dangerouslySetInnerHTML={{
+                                __html:
+                                  svg('like', 'ecl-icon--xs ecl-teaser__stat-icon') +
+                                  (child.likes.hasAccountLike ? 'Unlike' : 'Like'),
+                              }}
+                              onClick={(e) =>
+                                this.props.flagComment(
+                                  child.comment_id,
+                                  child.likes.hasAccountLike ? 'unflag' : 'flag',
+                                  'like_comment'
+                                )
+                              }
+                            />
+                          </div>
                         )}
-                      </div>
                     </div>
                   )}
                 </div>

--- a/lib/themes/eic_community/react/components/Block/CommentsDiscussion/Partials/TopAnswer.js
+++ b/lib/themes/eic_community/react/components/Block/CommentsDiscussion/Partials/TopAnswer.js
@@ -86,13 +86,15 @@ class TopAnswer extends React.Component {
                         </span>
                       </div>
                     }
-                    <div className="ecl-comment__action">
-                      {this.state.canLike && <a
-                        style={{cursor: 'pointer'}}
-                        dangerouslySetInnerHTML={{__html: svg('like', 'ecl-icon--xs ecl-teaser__stat-icon') + (this.props.comment.likes.hasAccountLike ? 'Unlike' : 'Like')}}
-                        onClick={() => this.props.flagComment(this.props.comment.comment_id, this.props.comment.likes.hasAccountLike ? 'unflag' : 'flag', 'like_comment')}
-                      />}
-                    </div>
+                    {this.state.canLike &&
+                      <div className="ecl-comment__action">
+                        <a
+                          style={{cursor: 'pointer'}}
+                          dangerouslySetInnerHTML={{__html: svg('like', 'ecl-icon--xs ecl-teaser__stat-icon') + (this.props.comment.likes.hasAccountLike ? 'Unlike' : 'Like')}}
+                          onClick={() => this.props.flagComment(this.props.comment.comment_id, this.props.comment.likes.hasAccountLike ? 'unflag' : 'flag', 'like_comment')}
+                        />
+                      </div>
+                    }
                   </div>}
                 </div>
 


### PR DESCRIPTION
### Improvements

- Remove small dot from FE when viewing a comment that cannot be liked.

### Test

- [ ] As TU, create a new public group
- [ ] As SA/SCM, change the group status to DRAFT
- [ ] As GO, create a new discussion and add a new comment
- [ ] As GO, SA or SCM, make sure you can only add replies and there is no blue dot next to the reply button 