### PR TITLE
[EICNET-2426]fix: Do not show comments block in edit form

### DIFF
--- a/lib/modules/eic_groups/src/Plugin/Block/CommentsFromDiscussionBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/CommentsFromDiscussionBlock.php
@@ -168,10 +168,11 @@ class CommentsFromDiscussionBlock extends BlockBase implements ContainerFactoryP
 
     $routes_to_ignore = [
       'entity.node.delete_form',
-      'entity.node.edit_form'
+      'entity.node.edit_form',
+      'entity.node.new_request'
     ];
 
-    // Do not show comments block in delete/edit content.
+    // Do not show comments block in delete/edit/request content.
     if (in_array($this->routeMatch->getRouteName(), $routes_to_ignore)) {
       return [
         '#cache' => [

--- a/lib/modules/eic_groups/src/Plugin/Block/CommentsFromDiscussionBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/CommentsFromDiscussionBlock.php
@@ -166,7 +166,13 @@ class CommentsFromDiscussionBlock extends BlockBase implements ContainerFactoryP
       'route',
     ];
 
-    if ('entity.node.delete_form' === $this->routeMatch->getRouteName()) {
+    $routes_to_ignore = [
+      'entity.node.delete_form',
+      'entity.node.edit_form'
+    ];
+
+    // Do not show comments block in delete/edit content.
+    if (in_array($this->routeMatch->getRouteName(), $routes_to_ignore)) {
       return [
         '#cache' => [
           'contexts' => $cache_context,


### PR DESCRIPTION
How to test:

- [ ] As TU go to your group discussion content
- [ ] Edit it
- [ ] Be sure you don't have the comment block below