### PR TITLE
Feature/eicnet 2297 action forms config (part 1)

### DIFF
--- a/config/sync/eic_admin.action_forms.entity.group.group_request_membership.yml
+++ b/config/sync/eic_admin.action_forms.entity.group.group_request_membership.yml
@@ -1,0 +1,6 @@
+route: entity.group.group_request_membership
+label: 'Group membership request'
+title: 'Request membership for [group:title]'
+description:
+  value: ''
+  format: full_html

--- a/config/sync/eic_admin.action_forms.entity.group_content.group_approve_membership.yml
+++ b/config/sync/eic_admin.action_forms.entity.group_content.group_approve_membership.yml
@@ -1,0 +1,6 @@
+route: entity.group_content.group_approve_membership
+label: 'Approve membership request'
+title: ''
+description:
+  value: ''
+  format: full_html

--- a/lib/modules/eic_admin/config/schema/eic_admin.action_forms.schema.yml
+++ b/lib/modules/eic_admin/config/schema/eic_admin.action_forms.schema.yml
@@ -1,0 +1,18 @@
+eic_admin.action_forms.*:
+  type: config_object
+  mapping:
+    route:
+      type: string
+      label: 'Route name'
+    label:
+      type: string
+      label: 'Label'
+    title:
+      type: string
+      label: 'Title'
+    description.value:
+      type: string
+      label: 'Description value'
+    description.format:
+      type: string
+      label: 'Description format'

--- a/lib/modules/eic_admin/eic_admin.links.menu.yml
+++ b/lib/modules/eic_admin/eic_admin.links.menu.yml
@@ -48,3 +48,8 @@ eic_admin.groups.events:
   route_name: view.admin_groups.page_admin_events
   parent: eic_admin.groups
   weight: 3
+eic_admin.actions_config:
+  title: 'Action forms configuration'
+  description: 'Configure labels and description for various action forms.'
+  parent: eic_admin.settings
+  route_name: eic_admin.actions_config

--- a/lib/modules/eic_admin/eic_admin.routing.yml
+++ b/lib/modules/eic_admin/eic_admin.routing.yml
@@ -34,3 +34,12 @@ eic_admin.update_all_group_permissions:
     _permission: 'access eic_admin dashboard'
   options:
     _admin_route: TRUE
+eic_admin.actions_config:
+  path: '/admin/config/eic/actions-forms'
+  defaults:
+    _title: 'Action forms configuration'
+    _form: '\Drupal\eic_admin\Form\ActionFormsForm'
+  requirements:
+    _permission: 'access eic_admin dashboard'
+  options:
+    _admin_route: TRUE

--- a/lib/modules/eic_admin/eic_admin.services.yml
+++ b/lib/modules/eic_admin/eic_admin.services.yml
@@ -1,0 +1,9 @@
+services:
+  eic_admin.action_forms_manager:
+    class: Drupal\eic_admin\Service\ActionFormsManager
+    arguments: ['@current_route_match', '@config.factory']
+  eic_admin.route_subscriber:
+    class: Drupal\eic_admin\Routing\RouteSubscriber
+    arguments: ['@eic_admin.action_forms_manager']
+    tags:
+      - { name: event_subscriber }

--- a/lib/modules/eic_admin/src/Controller/ActionForms.php
+++ b/lib/modules/eic_admin/src/Controller/ActionForms.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Drupal\eic_admin\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Render\Markup;
+use Drupal\Core\Utility\Token;
+use Drupal\eic_admin\Service\ActionFormsManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Custom implementation to alter action forms.
+ */
+class ActionForms extends ControllerBase {
+
+  /**
+   * The action forms manager service.
+   *
+   * @var \Drupal\eic_admin\Service\ActionFormsManager
+   */
+  protected $actionFormsManager;
+
+  /**
+   * The token service.
+   *
+   * @var \Drupal\Core\Utility\Token
+   */
+  protected $tokenService;
+
+  /**
+   * ActionForms constructor.
+   *
+   * @param \Drupal\eic_admin\Service\ActionFormsManager $action_forms_manager
+   *   The action forms manager service.
+   * @param \Drupal\Core\Utility\Token $token_service
+   *   The token service.
+   */
+  public function __construct(ActionFormsManager $action_forms_manager, Token $token_service) {
+    $this->actionFormsManager = $action_forms_manager;
+    $this->tokenService = $token_service;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('eic_admin.action_forms_manager'),
+      $container->get('token'),
+    );
+  }
+
+  /**
+   * Renders title for the current page.
+   *
+   * @return \Drupal\Component\Render\MarkupInterface
+   *   The untranslated page title.
+   */
+  public function pageTitle() {
+    $title = '';
+    $route_name = $this->actionFormsManager->routeMatch->getRouteName();
+    if ($config = $this->actionFormsManager->getRouteConfig($route_name)) {
+      $route_parameters = [];
+      foreach ($this->actionFormsManager->routeMatch->getParameters() as $parameter_type => $entity) {
+        $route_parameters[$parameter_type] = $entity;
+      }
+      $title = $config->get('title');
+      $title = $this->tokenService->replace($title, $route_parameters);
+    }
+
+    return Markup::create($title);
+  }
+
+}

--- a/lib/modules/eic_admin/src/Form/ActionFormsForm.php
+++ b/lib/modules/eic_admin/src/Form/ActionFormsForm.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Drupal\eic_admin\Form;
+
+use Drupal\Core\Config\ConfigBase;
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Configure action forms for this site.
+ */
+class ActionFormsForm extends ConfigFormBase {
+
+  /**
+   * The action forms manager service.
+   *
+   * @var \Drupal\eic_admin\Service\ActionFormsManager
+   */
+  protected $actionFormsManager;
+
+  /**
+   * Request stack.
+   *
+   * @var \Drupal\Core\Routing\RouteProviderInterface
+   */
+  protected $routeProvider;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    $instance = parent::create($container);
+    $instance->actionFormsManager = $container->get('eic_admin.action_forms_manager');
+    $instance->routeProvider = $container->get('router.route_provider');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'eic_admin_action_forms_config';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return ['eic_admin.action_forms.'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $configs = $this->configFactory->loadMultiple($this->configFactory->listAll('eic_admin.action_forms.'));
+
+    $form['routes'] = [
+      '#type' => 'vertical_tabs',
+    ];
+
+    foreach ($configs as $config) {
+      $route = $this->routeProvider->getRouteByName($config->get('route'));
+      $route_name = $this->getConfigMachineName($config);
+      $form[$route_name] = [
+        '#type' => 'details',
+        '#title' => empty($config->get('label')) ? $this->t('undefined') : $config->get('label'),
+        '#group' => 'routes',
+        '#tree' => TRUE,
+      ];
+      $form[$route_name]['route'] = [
+        '#type' => 'textfield',
+        '#title' => $this->t('Route'),
+        '#default_value' => $config->get('route'),
+        '#description' => $this->t('Route name of the page.'),
+        '#disabled' => TRUE,
+        '#tree' => TRUE,
+      ];
+      $form[$route_name]['label'] = [
+        '#type' => 'textfield',
+        '#title' => $this->t('Label'),
+        '#default_value' => $config->get('label'),
+        '#description' => $this->t('Administrative label.'),
+        '#required' => TRUE,
+        '#tree' => TRUE,
+      ];
+      $form[$route_name]['title'] = [
+        '#type' => 'textfield',
+        '#title' => $this->t('Title'),
+        '#default_value' => $config->get('title'),
+        '#description' => $this->t('Override page title. Leave blank to keep original title.'),
+        '#tree' => TRUE,
+      ];
+      $form[$route_name]['description'] = [
+        '#type' => 'text_format',
+        '#title' => $this->t('Description'),
+        '#default_value' => $config->get('description.value'),
+        '#description' => $this->t('Provide an additional description block.'),
+        '#format' => $config->get('description.format'),
+      ];
+      $form[$route_name]['token_tree'] = [
+        '#theme' => 'token_tree_link',
+        '#token_types' => $route->getDefault('_entity_types'),
+        '#global_types' => TRUE,
+        '#click_insert' => TRUE,
+        '#show_restricted' => FALSE,
+        '#show_nested' => FALSE,
+        '#recursion_limit' => 3,
+        '#text' => NULL,
+        '#options' => [],
+      ];
+    }
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    /** @var \Drupal\Core\Config\Config $config */
+    foreach ($this->actionFormsManager->getAllRouteConfigs() as $config) {
+      $config_values = $form_state->getValue($this->getConfigMachineName($config));
+      if (empty($config_values)) {
+        continue;
+      }
+      $config->set('label', $config_values['label']);
+      $config->set('title', $config_values['title']);
+      $config->set('description.value', $config_values['description']['value']);
+      $config->set('description.format', $config_values['description']['format']);
+      $config->save();
+
+      // @todo Invalidate cache for this specific route?
+    }
+    parent::submitForm($form, $form_state);
+  }
+
+  /**
+   * Returns a 'machine name' for the given config.
+   *
+   * We assume that there is only one config with the same route name.
+   * The returned machine name is hence a sanitized version of a route name.
+   *
+   * @param \Drupal\Core\Config\ConfigBase $config
+   *   The config object.
+   *
+   * @return string|false
+   *   The machine name of FALSE if route is not found.
+   */
+  protected function getConfigMachineName(ConfigBase $config) {
+    // Since form elements don't seem to work well with keys including dots, we
+    // sanitize the route name and use it as the machine name.
+    if ($config->get('route')) {
+      return str_replace('.', '__', $config->get('route'));
+    }
+    return FALSE;
+  }
+
+}

--- a/lib/modules/eic_admin/src/Routing/RouteSubscriber.php
+++ b/lib/modules/eic_admin/src/Routing/RouteSubscriber.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Drupal\eic_admin\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Drupal\eic_admin\Service\ActionFormsManager;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Listens to the dynamic route events.
+ */
+class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * The action forms manager service.
+   *
+   * @var \Drupal\eic_admin\Service\ActionFormsManager
+   */
+  protected $actionFormsManager;
+
+  /**
+   * ActionForms constructor.
+   *
+   * @param \Drupal\eic_admin\Service\ActionFormsManager $action_forms_manager
+   *   The action forms manager service.
+   */
+  public function __construct(ActionFormsManager $action_forms_manager) {
+    $this->actionFormsManager = $action_forms_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+    $routes = $this->actionFormsManager->getAllRouteConfigs();
+
+    foreach ($routes as $config) {
+      // If title is provided, we override the title callback.
+      if ($route = $collection->get($config->get('route'))) {
+        $title = $config->get('title');
+
+        if (!empty($title)) {
+          $route->setDefault('_title', '');
+          $route->setDefault('_title_callback', '\Drupal\eic_admin\Controller\ActionForms::pageTitle');
+        }
+        // Store the parameters in a custom variable for later use.
+        $entity_types = [];
+        foreach ($route->getOption('parameters') as $param) {
+          if (!empty($param['type'])) {
+            // We split the 'entity:entity_type' value tot get the entity type
+            // only.
+            $entity_types[] = explode(':', $param['type'])[1];
+          }
+        }
+        $route->setDefault('_entity_types', $entity_types);
+      }
+    }
+  }
+
+}

--- a/lib/modules/eic_admin/src/Service/ActionFormsManager.php
+++ b/lib/modules/eic_admin/src/Service/ActionFormsManager.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Drupal\eic_admin\Service;
+
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\Config\ConfigFactoryInterface;
+
+/**
+ * Class that manages functions for the confirmation forms.
+ *
+ * @package Drupal\eic_admin\Service
+ */
+class ActionFormsManager {
+
+  use StringTranslationTrait;
+
+  /**
+   * The current route match.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  public $routeMatch;
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * Constructs a new ShareManager object.
+   *
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The current route match.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   */
+  public function __construct(RouteMatchInterface $route_match, ConfigFactoryInterface $config_factory) {
+    $this->routeMatch = $route_match;
+    $this->configFactory = $config_factory;
+  }
+
+  /**
+   * Get the config for the given route.
+   *
+   * @param string|null $route_name
+   *   The route name for which we want to retrieve the config. Defaults to
+   *   current route.
+   *
+   * @return \Drupal\Core\Config\ImmutableConfig|false
+   *   The config object or FALSE if not found.
+   */
+  public function getRouteConfig(string $route_name = NULL) {
+    if (empty($route_name)) {
+      $route_name = $this->routeMatch->getRouteName();
+    }
+
+    return $this->configFactory->get("eic_admin.action_forms.$route_name") ?? FALSE;
+  }
+
+  /**
+   * Returns all the existing config objects for action forms.
+   *
+   * @return \Drupal\Core\Config\Config[]
+   *   An array of editable config objects.
+   */
+  public function getAllRouteConfigs(): array {
+    $configs = [];
+    foreach ($this->configFactory->listAll('eic_admin.action_forms.') as $config_name) {
+      if ($config = $this->configFactory->getEditable($config_name)) {
+        $configs[$config_name] = $config;
+      }
+    }
+    return $configs;
+  }
+
+}


### PR DESCRIPTION
### Tests

- [ ] As SA go to `/admin/config/eic/actions-forms`
- [ ] Configure a custom page title (with tokens) for the `Group membership request` page
- [ ] As TU, go to a public group that is open on membership request
- [ ] Click the button to request membership
- [ ] Check that you have your title displayed (meta tag)
- [ ] As SA go to `/admin/config/eic/actions-forms`
- [ ] Remove your custom title (lave field blank)
- [ ] Clear the cache
- [ ] As TU, go to a public group that is open on membership request
- [ ] Click the button to request membership
- [ ] Check that you get the default page title


### Remarks

- Configs must be created manually for now