### PR TITLE
[EICNET-2389]chore: Adapt the breadcrumb for the add group pages

### DIFF
--- a/lib/modules/eic_groups/src/Breadcrumb/GroupBreadcrumbBuilder.php
+++ b/lib/modules/eic_groups/src/Breadcrumb/GroupBreadcrumbBuilder.php
@@ -163,7 +163,8 @@ class GroupBreadcrumbBuilder implements BreadcrumbBuilderInterface {
       $group_type = $group->getGroupType()->id();
     }
 
-    if (!$group_type && $route_match->getParameter('group_type') instanceof GroupTypeInterface) {
+    if ($route_match->getParameter('group_type') instanceof GroupTypeInterface) {
+    // This has higher priority because of add group pages where a group doesn't exists yet.
       $group_type = $route_match->getParameter('group_type')->id();
     }
 

--- a/lib/modules/eic_groups/src/Breadcrumb/GroupBreadcrumbBuilder.php
+++ b/lib/modules/eic_groups/src/Breadcrumb/GroupBreadcrumbBuilder.php
@@ -154,13 +154,16 @@ class GroupBreadcrumbBuilder implements BreadcrumbBuilderInterface {
    * {@inheritdoc}
    */
   public function build(RouteMatchInterface $route_match) {
+    $group_type = 'group';
     $breadcrumb = new Breadcrumb();
-
     // Adds homepage link.
     $links[] = Link::createFromRoute($this->t('Home'), '<front>');
     $group = $this->eicGroupsHelper->getGroupFromRoute();
-    $group_type = 'group';
-    if ($route_match->getParameter('group_type') instanceof GroupTypeInterface) {
+    if ($group instanceof GroupInterface) {
+      $group_type = $group->getGroupType()->id();
+    }
+
+    if (!$group_type && $route_match->getParameter('group_type') instanceof GroupTypeInterface) {
       $group_type = $route_match->getParameter('group_type')->id();
     }
 

--- a/lib/modules/eic_groups/src/Breadcrumb/GroupBreadcrumbBuilder.php
+++ b/lib/modules/eic_groups/src/Breadcrumb/GroupBreadcrumbBuilder.php
@@ -164,7 +164,7 @@ class GroupBreadcrumbBuilder implements BreadcrumbBuilderInterface {
     }
 
     if ($route_match->getParameter('group_type') instanceof GroupTypeInterface) {
-    // This has higher priority because of add group pages where a group doesn't exists yet.
+    // This has higher priority because of add group pages where a group doesn't exist yet.
       $group_type = $route_match->getParameter('group_type')->id();
     }
 


### PR DESCRIPTION
## To Test

- [ ] Go to /group/add/event
- [ ] Breadcrumb should be Home > Events > Add Event
- [ ] Go to /group/add/group
- [ ] Breadcrumb should be Home > Groups > Add Group