### PR TITLE
Feature/eicnet 2300 invite user action form

### DIFF
--- a/config/sync/core.entity_form_display.group_content.event-group_membership_request.default.yml
+++ b/config/sync/core.entity_form_display.group_content.event-group_membership_request.default.yml
@@ -1,0 +1,35 @@
+uuid: 3117c080-ddef-4f53-a425-3a2784915560
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.group_content.event-group_membership_request.grequest_status
+    - field.field.group_content.event-group_membership_request.grequest_updated_by
+    - group.content_type.event-group_membership_request
+id: group_content.event-group_membership_request.default
+targetEntityType: group_content
+bundle: event-group_membership_request
+mode: default
+content:
+  entity_id:
+    type: entity_reference_autocomplete
+    weight: 1
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 0
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+hidden:
+  grequest_status: true
+  grequest_updated_by: true
+  path: true
+  uid: true

--- a/config/sync/core.entity_form_display.group_content.group-group_membership_request.default.yml
+++ b/config/sync/core.entity_form_display.group_content.group-group_membership_request.default.yml
@@ -1,0 +1,35 @@
+uuid: d2c1a381-2961-4806-a5b8-936cda9b91dd
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.group_content.group-group_membership_request.grequest_status
+    - field.field.group_content.group-group_membership_request.grequest_updated_by
+    - group.content_type.group-group_membership_request
+id: group_content.group-group_membership_request.default
+targetEntityType: group_content
+bundle: group-group_membership_request
+mode: default
+content:
+  entity_id:
+    type: entity_reference_autocomplete
+    weight: 1
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 0
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+hidden:
+  grequest_status: true
+  grequest_updated_by: true
+  path: true
+  uid: true

--- a/config/sync/eic_admin.action_forms.entity.group.group_request_membership.yml
+++ b/config/sync/eic_admin.action_forms.entity.group.group_request_membership.yml
@@ -1,6 +1,6 @@
 route: entity.group.group_request_membership
 label: 'Group membership request'
-title: 'Request membership for [group:title]'
+title: 'Membership request confirmation'
 description:
-  value: ''
+  value: "<p>You are about to request to join <a href=\"[group:url]\">[group:title]</a>.</p>\r\n\r\n<p>Click the request group membership button to complete this action.</p>\r\n"
   format: full_html

--- a/config/sync/eic_admin.action_forms.entity.group_content.group_reject_membership.yml
+++ b/config/sync/eic_admin.action_forms.entity.group_content.group_reject_membership.yml
@@ -1,0 +1,6 @@
+route: entity.group_content.group_reject_membership
+label: 'Reject membership request'
+title: ''
+description:
+  value: ""
+  format: full_html

--- a/config/sync/eic_admin.action_forms.ginvite.invitation.bulk.confirm.yml
+++ b/config/sync/eic_admin.action_forms.ginvite.invitation.bulk.confirm.yml
@@ -1,0 +1,6 @@
+route: ginvite.invitation.bulk.confirm
+label: 'Invite members to group - confirmation'
+title: 'Invite users to the group (2 of 2)'
+description:
+  value: ''
+  format: full_html

--- a/config/sync/eic_admin.action_forms.ginvite.invitation.bulk.yml
+++ b/config/sync/eic_admin.action_forms.ginvite.invitation.bulk.yml
@@ -1,0 +1,6 @@
+route: ginvite.invitation.bulk
+label: 'Invite members to group'
+title: 'Invite users to the group (1 of 2)'
+description:
+  value: "<p>You are about to invite users to <a href=\"[group:url]\">[group:title]</a>.<br />\r\n&nbsp;<br />\r\nIn order to complete the invitations process, please confirm the list of users below matches the users you wish to invite to the group. Click the confirm invitations button to complete this action.</p>\r\n"
+  format: full_html

--- a/lib/modules/eic_admin/eic_admin.services.yml
+++ b/lib/modules/eic_admin/eic_admin.services.yml
@@ -1,7 +1,7 @@
 services:
   eic_admin.action_forms_manager:
     class: Drupal\eic_admin\Service\ActionFormsManager
-    arguments: ['@current_route_match', '@config.factory']
+    arguments: ['@current_route_match', '@config.factory', '@request_stack', '@title_resolver']
   eic_admin.route_subscriber:
     class: Drupal\eic_admin\Routing\RouteSubscriber
     arguments: ['@eic_admin.action_forms_manager']

--- a/lib/modules/eic_admin/src/Plugin/Block/ActionFormDescriptionBlock.php
+++ b/lib/modules/eic_admin/src/Plugin/Block/ActionFormDescriptionBlock.php
@@ -3,14 +3,11 @@
 namespace Drupal\eic_admin\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
-use Drupal\Core\Controller\TitleResolverInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Utility\Token;
 use Drupal\eic_admin\Service\ActionFormsManager;
-use Symfony\Cmf\Component\Routing\RouteObjectInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Provides a custom group content menu block.
@@ -45,20 +42,6 @@ class ActionFormDescriptionBlock extends BlockBase implements ContainerFactoryPl
   protected $tokenService;
 
   /**
-   * The request stack service.
-   *
-   * @var \Symfony\Component\HttpFoundation\RequestStack
-   */
-  protected $requestStack;
-
-  /**
-   * The title resolver service.
-   *
-   * @var \Drupal\Core\Controller\TitleResolverInterface
-   */
-  protected $titleResolver;
-
-  /**
    * Constructs a new ActionFormDescriptionBlock instance.
    *
    * @param array $configuration
@@ -73,10 +56,6 @@ class ActionFormDescriptionBlock extends BlockBase implements ContainerFactoryPl
    *   The action forms manager service.
    * @param \Drupal\Core\Utility\Token $token_service
    *   The token service.
-   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
-   *   The request stack service.
-   * @param \Drupal\Core\Controller\TitleResolverInterface $title_resolver
-   *   The title resolver service.
    */
   public function __construct(
     array $configuration,
@@ -84,16 +63,12 @@ class ActionFormDescriptionBlock extends BlockBase implements ContainerFactoryPl
     $plugin_definition,
     RouteMatchInterface $route_match,
     ActionFormsManager $action_forms_manager,
-    Token $token_service,
-    RequestStack $request_stack,
-    TitleResolverInterface $title_resolver
+    Token $token_service
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->routeMatch = $route_match;
     $this->actionFormsManager = $action_forms_manager;
     $this->tokenService = $token_service;
-    $this->requestStack = $request_stack;
-    $this->titleResolver = $title_resolver;
   }
 
   /**
@@ -111,9 +86,7 @@ class ActionFormDescriptionBlock extends BlockBase implements ContainerFactoryPl
       $plugin_definition,
       $container->get('current_route_match'),
       $container->get('eic_admin.action_forms_manager'),
-      $container->get('token'),
-      $container->get('request_stack'),
-      $container->get('title_resolver')
+      $container->get('token')
     );
   }
 
@@ -130,13 +103,8 @@ class ActionFormDescriptionBlock extends BlockBase implements ContainerFactoryPl
         $route_parameters[$parameter_type] = $entity;
       }
 
-      $request = $this->requestStack->getCurrentRequest();
-
       // Prepare title and description variables.
-      $title = '';
-      if ($route = $request->attributes->get(RouteObjectInterface::ROUTE_OBJECT)) {
-        $title = $this->titleResolver->getTitle($request, $route);
-      }
+      $title = $this->actionFormsManager->getCurrentRequestPageTitle();
       $text = $this->tokenService->replace($config->get('description.value'), $route_parameters);
 
       if (!empty($title)) {

--- a/lib/modules/eic_admin/src/Service/ActionFormsManager.php
+++ b/lib/modules/eic_admin/src/Service/ActionFormsManager.php
@@ -2,9 +2,12 @@
 
 namespace Drupal\eic_admin\Service;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Controller\TitleResolverInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
-use Drupal\Core\Config\ConfigFactoryInterface;
+use Symfony\Cmf\Component\Routing\RouteObjectInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Class that manages functions for the confirmation forms.
@@ -30,16 +33,41 @@ class ActionFormsManager {
   protected $configFactory;
 
   /**
+   * The request stack service.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
+   * The title resolver service.
+   *
+   * @var \Drupal\Core\Controller\TitleResolverInterface
+   */
+  protected $titleResolver;
+
+  /**
    * Constructs a new ShareManager object.
    *
    * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
    *   The current route match.
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The config factory.
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
+   *   The request stack service.
+   * @param \Drupal\Core\Controller\TitleResolverInterface $title_resolver
+   *   The title resolver service.
    */
-  public function __construct(RouteMatchInterface $route_match, ConfigFactoryInterface $config_factory) {
+  public function __construct(
+    RouteMatchInterface $route_match,
+    ConfigFactoryInterface $config_factory,
+    RequestStack $request_stack,
+    TitleResolverInterface $title_resolver
+  ) {
     $this->routeMatch = $route_match;
     $this->configFactory = $config_factory;
+    $this->requestStack = $request_stack;
+    $this->titleResolver = $title_resolver;
   }
 
   /**
@@ -88,6 +116,21 @@ class ActionFormsManager {
       $routes[] = $config->get('route');
     }
     return $routes;
+  }
+
+  /**
+   * Returns the page title for the current request.
+   *
+   * @return string
+   *   The page title.
+   */
+  public function getCurrentRequestPageTitle() {
+    $title = '';
+    $request = $this->requestStack->getCurrentRequest();
+    if ($route = $request->attributes->get(RouteObjectInterface::ROUTE_OBJECT)) {
+      $title = $this->titleResolver->getTitle($request, $route);
+    }
+    return $title;
   }
 
 }

--- a/lib/modules/eic_groups/src/Breadcrumb/GroupBreadcrumbBuilder.php
+++ b/lib/modules/eic_groups/src/Breadcrumb/GroupBreadcrumbBuilder.php
@@ -113,8 +113,11 @@ class GroupBreadcrumbBuilder implements BreadcrumbBuilderInterface {
     switch ($route_match->getRouteName()) {
       case 'entity.group.add_form':
       case 'entity.group.canonical':
+      case 'entity.group_content.group_approve_membership':
+      case 'entity.group_content.group_reject_membership':
         $applies = TRUE;
         break;
+
       case 'entity.node.canonical':
         $node = $route_match->getParameter('node');
 
@@ -122,6 +125,7 @@ class GroupBreadcrumbBuilder implements BreadcrumbBuilderInterface {
           $applies = GroupContent::loadByEntity($node) ? TRUE : FALSE;
         }
         break;
+
       case 'entity.group_content.new_request':
       case 'entity.group_content.user_close_request':
         $group_content = $route_match->getParameter('group_content');
@@ -164,7 +168,8 @@ class GroupBreadcrumbBuilder implements BreadcrumbBuilderInterface {
     }
 
     if ($route_match->getParameter('group_type') instanceof GroupTypeInterface) {
-    // This has higher priority because of add group pages where a group doesn't exist yet.
+      // This has higher priority because of add group pages where a group
+      // doesn't exist yet.
       $group_type = $route_match->getParameter('group_type')->id();
     }
 
@@ -279,6 +284,11 @@ class GroupBreadcrumbBuilder implements BreadcrumbBuilderInterface {
             $breadcrumb->addCacheableDependency($access);
           }
         }
+        break;
+
+      case 'entity.group_content.group_approve_membership':
+      case 'entity.group_content.group_reject_membership':
+        $links[] = $group->toLink();
         break;
 
       case 'entity.group_content.new_request':

--- a/lib/modules/eic_groups/src/Breadcrumb/GroupBreadcrumbBuilder.php
+++ b/lib/modules/eic_groups/src/Breadcrumb/GroupBreadcrumbBuilder.php
@@ -115,6 +115,8 @@ class GroupBreadcrumbBuilder implements BreadcrumbBuilderInterface {
       case 'entity.group.canonical':
       case 'entity.group_content.group_approve_membership':
       case 'entity.group_content.group_reject_membership':
+      case 'ginvite.invitation.bulk':
+      case 'ginvite.invitation.bulk.confirm':
         $applies = TRUE;
         break;
 
@@ -288,6 +290,8 @@ class GroupBreadcrumbBuilder implements BreadcrumbBuilderInterface {
 
       case 'entity.group_content.group_approve_membership':
       case 'entity.group_content.group_reject_membership':
+      case 'ginvite.invitation.bulk':
+      case 'ginvite.invitation.bulk.confirm':
         $links[] = $group->toLink();
         break;
 

--- a/lib/modules/eic_user/src/Hooks/FormAlter.php
+++ b/lib/modules/eic_user/src/Hooks/FormAlter.php
@@ -53,6 +53,10 @@ class FormAlter {
       'page' => 1
     ])->toString();
 
+    $options = [
+      'selected_terms_label' => $this->t('Select existing platform users to invite', [], ['context' => 'eic_user']),
+    ];
+
     $form['existing_users'] = EntityTreeWidget::getEntityTreeFieldStructure(
       [],
       'user',
@@ -60,7 +64,8 @@ class FormAlter {
       50,
       $url_search,
       $url_search,
-      $url_search
+      $url_search,
+      $options
     );
     $form['existing_users']['#weight'] = -2;
 

--- a/lib/modules/eic_user/src/Hooks/FormAlter.php
+++ b/lib/modules/eic_user/src/Hooks/FormAlter.php
@@ -26,6 +26,7 @@ class FormAlter {
    * @param $form_id
    */
   public function alterBulkGroupInvitation(&$form, FormStateInterface $form_state, $form_id) {
+    $maximum_users = 50;
     /** @var \Drupal\group\Entity\GroupInterface $group */
     $group = \Drupal::routeMatch()->getParameter('group');
 
@@ -57,21 +58,44 @@ class FormAlter {
       'selected_terms_label' => $this->t('Select existing platform users to invite', [], ['context' => 'eic_user']),
     ];
 
+    // Existing users field.
     $form['existing_users'] = EntityTreeWidget::getEntityTreeFieldStructure(
       [],
       'user',
       '',
-      50,
+      $maximum_users,
       $url_search,
       $url_search,
       $url_search,
       $options
     );
     $form['existing_users']['#weight'] = -2;
+    $form['existing_users']['#description'] = $this->t('You can select up to <strong>@count</strong> existing platform users.',
+      ['@count' => $maximum_users],
+      ['context' => 'eic_user']
+    );
+
+    // Input divider.
+    $form['input_divider'] = [
+      '#markup' => $this->t('You can also', [], ['context' => 'eic_user']),
+      '#prefix' => '<div id="input-divider">',
+      '#suffix' => '</div>',
+      '#weight' => $form['existing_users']['#weight'] + 1,
+    ];
+
+    // Tweak email_address field.
+    $form['email_address']['#title'] = $this->t('Select new users to invite to the platform',
+      [],
+      ['context' => 'eic_user']
+    );
+    $form['email_address']['#attributes']['placeholder'] = $this->t('Recipients email addresses here',
+      [],
+      ['context' => 'eic_user']
+    );
+    $form['email_address']['#required'] = FALSE;
 
     $form['existing_users']['#attached']['library'][] = 'eic_community/react-tree-field';
 
-    $form['email_address']['#required'] = FALSE;
     $form['#submit'][] = [$this, 'submitBulkInviteUsers'];
     // Remove the default validation.
     $form['#validate'] = [

--- a/lib/themes/eic_community/includes/preprocess/blocks/block.inc
+++ b/lib/themes/eic_community/includes/preprocess/blocks/block.inc
@@ -22,7 +22,6 @@ function eic_community_preprocess_block(array &$variables) {
   // Add class to blocks to have them centered.
   switch ($variables['elements']['#id']) {
     case 'eic_admin_action_forms_description':
-      $variables['attributes']['class'][] = 'ecl-container';
       $variables['attributes']['class'][] = 'ecl-form';
       break;
   }

--- a/lib/themes/eic_community/sass/components/_form.scss
+++ b/lib/themes/eic_community/sass/components/_form.scss
@@ -20,6 +20,15 @@
     color: $ecl-color-grey-50;
   }
 
+  & div#input-divider {
+    padding: map-get($ecl-spacing, 'm') 0;
+    background-color: map-get($ecl-colors, 'blue-5');
+    text-align: center;
+    text-transform: uppercase;
+    font-weight: 700;
+    color: map-get($ecl-colors, 'blue');
+  }
+
   &,
   &__section {
     margin-top: map-get($ecl-spacing, '2xl');


### PR DESCRIPTION
### Tests

- [x] Go a group and click on "Invite users"
- [x] Check that there is no group header block
- [x] Check that you have a title and description block
- [x] Select some users, then put a non-valid email address in the textarea and submit
- [x] Check that your preselection of users still remains

### To do

- [ ] Modify "Back to group" button: add `ecl-button--ghost` class and remove `ecl-button--primary`
- [ ] Put "Back to group" button: after the submit button

### Remarks

- Not all of the FA in the ticket is implemented (e.g. button labels are customisable through Translation UI)