### PR TITLE
EICNET-2461: Sharing content to another group should be filtered on the availability of that CT in that specific group

### DIFF
--- a/lib/modules/eic_groups/modules/eic_share_content/eic_share_content.routing.yml
+++ b/lib/modules/eic_groups/modules/eic_share_content/eic_share_content.routing.yml
@@ -15,7 +15,7 @@ eic_share_content.share:
       group:
         type: entity:group
 eic_share_content.groups:
-  path: '/share/group/{group}/user/{user}/groups'
+  path: '/share/group/{group}/content/{node}/user/{user}/groups'
   methods: [ GET ]
   defaults:
     _controller: 'Drupal\eic_share_content\Controller\ShareContentController::getGroups'
@@ -28,5 +28,7 @@ eic_share_content.groups:
     parameters:
       user:
         type: entity:user
+      node:
+        type: entity:node
       group:
         type: entity:group

--- a/lib/modules/eic_groups/modules/eic_share_content/src/Controller/ShareContentController.php
+++ b/lib/modules/eic_groups/modules/eic_share_content/src/Controller/ShareContentController.php
@@ -117,12 +117,12 @@ class ShareContentController extends ControllerBase {
    * @return \Symfony\Component\HttpFoundation\JsonResponse
    * @throws \Drupal\Core\TypedData\Exception\MissingDataException
    */
-  public function getGroups(GroupInterface $group, UserInterface $user): JsonResponse {
+  public function getGroups(GroupInterface $group, NodeInterface $node, UserInterface $user): JsonResponse {
     if ($user->id() !== $this->currentUser->id()) {
       throw new InvalidArgumentException();
     }
 
-    $groups = $this->shareManager->getShareableTargetGroupsForUser($this->currentUser, $group);
+    $groups = $this->shareManager->getShareableTargetGroupsForUser($this->currentUser, $group, $node);
     $formatted_groups = [];
     foreach ($groups as $group) {
       $formatted_groups[$group->bundle()][] = [

--- a/lib/themes/eic_community/includes/preprocess/common.inc
+++ b/lib/themes/eic_community/includes/preprocess/common.inc
@@ -82,9 +82,10 @@ function _eic_community_get_share_group_content_link(
 
   return [
     '#theme' => 'eic_share_content_link',
-    '#get_groups_url' => Url::fromRoute('eic_share_content.groups',[
+    '#get_groups_url' => Url::fromRoute('eic_share_content.groups', [
       'user' => $account->id(),
-      'group' => $current_group->id()
+      'group' => $current_group->id(),
+      'node' => $node->id(),
     ])->toString(),
     '#endpoint' => Url::fromRoute('eic_share_content.share', [
       'group' => $current_group->id(),
@@ -317,7 +318,7 @@ function _eic_community_process_term_parents_tree(TermInterface $term, array $te
   if (!$parent) {
     return [];
   }
-  
+
   if (!isset($terms[$parent->id()])) {
     $terms[$parent->id()]['term'] = $parent;
     $terms[$parent->id()]['title'] = $parent->getName();


### PR DESCRIPTION
### Improvements

- Prevent members from sharing content in groups with content type plugin disabled;
- Improvements to the share group service and controller.

### Test

- [x] As TU (member of public groups and organisations), create a new gallery in a group
- [ ] Try to share the gallery with another group and make sure your organisations are not shown.
- [x] Try to create an event in the group.
- [x] Try to share the event with another group and make sure all of your organisations are shown.