### PR TITLE
EICNET-2463: Error when trying to create a News in a group

### DIFF
--- a/lib/modules/eic_groups/src/Access/GroupContentCreateEntityAccessCheck.php
+++ b/lib/modules/eic_groups/src/Access/GroupContentCreateEntityAccessCheck.php
@@ -64,6 +64,13 @@ class GroupContentCreateEntityAccessCheck extends GroupContentCreateEntityAccess
   public function access(Route $route, AccountInterface $account, GroupInterface $group, $plugin_id) {
     $access = $this->groupContentCreateEntityAccessCheck->access($route, $account, $group, $plugin_id);
 
+    // If the group content plugin is not installed, we deny access.
+    if (!$group->getGroupType()->hasContentPlugin($plugin_id)) {
+      return AccessResult::forbidden()
+        ->addCacheableDependency($account)
+        ->addCacheableDependency($group);
+    }
+
     // Edge case where we make sure that no user (even user 1 or a user with
     // Drupal administrator role) can create new book pages inside groups.
     // There should only be 1 book page per group and it's automatically


### PR DESCRIPTION
### Improvements

- Deny access to create group content if it's disabled in the group.

### Test

- [x] As TU (member), try to create a News in a group `/groups/<group-name>/content/create/group_node:news`
- [x] Make sure you get an access denied page. **Note** that the News content type is not enabled in groups.