### PR TITLE
[EICNET-2386]chore: Remove view members permission from GM role

### DIFF
--- a/config/sync/group.role.group-member.yml
+++ b/config/sync/group.role.group-member.yml
@@ -35,7 +35,6 @@ permissions:
   - 'update own group_node:wiki_page entity'
   - 'view comments'
   - 'view group'
-  - 'view group_membership content'
   - 'view group_node:book entity'
   - 'view group_node:discussion entity'
   - 'view group_node:document entity'

--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -852,7 +852,7 @@ function eic_groups_entity_operation(EntityInterface $entity) {
   }
 
   $current_user = \Drupal::currentUser();
-  if ($entity->hasPermission('administer members', $current_user->getAccount())) {
+  if ($entity->hasPermission('view group_membership content', $current_user->getAccount())) {
     return [
       'edit-members' => [
         'title' => t('Edit members'),


### PR DESCRIPTION
## To Test

- [ ] Login as GM, you should not be able to access /groups/{group}/members
- [ ] Login as GA/GO you should be able to access it and see the "Edit members" link in the operations dropdown