### PR TITLE
[EICNET-2342]fix: Add like stats to discussion teaser

### DIFF
--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/DiscussionResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/DiscussionResultItem.js
@@ -112,6 +112,13 @@ class DiscussionResultItem extends React.Component {
                 <div className="ecl-discussion-thread__stats-items">
                   <div className="ecl-discussion-thread__stats-item">
                     <span
+                      dangerouslySetInnerHTML={{__html: svg('like', 'ecl-icon ecl-icon--xs ecl-discussion-thread__stats-item-icon')}}
+                    />
+                    <span className="ecl-discussion-thread__stats-item-label">Reactions</span>
+                    <span className="ecl-discussion-thread__stats-item-value">{this.props.result.its_flag_like_content || 0}</span>
+                  </div>
+                  <div className="ecl-discussion-thread__stats-item">
+                    <span
                       dangerouslySetInnerHTML={{__html: svg('comment', 'ecl-icon ecl-icon--xs ecl-discussion-thread__stats-item-icon')}}
                     />
                     <span className="ecl-discussion-thread__stats-item-label">Reactions</span>


### PR DESCRIPTION
How to test:

- [ ] Go to group discussions overview
- [ ] Be sure you have likes statistics near to the comment one