### PR TITLE
EICNET-2473: Fix moderation state field in FE forms

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/form/form-element.inc
+++ b/lib/themes/eic_community/includes/preprocess/form/form-element.inc
@@ -15,6 +15,17 @@ function eic_community_preprocess_form_element(array &$variables): void {
   if (in_array($variables['element']['#type'], ['checkbox', 'radio'])) {
     $variables['label_display'] = 'none';
   }
+
+  if (in_array($variables['element']['#type'], ['select'])) {
+    // Remove "container-inline" class from select lists.
+    if (
+      (isset($variables['attributes']['class'])) &&
+      ($key = array_search('container-inline', $variables['attributes']['class'])) !== FALSE
+    ) {
+      unset($variables['attributes']['class'][$key]);
+    }
+  }
+
   $ecl_type_mappings = [
     'textfield' => 'text-input',
     'password' => 'text-input',


### PR DESCRIPTION
### Improvements

- Remove "container-inline" class from select lists.

### Tests

- [ ] As TU, try to create a group and make sure the Moderation state field doens't look broken.