### PR TITLE
Feature/eicnet 2297 action forms config part 2

### DIFF
--- a/config/sync/context.context.global_action_forms.yml
+++ b/config/sync/context.context.global_action_forms.yml
@@ -1,0 +1,41 @@
+uuid: 53b1c0ac-f522-4321-80e9-f5c925edae0d
+langcode: en
+status: true
+dependencies:
+  module:
+    - eic_admin
+label: 'Global - Action forms'
+name: global_action_forms
+group: Global
+description: ''
+requireAllConditions: false
+disabled: false
+conditions:
+  eic_admin_action_forms:
+    id: eic_admin_action_forms
+    negate: false
+    uuid: 77e8221e-c075-44b8-b177-3890c2dbeab5
+    context_mapping: {  }
+reactions:
+  blocks:
+    id: blocks
+    uuid: a3fe0a55-8165-4df4-ad77-4289f354787b
+    blocks:
+      43b8e7b3-0b81-41b1-9f1a-f2e4dbd689ba:
+        uuid: 43b8e7b3-0b81-41b1-9f1a-f2e4dbd689ba
+        id: eic_admin_action_forms_description
+        label: 'EIC Admin - Action forms description'
+        provider: eic_admin
+        label_display: '0'
+        region: content_before
+        weight: '0'
+        custom_id: eic_admin_action_forms_description
+        theme: eic_community
+        css_class: ''
+        unique: 0
+        context_id: global_action_forms
+        context_mapping: {  }
+        third_party_settings: {  }
+    include_default_blocks: 0
+    saved: false
+weight: 0

--- a/config/sync/context.context.group_global.yml
+++ b/config/sync/context.context.group_global.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - group_content_menu.group_content_menu_type.group_main_menu
   module:
+    - eic_admin
     - eic_groups
     - group
     - route_condition
@@ -31,6 +32,11 @@ conditions:
     uuid: df5ac6fd-1e86-44f6-9ff6-e46b4cfc36f1
     context_mapping: {  }
     routes: "entity.user.*\r\nprofile.user_page.*\r\neic_user.user.*"
+  eic_admin_action_forms:
+    id: eic_admin_action_forms
+    negate: true
+    uuid: 629181fe-8095-416d-9998-a3aa61d4af41
+    context_mapping: {  }
 reactions:
   blocks:
     id: blocks

--- a/lib/modules/eic_admin/config/schema/eic_admin.schema.yml
+++ b/lib/modules/eic_admin/config/schema/eic_admin.schema.yml
@@ -1,0 +1,3 @@
+condition.plugin.eic_admin_action_forms:
+  type: condition.plugin
+  label: 'Action Forms condition'

--- a/lib/modules/eic_admin/src/Controller/ActionForms.php
+++ b/lib/modules/eic_admin/src/Controller/ActionForms.php
@@ -4,6 +4,7 @@ namespace Drupal\eic_admin\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Render\Markup;
+use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Utility\Token;
 use Drupal\eic_admin\Service\ActionFormsManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -21,6 +22,13 @@ class ActionForms extends ControllerBase {
   protected $actionFormsManager;
 
   /**
+   * The current route match.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
    * The token service.
    *
    * @var \Drupal\Core\Utility\Token
@@ -32,11 +40,17 @@ class ActionForms extends ControllerBase {
    *
    * @param \Drupal\eic_admin\Service\ActionFormsManager $action_forms_manager
    *   The action forms manager service.
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The current route match.
    * @param \Drupal\Core\Utility\Token $token_service
    *   The token service.
    */
-  public function __construct(ActionFormsManager $action_forms_manager, Token $token_service) {
+  public function __construct(
+    ActionFormsManager $action_forms_manager,
+    RouteMatchInterface $route_match,
+    Token $token_service) {
     $this->actionFormsManager = $action_forms_manager;
+    $this->routeMatch = $route_match;
     $this->tokenService = $token_service;
   }
 
@@ -46,6 +60,7 @@ class ActionForms extends ControllerBase {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('eic_admin.action_forms_manager'),
+      $container->get('current_route_match'),
       $container->get('token'),
     );
   }
@@ -58,10 +73,10 @@ class ActionForms extends ControllerBase {
    */
   public function pageTitle() {
     $title = '';
-    $route_name = $this->actionFormsManager->routeMatch->getRouteName();
+    $route_name = $this->routeMatch->getRouteName();
     if ($config = $this->actionFormsManager->getRouteConfig($route_name)) {
       $route_parameters = [];
-      foreach ($this->actionFormsManager->routeMatch->getParameters() as $parameter_type => $entity) {
+      foreach ($this->routeMatch->getParameters() as $parameter_type => $entity) {
         $route_parameters[$parameter_type] = $entity;
       }
       $title = $config->get('title');

--- a/lib/modules/eic_admin/src/Plugin/Block/ActionFormDescriptionBlock.php
+++ b/lib/modules/eic_admin/src/Plugin/Block/ActionFormDescriptionBlock.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Drupal\eic_admin\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Utility\Token;
+use Drupal\eic_admin\Service\ActionFormsManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a custom group content menu block.
+ *
+ * @Block(
+ *   id = "eic_admin_action_forms_description",
+ *   admin_label = @Translation("EIC Admin - Action forms description"),
+ *   category = @Translation("European Innovation Council"),
+ * )
+ */
+class ActionFormDescriptionBlock extends BlockBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The current route match.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
+   * The action forms manager service.
+   *
+   * @var \Drupal\eic_admin\Service\ActionFormsManager
+   */
+  protected $actionFormsManager;
+
+  /**
+   * The token service.
+   *
+   * @var \Drupal\Core\Utility\Token
+   */
+  protected $tokenService;
+
+  /**
+   * Constructs a new ActionFormDescriptionBlock instance.
+   *
+   * @param array $configuration
+   *   The plugin configuration.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The current route match.
+   * @param \Drupal\eic_admin\Service\ActionFormsManager $action_forms_manager
+   *   The action forms manager service.
+   * @param \Drupal\Core\Utility\Token $token_service
+   *   The token service.
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    RouteMatchInterface $route_match,
+    ActionFormsManager $action_forms_manager,
+    Token $token_service
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->routeMatch = $route_match;
+    $this->actionFormsManager = $action_forms_manager;
+    $this->tokenService = $token_service;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(
+    ContainerInterface $container,
+    array $configuration,
+    $plugin_id,
+    $plugin_definition
+  ) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('current_route_match'),
+      $container->get('eic_admin.action_forms_manager'),
+      $container->get('token')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $build = [];
+
+    // If current route exist in config, return the content of its description.
+    if ($config = $this->actionFormsManager->getRouteConfig()) {
+      $route_parameters = [];
+      foreach ($this->routeMatch->getParameters() as $parameter_type => $entity) {
+        $route_parameters[$parameter_type] = $entity;
+      }
+      $text = $this->tokenService->replace($config->get('description.value'), $route_parameters);
+      $build['content'] = [
+        '#type' => 'processed_text',
+        '#text' => $text,
+        '#format' => $config->get('description.format'),
+      ];
+    }
+
+    return $build;
+  }
+
+}

--- a/lib/modules/eic_admin/src/Plugin/Block/ActionFormDescriptionBlock.php
+++ b/lib/modules/eic_admin/src/Plugin/Block/ActionFormDescriptionBlock.php
@@ -154,4 +154,11 @@ class ActionFormDescriptionBlock extends BlockBase implements ContainerFactoryPl
     return $build;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheMaxAge() {
+    return 0;
+  }
+
 }

--- a/lib/modules/eic_admin/src/Plugin/Condition/ActionForms.php
+++ b/lib/modules/eic_admin/src/Plugin/Condition/ActionForms.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Drupal\eic_admin\Plugin\Condition;
+
+use Drupal\Core\Condition\ConditionPluginBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Url;
+use Drupal\eic_admin\Service\ActionFormsManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a 'Action Forms' condition.
+ *
+ * @Condition(
+ *   id = "eic_admin_action_forms",
+ *   label = @Translation("EIC Action Forms"),
+ * )
+ */
+class ActionForms extends ConditionPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The action forms manager service.
+   *
+   * @var \Drupal\eic_admin\Service\ActionFormsManager
+   */
+  protected $actionFormsManager;
+
+  /**
+   * Creates a new ActionForms instance.
+   *
+   * @param array $configuration
+   *   The plugin configuration, i.e. an array with configuration values keyed
+   *   by configuration option name. The special key 'context' may be used to
+   *   initialize the defined contexts by setting it to an array of context
+   *   values keyed by context names.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\eic_admin\Service\ActionFormsManager $action_forms_manager
+   *   The action forms manager service.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ActionFormsManager $action_forms_manager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->actionFormsManager = $action_forms_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('eic_admin.action_forms_manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+
+    $form['info'] = [
+      '#markup' => $this->t('Acts on all defined action forms, see <a href=":action_forms_config_page">here</a>.', [
+        ':action_forms_config_page' => Url::fromRoute('eic_admin.actions_config')->toString(),
+      ]),
+    ];
+
+    $form['routes'] = [
+      '#theme' => 'item_list',
+      '#list_type' => 'ul',
+      '#title' => 'Routes',
+      '#items' => $this->getActionFormRoutes(),
+    ];
+
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function summary() {
+    return '';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function evaluate() {
+    if ($this->isNegated()) {
+      return in_array($this->actionFormsManager->routeMatch->getRouteName(), $this->getActionFormRoutes());
+    }
+    return !in_array($this->actionFormsManager->routeMatch->getRouteName(), $this->getActionFormRoutes());
+  }
+
+  /**
+   * Returns all the existing action form routes.
+   *
+   * @return string[]
+   *   A list of route names.
+   */
+  protected function getActionFormRoutes() {
+    $routes = [];
+    foreach ($this->actionFormsManager->getAllRouteConfigs() as $config) {
+      $routes[] = $config->get('route');
+    }
+    return $routes;
+  }
+
+}

--- a/lib/modules/eic_admin/src/Service/ActionFormsManager.php
+++ b/lib/modules/eic_admin/src/Service/ActionFormsManager.php
@@ -20,7 +20,7 @@ class ActionFormsManager {
    *
    * @var \Drupal\Core\Routing\RouteMatchInterface
    */
-  public $routeMatch;
+  protected $routeMatch;
 
   /**
    * The config factory.
@@ -74,6 +74,20 @@ class ActionFormsManager {
       }
     }
     return $configs;
+  }
+
+  /**
+   * Returns all the existing action form routes.
+   *
+   * @return string[]
+   *   A list of route names.
+   */
+  public function getActionFormRoutes() {
+    $routes = [];
+    foreach ($this->getAllRouteConfigs() as $config) {
+      $routes[] = $config->get('route');
+    }
+    return $routes;
   }
 
 }

--- a/lib/themes/eic_community/includes/preprocess/blocks/block.inc
+++ b/lib/themes/eic_community/includes/preprocess/blocks/block.inc
@@ -19,6 +19,14 @@ function eic_community_preprocess_block(array &$variables) {
   );
   $variables['icon_file_path'] = $variables['eic_icon_path'];
 
+  // Add class to blocks to have them centered.
+  switch ($variables['elements']['#id']) {
+    case 'eic_admin_action_forms_description':
+      $variables['attributes']['class'][] = 'ecl-container';
+      $variables['attributes']['class'][] = 'ecl-form';
+      break;
+  }
+
   if ($variables['base_plugin_id'] == 'block_content') {
     /** @var \Drupal\block_content\Entity\BlockContent $block_content */
     $block_content = $variables['content']['#block_content'];


### PR DESCRIPTION
### Tests

- [x] As SA go to `/admin/config/eic/actions-forms`
- [x] Configure a custom page title and description (with tokens) for the Group membership request page
- [x] As TU, go to a public group that is open on membership request
- [x] Click the button to request membership
- [x] Check that you have your title and description displayed
- [x] Check that both title and description are centered


### Remarks

- This PR must be reviewed/merged first: https://github.com/EIC-EA/EIC-community-D8/pull/1546