### PR TITLE
[EICNET-2049]feat: Add most active score for discussions

### DIFF
--- a/config/sync/context.context.group_discussions_overviews.yml
+++ b/config/sync/context.context.group_discussions_overviews.yml
@@ -5,7 +5,6 @@ dependencies:
   module:
     - eic_search
     - route_condition
-    - system
 label: 'Group - Discussions - Overviews'
 name: group_discussions_overviews
 group: Groups
@@ -24,8 +23,8 @@ reactions:
     id: blocks
     uuid: 9c311d0e-a590-452a-ad85-a32b685d7729
     blocks:
-      a625a334-816d-4015-a47a-196b68443e72:
-        uuid: a625a334-816d-4015-a47a-196b68443e72
+      a24ae5bf-53ca-4c70-8fbb-d6d578a89eb8:
+        uuid: a24ae5bf-53ca-4c70-8fbb-d6d578a89eb8
         id: eic_search_overview
         label: ''
         provider: eic_search
@@ -43,6 +42,7 @@ reactions:
           sm_content_field_vocab_topics_string: sm_content_field_vocab_topics_string
           sm_content_field_vocab_geo_string: sm_content_field_vocab_geo_string
         sort_options:
+          its_activity_score: its_activity_score
           its_flag_highlight_content: its_flag_highlight_content
           dm_aggregated_changed: dm_aggregated_changed
           its_last_comment_timestamp: its_last_comment_timestamp
@@ -55,6 +55,7 @@ reactions:
         enable_search: 1
         page_options: normal
         prefilter_group: 1
+        enable_date_filter: 0
         add_facet_interests: 0
         add_facet_my_groups: 0
         third_party_settings: {  }

--- a/lib/modules/eic_search/eic_search.services.yml
+++ b/lib/modules/eic_search/eic_search.services.yml
@@ -116,6 +116,7 @@ services:
       - { name: eic_search.document_processor, priority: 16 }
   eic_search.document_processor_discussion:
     class: Drupal\eic_search\Search\DocumentProcessor\ProcessorDiscussion
+    arguments: ['@eic_statistics.helper']
     tags:
       - { name: eic_search.document_processor, priority: 18 }
   eic_search.document_processor_visibility:

--- a/lib/modules/eic_search/src/Search/Sources/DiscussionSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/DiscussionSourceType.php
@@ -4,6 +4,7 @@ namespace Drupal\eic_search\Search\Sources;
 
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\eic_flags\FlagType;
+use Drupal\eic_search\Search\DocumentProcessor\DocumentProcessorInterface;
 use Drupal\eic_search\Service\SolrDocumentProcessor;
 
 /**
@@ -52,6 +53,10 @@ class DiscussionSourceType extends SourceType {
    */
   public function getAvailableSortOptions(): array {
     return [
+      DocumentProcessorInterface::SOLR_MOST_ACTIVE_ID => [
+        'label' => $this->t('Most active', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Most active', [], ['context' => 'eic_search']),
+      ],
       'its_flag_highlight_content' => [
         'label' => $this->t('Highlight', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Highlighted first', [], ['context' => 'eic_search']),

--- a/lib/modules/eic_statistics/src/StatisticsHelper.php
+++ b/lib/modules/eic_statistics/src/StatisticsHelper.php
@@ -155,12 +155,13 @@ class StatisticsHelper {
     // Flags statistics.
     $countable_flags = [
       FlagType::LIKE_CONTENT,
+      FlagType::FOLLOW_CONTENT
     ];
     foreach ($this->flagService->getAllFlags($entity->getEntityTypeId()) as $flag) {
       if (!in_array($flag->id(), $countable_flags)) {
         continue;
       }
-      
+
       $entity_flag_counts = $this->flagCountManager->getEntityFlagCounts($entity);
       $result[$flag->id()] = $entity_flag_counts[$flag->id()] ?? 0;
     }


### PR DESCRIPTION
How to test it:

- [ ] Resync solr
- [ ] go to a group discussions
- [ ] Sort by most activity score
- [ ] See if it's working well

here is the formula: 3*(number of comments) + number of likes + 2*(number of followers)