### PR TITLE
Feature/eicnet 2468 group invitations migration

### DIFF
--- a/config/sync/migrate_plus.migration.upgrade_d7_group_declined_invitations.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_group_declined_invitations.yml
@@ -45,7 +45,7 @@ process:
       migration:
         - upgrade_d7_node_complete_group
         - upgrade_d7_node_complete_organisation
-        - upgrade_d7_node_complete_event
+        - upgrade_d7_node_complete_event_site
       no_stub: true
     -
       plugin: skip_on_empty
@@ -75,5 +75,5 @@ migration_dependencies:
     - upgrade_d7_user
     - upgrade_d7_node_complete_group
     - upgrade_d7_node_complete_organisation
-    - upgrade_d7_node_complete_event
+    - upgrade_d7_node_complete_event_site
   optional: {  }

--- a/config/sync/migrate_plus.migration.upgrade_d7_group_declined_invitations.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_group_declined_invitations.yml
@@ -9,6 +9,7 @@ cck_plugin_method: null
 migration_tags:
   - 'Drupal 7'
   - Content
+  - Invitations
 migration_group: migrate_drupal_7
 label: 'Group declined invitations'
 source:
@@ -16,6 +17,7 @@ source:
   type: og_membership_type_default
   state: 3
   include_user_data: true
+  invitations_only: true
   track_changes: true
   constants:
     group_invitation_plugin_id: group_invitation

--- a/config/sync/migrate_plus.migration.upgrade_d7_group_declined_invitations.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_group_declined_invitations.yml
@@ -1,0 +1,77 @@
+uuid: 06642413-2a27-41f3-b0fe-cb36cc998928
+langcode: en
+status: true
+dependencies: {  }
+id: upgrade_d7_group_declined_invitations
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags:
+  - 'Drupal 7'
+  - Content
+migration_group: migrate_drupal_7
+label: 'Group declined invitations'
+source:
+  plugin: eic_d7_og_user_membership
+  type: og_membership_type_default
+  state: 3
+  include_user_data: true
+  track_changes: true
+  constants:
+    group_invitation_plugin_id: group_invitation
+process:
+  type:
+    plugin: concat
+    source:
+      - node_type
+      - constants/group_invitation_plugin_id
+    delimiter: '-'
+  uid:
+    -
+      plugin: migration_lookup
+      source: etid
+      migration: upgrade_d7_user
+      no_stub: true
+    -
+      plugin: skip_on_empty
+      method: row
+      message: 'User not found'
+  gid:
+    -
+      plugin: migration_lookup
+      source: gid
+      migration:
+        - upgrade_d7_node_complete_group
+        - upgrade_d7_node_complete_organisation
+        - upgrade_d7_node_complete_event
+      no_stub: true
+    -
+      plugin: skip_on_empty
+      method: row
+      message: 'Group not found'
+  entity_id:
+    -
+      plugin: migration_lookup
+      source: etid
+      migration: upgrade_d7_user
+      no_stub: true
+    -
+      plugin: skip_on_empty
+      method: row
+      message: 'User not found'
+  invitee_mail: mail
+  invitation_status:
+    -
+      plugin: default_value
+      default_value: 2
+  created: created
+  changed: created
+destination:
+  plugin: 'entity:group_content'
+migration_dependencies:
+  required:
+    - upgrade_d7_user
+    - upgrade_d7_node_complete_group
+    - upgrade_d7_node_complete_organisation
+    - upgrade_d7_node_complete_event
+  optional: {  }

--- a/config/sync/migrate_plus.migration.upgrade_d7_group_pending_invitations.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_group_pending_invitations.yml
@@ -45,7 +45,7 @@ process:
       migration:
         - upgrade_d7_node_complete_group
         - upgrade_d7_node_complete_organisation
-        - upgrade_d7_node_complete_event
+        - upgrade_d7_node_complete_event_site
       no_stub: true
     -
       plugin: skip_on_empty
@@ -75,5 +75,5 @@ migration_dependencies:
     - upgrade_d7_user
     - upgrade_d7_node_complete_group
     - upgrade_d7_node_complete_organisation
-    - upgrade_d7_node_complete_event
+    - upgrade_d7_node_complete_event_site
   optional: {  }

--- a/config/sync/migrate_plus.migration.upgrade_d7_group_pending_invitations.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_group_pending_invitations.yml
@@ -9,6 +9,7 @@ cck_plugin_method: null
 migration_tags:
   - 'Drupal 7'
   - Content
+  - Invitations
 migration_group: migrate_drupal_7
 label: 'Group pending invitations'
 source:
@@ -16,6 +17,7 @@ source:
   type: og_membership_type_default
   state: 2
   include_user_data: true
+  invitations_only: true
   track_changes: true
   constants:
     group_invitation_plugin_id: group_invitation

--- a/config/sync/migrate_plus.migration.upgrade_d7_group_pending_invitations.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_group_pending_invitations.yml
@@ -1,0 +1,77 @@
+uuid: bb8e8cbe-54e6-48c4-83d5-a39473a21d37
+langcode: en
+status: true
+dependencies: {  }
+id: upgrade_d7_group_pending_invitations
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags:
+  - 'Drupal 7'
+  - Content
+migration_group: migrate_drupal_7
+label: 'Group pending invitations'
+source:
+  plugin: eic_d7_og_user_membership
+  type: og_membership_type_default
+  state: 2
+  include_user_data: true
+  track_changes: true
+  constants:
+    group_invitation_plugin_id: group_invitation
+process:
+  type:
+    plugin: concat
+    source:
+      - node_type
+      - constants/group_invitation_plugin_id
+    delimiter: '-'
+  uid:
+    -
+      plugin: migration_lookup
+      source: etid
+      migration: upgrade_d7_user
+      no_stub: true
+    -
+      plugin: skip_on_empty
+      method: row
+      message: 'User not found'
+  gid:
+    -
+      plugin: migration_lookup
+      source: gid
+      migration:
+        - upgrade_d7_node_complete_group
+        - upgrade_d7_node_complete_organisation
+        - upgrade_d7_node_complete_event
+      no_stub: true
+    -
+      plugin: skip_on_empty
+      method: row
+      message: 'Group not found'
+  entity_id:
+    -
+      plugin: migration_lookup
+      source: etid
+      migration: upgrade_d7_user
+      no_stub: true
+    -
+      plugin: skip_on_empty
+      method: row
+      message: 'User not found'
+  invitee_mail: mail
+  invitation_status:
+    -
+      plugin: default_value
+      default_value: 0
+  created: created
+  changed: created
+destination:
+  plugin: 'entity:group_content'
+migration_dependencies:
+  required:
+    - upgrade_d7_user
+    - upgrade_d7_node_complete_group
+    - upgrade_d7_node_complete_organisation
+    - upgrade_d7_node_complete_event
+  optional: {  }

--- a/config/sync/migrate_plus.migration.upgrade_d7_group_pending_visitor_invitations.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_group_pending_visitor_invitations.yml
@@ -9,6 +9,7 @@ cck_plugin_method: null
 migration_tags:
   - 'Drupal 7'
   - Content
+  - Invitations
 migration_group: migrate_drupal_7
 label: 'Group pending visitor invitations'
 source:

--- a/config/sync/migrate_plus.migration.upgrade_d7_group_pending_visitor_invitations.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_group_pending_visitor_invitations.yml
@@ -1,0 +1,68 @@
+uuid: 25fac7c0-09b7-4a7c-91d6-b614fffc1e0c
+langcode: en
+status: true
+dependencies: {  }
+id: upgrade_d7_group_pending_visitor_invitations
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags:
+  - 'Drupal 7'
+  - Content
+migration_group: migrate_drupal_7
+label: 'Group pending visitor invitations'
+source:
+  plugin: eic_d7_c4m_og_invite_visitors
+  track_changes: true
+  constants:
+    group_invitation_plugin_id: group_invitation
+process:
+  type:
+    plugin: concat
+    source:
+      - node_type
+      - constants/group_invitation_plugin_id
+    delimiter: '-'
+  uid:
+    -
+      plugin: migration_lookup
+      source: inv_inviter_id
+      migration: upgrade_d7_user
+      no_stub: true
+    -
+      plugin: skip_on_empty
+      method: row
+      message: 'User not found'
+  gid:
+    -
+      plugin: migration_lookup
+      source: inv_group_id
+      migration:
+        - upgrade_d7_node_complete_group
+        - upgrade_d7_node_complete_organisation
+        - upgrade_d7_node_complete_event
+      no_stub: true
+    -
+      plugin: skip_on_empty
+      method: row
+      message: 'Group not found'
+  entity_id:
+    -
+      plugin: default_value
+      default_value: 0
+  invitee_mail: inv_email
+  invitation_status:
+    -
+      plugin: default_value
+      default_value: 0
+  created: inv_created
+  changed: inv_updated
+destination:
+  plugin: 'entity:group_content'
+migration_dependencies:
+  required:
+    - upgrade_d7_user
+    - upgrade_d7_node_complete_group
+    - upgrade_d7_node_complete_organisation
+    - upgrade_d7_node_complete_event
+  optional: {  }

--- a/config/sync/migrate_plus.migration.upgrade_d7_group_pending_visitor_invitations.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_group_pending_visitor_invitations.yml
@@ -41,7 +41,7 @@ process:
       migration:
         - upgrade_d7_node_complete_group
         - upgrade_d7_node_complete_organisation
-        - upgrade_d7_node_complete_event
+        - upgrade_d7_node_complete_event_site
       no_stub: true
     -
       plugin: skip_on_empty
@@ -65,5 +65,5 @@ migration_dependencies:
     - upgrade_d7_user
     - upgrade_d7_node_complete_group
     - upgrade_d7_node_complete_organisation
-    - upgrade_d7_node_complete_event
+    - upgrade_d7_node_complete_event_site
   optional: {  }

--- a/config/sync/migrate_plus.migration.upgrade_d7_user_membership.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_user_membership.yml
@@ -44,7 +44,7 @@ process:
       migration:
         - upgrade_d7_node_complete_group
         - upgrade_d7_node_complete_organisation
-        - upgrade_d7_node_complete_event
+        - upgrade_d7_node_complete_event_site
       no_stub: true
     -
       plugin: skip_on_empty
@@ -78,5 +78,5 @@ migration_dependencies:
     - upgrade_d7_user
     - upgrade_d7_node_complete_group
     - upgrade_d7_node_complete_organisation
-    - upgrade_d7_node_complete_event
+    - upgrade_d7_node_complete_event_site
   optional: {  }

--- a/config/sync/migrate_plus.migration.upgrade_d7_user_membership.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_user_membership.yml
@@ -77,4 +77,6 @@ migration_dependencies:
   required:
     - upgrade_d7_user
     - upgrade_d7_node_complete_group
+    - upgrade_d7_node_complete_organisation
+    - upgrade_d7_node_complete_event
   optional: {  }

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_group_declined_invitations.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_group_declined_invitations.yml
@@ -1,0 +1,75 @@
+langcode: en
+status: true
+dependencies: {  }
+id: upgrade_d7_group_declined_invitations
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags:
+  - 'Drupal 7'
+  - Content
+migration_group: migrate_drupal_7
+label: 'Group declined invitations'
+source:
+  plugin: eic_d7_og_user_membership
+  type: og_membership_type_default
+  state: 3
+  include_user_data: true
+  track_changes: true
+  constants:
+    group_invitation_plugin_id: group_invitation
+process:
+  type:
+    plugin: concat
+    source:
+      - node_type
+      - constants/group_invitation_plugin_id
+    delimiter: '-'
+  uid:
+    -
+      plugin: migration_lookup
+      source: etid
+      migration: upgrade_d7_user
+      no_stub: true
+    -
+      plugin: skip_on_empty
+      method: row
+      message: 'User not found'
+  gid:
+    -
+      plugin: migration_lookup
+      source: gid
+      migration:
+        - upgrade_d7_node_complete_group
+        - upgrade_d7_node_complete_organisation
+        - upgrade_d7_node_complete_event
+      no_stub: true
+    -
+      plugin: skip_on_empty
+      method: row
+      message: 'Group not found'
+  entity_id:
+    -
+      plugin: migration_lookup
+      source: etid
+      migration: upgrade_d7_user
+      no_stub: true
+    -
+      plugin: skip_on_empty
+      method: row
+      message: 'User not found'
+  invitee_mail: mail
+  invitation_status:
+    - plugin: default_value
+      default_value: 2
+  created: created
+  changed: created
+
+destination:
+  plugin: 'entity:group_content'
+migration_dependencies:
+  required:
+    - upgrade_d7_user
+    - upgrade_d7_node_complete_group
+    - upgrade_d7_node_complete_organisation
+    - upgrade_d7_node_complete_event
+  optional: { }

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_group_declined_invitations.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_group_declined_invitations.yml
@@ -7,6 +7,7 @@ cck_plugin_method: null
 migration_tags:
   - 'Drupal 7'
   - Content
+  - Invitations
 migration_group: migrate_drupal_7
 label: 'Group declined invitations'
 source:
@@ -14,6 +15,7 @@ source:
   type: og_membership_type_default
   state: 3
   include_user_data: true
+  invitations_only: true
   track_changes: true
   constants:
     group_invitation_plugin_id: group_invitation

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_group_declined_invitations.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_group_declined_invitations.yml
@@ -43,7 +43,7 @@ process:
       migration:
         - upgrade_d7_node_complete_group
         - upgrade_d7_node_complete_organisation
-        - upgrade_d7_node_complete_event
+        - upgrade_d7_node_complete_event_site
       no_stub: true
     -
       plugin: skip_on_empty
@@ -73,5 +73,5 @@ migration_dependencies:
     - upgrade_d7_user
     - upgrade_d7_node_complete_group
     - upgrade_d7_node_complete_organisation
-    - upgrade_d7_node_complete_event
+    - upgrade_d7_node_complete_event_site
   optional: { }

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_group_pending_invitations.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_group_pending_invitations.yml
@@ -7,6 +7,7 @@ cck_plugin_method: null
 migration_tags:
   - 'Drupal 7'
   - Content
+  - Invitations
 migration_group: migrate_drupal_7
 label: 'Group pending invitations'
 source:
@@ -14,6 +15,7 @@ source:
   type: og_membership_type_default
   state: 2
   include_user_data: true
+  invitations_only: true
   track_changes: true
   constants:
     group_invitation_plugin_id: group_invitation

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_group_pending_invitations.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_group_pending_invitations.yml
@@ -1,0 +1,75 @@
+langcode: en
+status: true
+dependencies: {  }
+id: upgrade_d7_group_pending_invitations
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags:
+  - 'Drupal 7'
+  - Content
+migration_group: migrate_drupal_7
+label: 'Group pending invitations'
+source:
+  plugin: eic_d7_og_user_membership
+  type: og_membership_type_default
+  state: 2
+  include_user_data: true
+  track_changes: true
+  constants:
+    group_invitation_plugin_id: group_invitation
+process:
+  type:
+    plugin: concat
+    source:
+      - node_type
+      - constants/group_invitation_plugin_id
+    delimiter: '-'
+  uid:
+    -
+      plugin: migration_lookup
+      source: etid
+      migration: upgrade_d7_user
+      no_stub: true
+    -
+      plugin: skip_on_empty
+      method: row
+      message: 'User not found'
+  gid:
+    -
+      plugin: migration_lookup
+      source: gid
+      migration:
+        - upgrade_d7_node_complete_group
+        - upgrade_d7_node_complete_organisation
+        - upgrade_d7_node_complete_event
+      no_stub: true
+    -
+      plugin: skip_on_empty
+      method: row
+      message: 'Group not found'
+  entity_id:
+    -
+      plugin: migration_lookup
+      source: etid
+      migration: upgrade_d7_user
+      no_stub: true
+    -
+      plugin: skip_on_empty
+      method: row
+      message: 'User not found'
+  invitee_mail: mail
+  invitation_status:
+    - plugin: default_value
+      default_value: 0
+  created: created
+  changed: created
+
+destination:
+  plugin: 'entity:group_content'
+migration_dependencies:
+  required:
+    - upgrade_d7_user
+    - upgrade_d7_node_complete_group
+    - upgrade_d7_node_complete_organisation
+    - upgrade_d7_node_complete_event
+  optional: { }

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_group_pending_invitations.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_group_pending_invitations.yml
@@ -43,7 +43,7 @@ process:
       migration:
         - upgrade_d7_node_complete_group
         - upgrade_d7_node_complete_organisation
-        - upgrade_d7_node_complete_event
+        - upgrade_d7_node_complete_event_site
       no_stub: true
     -
       plugin: skip_on_empty
@@ -73,5 +73,5 @@ migration_dependencies:
     - upgrade_d7_user
     - upgrade_d7_node_complete_group
     - upgrade_d7_node_complete_organisation
-    - upgrade_d7_node_complete_event
+    - upgrade_d7_node_complete_event_site
   optional: { }

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_group_pending_visitor_invitations.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_group_pending_visitor_invitations.yml
@@ -1,0 +1,65 @@
+langcode: en
+status: true
+dependencies: {  }
+id: upgrade_d7_group_pending_visitor_invitations
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags:
+  - 'Drupal 7'
+  - Content
+migration_group: migrate_drupal_7
+label: 'Group pending visitor invitations'
+source:
+  plugin: eic_d7_c4m_og_invite_visitors
+  track_changes: true
+  constants:
+    group_invitation_plugin_id: group_invitation
+process:
+  type:
+    plugin: concat
+    source:
+      - node_type
+      - constants/group_invitation_plugin_id
+    delimiter: '-'
+  uid:
+    -
+      plugin: migration_lookup
+      source: inv_inviter_id
+      migration: upgrade_d7_user
+      no_stub: true
+    -
+      plugin: skip_on_empty
+      method: row
+      message: 'User not found'
+  gid:
+    -
+      plugin: migration_lookup
+      source: inv_group_id
+      migration:
+        - upgrade_d7_node_complete_group
+        - upgrade_d7_node_complete_organisation
+        - upgrade_d7_node_complete_event
+      no_stub: true
+    -
+      plugin: skip_on_empty
+      method: row
+      message: 'Group not found'
+  entity_id:
+    - plugin: default_value
+      default_value: 0
+  invitee_mail: inv_email
+  invitation_status:
+    - plugin: default_value
+      default_value: 0
+  created: inv_created
+  changed: inv_updated
+
+destination:
+  plugin: 'entity:group_content'
+migration_dependencies:
+  required:
+    - upgrade_d7_user
+    - upgrade_d7_node_complete_group
+    - upgrade_d7_node_complete_organisation
+    - upgrade_d7_node_complete_event
+  optional: { }

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_group_pending_visitor_invitations.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_group_pending_visitor_invitations.yml
@@ -7,6 +7,7 @@ cck_plugin_method: null
 migration_tags:
   - 'Drupal 7'
   - Content
+  - Invitations
 migration_group: migrate_drupal_7
 label: 'Group pending visitor invitations'
 source:

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_group_pending_visitor_invitations.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_group_pending_visitor_invitations.yml
@@ -39,7 +39,7 @@ process:
       migration:
         - upgrade_d7_node_complete_group
         - upgrade_d7_node_complete_organisation
-        - upgrade_d7_node_complete_event
+        - upgrade_d7_node_complete_event_site
       no_stub: true
     -
       plugin: skip_on_empty
@@ -62,5 +62,5 @@ migration_dependencies:
     - upgrade_d7_user
     - upgrade_d7_node_complete_group
     - upgrade_d7_node_complete_organisation
-    - upgrade_d7_node_complete_event
+    - upgrade_d7_node_complete_event_site
   optional: { }

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_user_membership.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_user_membership.yml
@@ -43,7 +43,7 @@ process:
       migration:
         - upgrade_d7_node_complete_group
         - upgrade_d7_node_complete_organisation
-        - upgrade_d7_node_complete_event
+        - upgrade_d7_node_complete_event_site
       no_stub: true
     -
       plugin: skip_on_empty
@@ -77,5 +77,5 @@ migration_dependencies:
     - upgrade_d7_user
     - upgrade_d7_node_complete_group
     - upgrade_d7_node_complete_organisation
-    - upgrade_d7_node_complete_event
+    - upgrade_d7_node_complete_event_site
   optional: { }

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_user_membership.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_user_membership.yml
@@ -75,6 +75,7 @@ destination:
 migration_dependencies:
   required:
     - upgrade_d7_user
-    # TODO: Add the remaining group migration once available.
     - upgrade_d7_node_complete_group
+    - upgrade_d7_node_complete_organisation
+    - upgrade_d7_node_complete_event
   optional: { }

--- a/lib/modules/eic_migrate/eic_migrate.module
+++ b/lib/modules/eic_migrate/eic_migrate.module
@@ -1,10 +1,25 @@
 <?php
 
 /**
+ * @file
+ * Contains hooks for eic_migrate module.
+ */
+
+use Drupal\eic_migrate\Commands\MigrateToolsOverrideCommands;
+
+/**
  * Implements hook_entity_type_alter().
- *
- * @param array $entity_types
  */
 function eic_migrate_entity_type_alter(array &$entity_types) {
   $entity_types['node']->addConstraint('migration_running_messages');
+}
+
+/**
+ * Implements hook_mail_alter().
+ */
+function eic_migrate_mail_alter(&$message) {
+  // If we are running migrations, prevent email sending.
+  if (\Drupal::service('state')->get(MigrateToolsOverrideCommands::STATE_MIGRATIONS_IS_RUNNING)) {
+    $message['send'] = FALSE;
+  }
 }

--- a/lib/modules/eic_migrate/eic_migrate.services.yml
+++ b/lib/modules/eic_migrate/eic_migrate.services.yml
@@ -1,6 +1,11 @@
 services:
-  eic_post_migration_subscriber:
+  eic_migrate.post_migration_subscriber:
     class: '\Drupal\eic_migrate\EventSubscriber\PostMigrationSubscriber'
     arguments: ['@migrate.lookup', '@entity_type.manager', '@group_flex.group_saver']
+    tags:
+      - { name: 'event_subscriber' }
+  eic_migrate.og_membership_subscriber:
+    class: '\Drupal\eic_migrate\EventSubscriber\OgMembershipSubscriber'
+    arguments: ['@entity_type.manager']
     tags:
       - { name: 'event_subscriber' }

--- a/lib/modules/eic_migrate/src/EventSubscriber/OgMembershipSubscriber.php
+++ b/lib/modules/eic_migrate/src/EventSubscriber/OgMembershipSubscriber.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Drupal\eic_migrate\EventSubscriber;
+
+use Drupal\Core\Database\Database;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\ginvite\Plugin\GroupContentEnabler\GroupInvitation;
+use Drupal\migrate\Event\MigrateEvents;
+use Drupal\migrate\Event\MigratePostRowSaveEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Event subscriber for OgMembership related migrations.
+ *
+ * @package Drupal\eic_migrate
+ */
+class OgMembershipSubscriber implements EventSubscriberInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The database connection to the migrate DB.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected $connection;
+
+  /**
+   * Constructs a new OgMembershipSubscriber object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   */
+  public function __construct(
+    EntityTypeManagerInterface $entity_type_manager
+  ) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->connection = Database::getConnection('default', 'migrate');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events[MigrateEvents::POST_ROW_SAVE][] = ['forceDeclinedInvitations'];
+    return $events;
+  }
+
+  /**
+   * Force the status of invitation.
+   *
+   * @param \Drupal\migrate\Event\MigratePostRowSaveEvent $event
+   *   The migrate post row save event object.
+   */
+  public function forceDeclinedInvitations(MigratePostRowSaveEvent $event) {
+    if ($event->getMigration()->getBaseId() != 'upgrade_d7_group_declined_invitations') {
+      return;
+    }
+
+    // Try to load the group invitation.
+    $destination = $event->getDestinationIdValues();
+    if (!$group_content = $this->entityTypeManager->getStorage('group_content')->load($destination[0])) {
+      return;
+    }
+
+    // We are migrating declined invitations. Since the ginvite module
+    // automatically sets the invitations status to pending when inserting new
+    // group_content, we need to resave the rejected status here.
+    $group_content->set('invitation_status', GroupInvitation::INVITATION_REJECTED)->save();
+  }
+
+}

--- a/lib/modules/eic_migrate/src/Plugin/migrate/source/C4mOgInviteVisitors.php
+++ b/lib/modules/eic_migrate/src/Plugin/migrate/source/C4mOgInviteVisitors.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Drupal\eic_migrate\Plugin\migrate\source;
+
+use Drupal\migrate\Plugin\migrate\source\SqlBase;
+
+/**
+ * Get OG User membership from D7.
+ *
+ * Usage:
+ *
+ * @code
+ * source:
+ *   plugin: eic_d7_c4m_og_invite_visitors
+ * @endcode
+ *
+ * @MigrateSource(
+ *   id = "eic_d7_c4m_og_invite_visitors",
+ *   source_module = "eic_migrate",
+ * )
+ */
+class C4mOgInviteVisitors extends SqlBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    $query = $this->select('c4m_og_invite_visitors', 'coiv');
+    $query->fields('coiv');
+    $query->innerJoin('node', 'n', 'n.nid = coiv.inv_group_id');
+    $query->addField('n', 'type', 'node_type');
+
+    return $query;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function fields() {
+    $fields = [
+      'inv_id' => $this->t('ID'),
+      'inv_uid' => $this->t('User ID'),
+      'inv_inviter_id' => $this->t('Inviter ID'),
+      'inv_group_id' => $this->t('Group ID'),
+      'inv_email' => $this->t('Invitee email'),
+      'inv_created' => $this->t('Created date'),
+      'inv_updated' => $this->t('Updated date'),
+      'inv_token' => $this->t('Token'),
+      'inv_expired' => $this->t('Expired'),
+      'node_type' => $this->t('Node (group) bundle'),
+    ];
+    return $fields;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getIds() {
+    $ids = [
+      'inv_id' => [
+        'type' => 'integer',
+        'alias' => 'coiv',
+      ],
+    ];
+    return $ids;
+  }
+
+}

--- a/lib/modules/eic_migrate/src/Plugin/migrate/source/OgUserMembership.php
+++ b/lib/modules/eic_migrate/src/Plugin/migrate/source/OgUserMembership.php
@@ -20,6 +20,8 @@ use Drupal\migrate\Plugin\migrate\source\SqlBase;
  *     Defaults to false.
  *   include_user_data: (optional) true if you want include user's data from
  *     users table. Defaults to false.
+ *   include_user_data: (optional) true if you want include user's data from
+ *     users table. Defaults to false.
  * @endcode
  *
  * 'state' option can be:

--- a/lib/modules/eic_migrate/src/Plugin/migrate/source/OgUserMembership.php
+++ b/lib/modules/eic_migrate/src/Plugin/migrate/source/OgUserMembership.php
@@ -20,8 +20,8 @@ use Drupal\migrate\Plugin\migrate\source\SqlBase;
  *     Defaults to false.
  *   include_user_data: (optional) true if you want include user's data from
  *     users table. Defaults to false.
- *   include_user_data: (optional) true if you want include user's data from
- *     users table. Defaults to false.
+ *   invitations_only: (optional) true if you want to get invitations only.
+ *     Defaults to false.
  * @endcode
  *
  * 'state' option can be:
@@ -64,6 +64,10 @@ class OgUserMembership extends SqlBase {
     if (!empty($this->configuration['include_user_data'])) {
       $query->leftJoin('users', 'u', 'ogm.etid = u.uid');
       $query->fields('u');
+    }
+    if (!empty($this->configuration['invitations_only'])) {
+      $query->innerJoin('field_data_og_membership_invitation', 'omi', 'omi.entity_id = ogm.id');
+      $query->condition('omi.og_membership_invitation_value', 1);
     }
 
     return $query;

--- a/lib/modules/eic_migrate/src/Plugin/migrate/source/OgUserMembership.php
+++ b/lib/modules/eic_migrate/src/Plugin/migrate/source/OgUserMembership.php
@@ -18,6 +18,8 @@ use Drupal\migrate\Plugin\migrate\source\SqlBase;
  *     table. Defaults to false.
  *   ignore_owner: (optional) true if you want to ignore the owner membership.
  *     Defaults to false.
+ *   include_user_data: (optional) true if you want include user's data from
+ *     users table. Defaults to false.
  * @endcode
  *
  * 'state' option can be:
@@ -44,18 +46,22 @@ class OgUserMembership extends SqlBase {
     $query->addField('n', 'uid', 'group_owner');
     $query->condition('ogm.entity_type', 'user');
 
-    if ($this->configuration['type']) {
+    if (!empty($this->configuration['type'])) {
       $query->condition('ogm.type', $this->configuration['type']);
     }
-    if ($this->configuration['state']) {
+    if (!empty($this->configuration['state'])) {
       $query->condition('ogm.state', $this->configuration['state']);
     }
-    if ($this->configuration['ignore_owner']) {
+    if (!empty($this->configuration['ignore_owner'])) {
       $query->where('n.uid != ogm.etid');
     }
-    if ($this->configuration['include_roles']) {
+    if (!empty($this->configuration['include_roles'])) {
       $query->leftJoin('og_users_roles', 'ogur', 'ogm.etid = ogur.uid AND ogm.gid = ogur.gid');
       $query->addField('ogur', 'rid');
+    }
+    if (!empty($this->configuration['include_user_data'])) {
+      $query->leftJoin('users', 'u', 'ogm.etid = u.uid');
+      $query->fields('u');
     }
 
     return $query;


### PR DESCRIPTION
### Improvements

- Added a `hook_mail_alter` to prevent emails to be sent out during migrations

### Tests

- [x] Run `upgrade_d7_group_pending_invitations`. You should get 1949/1952migrated items
- [x] Run `upgrade_d7_group_declined_invitations`. There is no items to migrate at this moment
- [x] Run `upgrade_d7_group_pending_visitor_invitations`. You should get 875/876 migrated items