### PR TITLE
EICNET-2460: I should not be able to see "manage members" as GM in organizations

### DIFF
--- a/config/sync/group.role.event-a416e6833.yml
+++ b/config/sync/group.role.event-a416e6833.yml
@@ -20,6 +20,7 @@ permissions:
   - 'access files overview'
   - 'access group search overview'
   - 'access latest activity stream'
+  - 'access members management'
   - 'access members overview'
   - 'access news overview'
   - 'access wiki overview'

--- a/config/sync/group.role.event-admin.yml
+++ b/config/sync/group.role.event-admin.yml
@@ -13,6 +13,7 @@ group_type: event
 permissions_ui: true
 permissions:
   - 'access group_node overview'
+  - 'access members management'
   - 'create group_node:discussion entity'
   - 'create group_node:document entity'
   - 'create group_node:gallery entity'

--- a/config/sync/group.role.event-bf4b46c3a.yml
+++ b/config/sync/group.role.event-bf4b46c3a.yml
@@ -20,6 +20,7 @@ permissions:
   - 'access files overview'
   - 'access group search overview'
   - 'access latest activity stream'
+  - 'access members management'
   - 'access members overview'
   - 'access news overview'
   - 'access wiki overview'

--- a/config/sync/group.role.event-eca6128ca.yml
+++ b/config/sync/group.role.event-eca6128ca.yml
@@ -20,6 +20,7 @@ permissions:
   - 'access files overview'
   - 'access group search overview'
   - 'access latest activity stream'
+  - 'access members management'
   - 'access members overview'
   - 'access news overview'
   - 'access wiki overview'

--- a/config/sync/group.role.event-owner.yml
+++ b/config/sync/group.role.event-owner.yml
@@ -15,6 +15,7 @@ permissions:
   - 'access discussions overview'
   - 'access group search overview'
   - 'access group_node overview'
+  - 'access members management'
   - 'create group_node:discussion entity'
   - 'create group_node:document entity'
   - 'create group_node:gallery entity'

--- a/config/sync/group.role.group-a416e6833.yml
+++ b/config/sync/group.role.group-a416e6833.yml
@@ -22,6 +22,7 @@ permissions:
   - 'access group search overview'
   - 'access group_node overview'
   - 'access latest activity stream'
+  - 'access members management'
   - 'access members overview'
   - 'access wiki overview'
   - 'administer members'

--- a/config/sync/group.role.group-admin.yml
+++ b/config/sync/group.role.group-admin.yml
@@ -14,6 +14,7 @@ permissions_ui: true
 permissions:
   - 'access group search overview'
   - 'access group_node overview'
+  - 'access members management'
   - 'create group_node:discussion entity'
   - 'create group_node:document entity'
   - 'create group_node:event entity'

--- a/config/sync/group.role.group-bf4b46c3a.yml
+++ b/config/sync/group.role.group-bf4b46c3a.yml
@@ -23,6 +23,7 @@ permissions:
   - 'access group search overview'
   - 'access group_node overview'
   - 'access latest activity stream'
+  - 'access members management'
   - 'access members overview'
   - 'access wiki overview'
   - 'administer members'

--- a/config/sync/group.role.group-eca6128ca.yml
+++ b/config/sync/group.role.group-eca6128ca.yml
@@ -22,6 +22,7 @@ permissions:
   - 'access group search overview'
   - 'access group_node overview'
   - 'access latest activity stream'
+  - 'access members management'
   - 'access members overview'
   - 'access wiki overview'
   - 'administer members'

--- a/config/sync/group.role.group-owner.yml
+++ b/config/sync/group.role.group-owner.yml
@@ -14,6 +14,7 @@ permissions_ui: true
 permissions:
   - 'access group search overview'
   - 'access group_node overview'
+  - 'access members management'
   - 'administer members'
   - 'create group_node:discussion entity'
   - 'create group_node:document entity'

--- a/config/sync/group.role.organisation-a416e6833.yml
+++ b/config/sync/group.role.organisation-a416e6833.yml
@@ -23,6 +23,7 @@ permissions:
   - 'access group search overview'
   - 'access group_node overview'
   - 'access latest activity stream'
+  - 'access members management'
   - 'access members overview'
   - 'access news overview'
   - 'access wiki overview'

--- a/config/sync/group.role.organisation-admin.yml
+++ b/config/sync/group.role.organisation-admin.yml
@@ -14,6 +14,7 @@ permissions_ui: true
 permissions:
   - 'access group search overview'
   - 'access group_node overview'
+  - 'access members management'
   - 'administer members'
   - 'create group_node:event entity'
   - 'create group_node:news entity'

--- a/config/sync/group.role.organisation-bf4b46c3a.yml
+++ b/config/sync/group.role.organisation-bf4b46c3a.yml
@@ -23,6 +23,7 @@ permissions:
   - 'access group search overview'
   - 'access group_node overview'
   - 'access latest activity stream'
+  - 'access members management'
   - 'access members overview'
   - 'access news overview'
   - 'access wiki overview'

--- a/config/sync/group.role.organisation-eca6128ca.yml
+++ b/config/sync/group.role.organisation-eca6128ca.yml
@@ -22,6 +22,7 @@ permissions:
   - 'access group content menu overview'
   - 'access group search overview'
   - 'access latest activity stream'
+  - 'access members management'
   - 'access members overview'
   - 'access news overview'
   - 'access wiki overview'

--- a/config/sync/group.role.organisation-owner.yml
+++ b/config/sync/group.role.organisation-owner.yml
@@ -14,6 +14,7 @@ permissions_ui: true
 permissions:
   - 'access group search overview'
   - 'access group_node overview'
+  - 'access members management'
   - 'administer members'
   - 'create group_node:event entity'
   - 'create group_node:news entity'

--- a/config/sync/views.view.eic_group_members.yml
+++ b/config/sync/views.view.eic_group_members.yml
@@ -423,7 +423,7 @@ display:
       access:
         type: group_permission
         options:
-          group_permission: 'view group_membership content'
+          group_permission: 'access members management'
       cache:
         type: tag
         options: {  }

--- a/lib/modules/eic_deploy/eic_deploy.install
+++ b/lib/modules/eic_deploy/eic_deploy.install
@@ -243,3 +243,39 @@ function eic_deploy_update_9007(&$sandbox) {
   $group_statistics_command = \Drupal::service('eic_group_statistics.helper');
   $group_statistics_command->updateAllGroupsStatistics();
 }
+
+/**
+ * Adds group permission 'access members management' to GO/GA/SA/SCM.
+ */
+function eic_deploy_update_9008(&$sandbox) {
+  $new_permissions = [
+    'access members management',
+  ];
+
+  $roles = [
+    'group-owner',
+    'group-admin',
+    'event-owner',
+    'event-admin',
+    'organisation-owner',
+    'organisation-admin',
+    'event-a416e6833',
+    'event-bf4b46c3a',
+    'event-eca6128ca',
+    'group-a416e6833',
+    'group-bf4b46c3a',
+    'group-eca6128ca',
+    'organisation-a416e6833',
+    'organisation-bf4b46c3a',
+    'organisation-eca6128ca',
+  ];
+
+  $group_visibilities = [
+    'public',
+    'private',
+    'restricted_community_members',
+    'custom_restricted',
+  ];
+
+  eic_deploy_add_group_permissions_to_role($new_permissions, $roles, $group_visibilities);
+}

--- a/lib/modules/eic_deploy/eic_deploy.module
+++ b/lib/modules/eic_deploy/eic_deploy.module
@@ -31,9 +31,14 @@ function eic_deploy_add_group_permissions_to_role(array $new_permissions = [], a
     $group_visibility = $group_visibility_storage->load($group->id());
 
     if (
-      !in_array($group->getGroupType()->id(), ['group', 'event']) ||
-      empty($permissions) ||
-      !in_array($group_visibility->getType(), $group_visibilities)
+      $group->getGroupType()->id() === 'organisation' &&
+      empty($permissions)
+    ) {
+      continue;
+    }
+    elseif (
+      in_array($group->getGroupType()->id(), ['group', 'event']) &&
+      (empty($permissions) || !in_array($group_visibility->getType(), $group_visibilities))
     ) {
       continue;
     }
@@ -56,7 +61,7 @@ function eic_deploy_add_group_permissions_to_role(array $new_permissions = [], a
     $group_permission->setNewRevision();
     $group_permission->setRevisionUserId(1);
     $group_permission->setRevisionCreationTime(time());
-    $group_permission->setRevisionLogMessage(t('Set default permissions for outsiders.'));
+    $group_permission->setRevisionLogMessage(t('Update group permissions.'));
 
     if (count($group_permission->validate()) > 0) {
       continue;

--- a/lib/modules/eic_groups/eic_groups.group.permissions.yml
+++ b/lib/modules/eic_groups/eic_groups.group.permissions.yml
@@ -1,0 +1,2 @@
+access members management:
+  title: 'Access members management page'


### PR DESCRIPTION
### Improvements

- Create new group permission to access members management
- Create hook_update to update all group permissions.

### Test

With QA DB

- [ ] Run drush cr
- [ ] Run drush cim
- [ ] Run drush updb
- [ ] As TU (member), go to your group or event or organisation and make sure you cannot see the "Edit members" link in the group management dropdown. Also make sure you cannot access the Edit members page via the URL.
- [ ] As GO/GA/SA/SCM, make sure you can view the "Edit members" link in the group management dropdown and also make sure you can access the Edit members page

With local DB

- [x] As TU (member), go to your group or event or organisation and make sure you cannot see the "Edit members" link in the group management dropdown. Also make sure you cannot access the Edit members page via the URL.
- [x] As GO/GA/SA/SCM, make sure you can view the "Edit members" link in the group management dropdown and also make sure you can access the Edit members page

### Deploy notes

- We need to manually trigger the job to run drush updb. CI/CD job `rollback_trigger_updb_qa` -> `Key = UPDB_VERSION, value = 9008`