### PR TITLE
EICNET-2387: Group invitation - if user does not exist anymore, it throws 500 error

### DIFF
--- a/lib/modules/eic_user/src/Hooks/FormAlter.php
+++ b/lib/modules/eic_user/src/Hooks/FormAlter.php
@@ -38,12 +38,13 @@ class FormAlter {
     $default_values = [];
 
     foreach ($existing_users as $existing_user) {
-      $user = User::load($existing_user['target_id']);
-      $default_values[] = [
-        'name' => realname_load($user),
-        'tid' => $user->id(),
-        'parent' => -1,
-      ];
+      if ($user = User::load($existing_user['target_id'])) {
+        $default_values[] = [
+          'name' => realname_load($user),
+          'tid' => $user->id(),
+          'parent' => -1,
+        ];
+      }
     }
 
     $url_search = Url::fromRoute('eic_search.solr_search', [
@@ -137,6 +138,8 @@ class FormAlter {
             ['context' => 'eic_user']
           )
         );
+
+        return;
       }
 
       $email = $user->getEmail();
@@ -155,7 +158,7 @@ class FormAlter {
         return;
       }
 
-      $emails[] = $user->getEmail();
+      $emails[] = $email;
     }
 
     $emails = array_merge($emails, $unexisting_users);


### PR DESCRIPTION
### Fixes

- Fix error when trying to invite a deleted user to a group.

### Test

- [x] As SA/SCM, go to a public group and click on "Invite users"
- [x] Try to delete a user from the platform that is shown in the list
- [x] Try to invite the deleted user and make sure you get an error message "User with id X does not exists in the platform."