### PR TITLE
EICNET-2341: CT document does not have the comment block listed

### DIFF
--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Partials/StatisticsFooterResult.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Partials/StatisticsFooterResult.js
@@ -10,7 +10,7 @@ const StatisticsFooterResult = ({result, enableViews = true, enableMembers = fal
       <span className="ecl-teaser__stat-label">Members</span>
       <span className="ecl-teaser__stat-value">{result.its_group_statistic_members || 0}</span>
     </div>}
-    {result?.ss_content_type !== 'document' || result?.its_content_comment_count !== undefined && <div className="ecl-teaser__stat">
+    {result?.ss_content_type !== 'document' && result?.its_content_comment_count !== undefined && <div className="ecl-teaser__stat">
       <div dangerouslySetInnerHTML={{__html: svg('comment', 'ecl-icon--xs ecl-teaser__stat-icon')}}/>
       <span className="ecl-teaser__stat-label">Reactions</span>
       <span className="ecl-teaser__stat-value">{result.its_content_comment_count || 0}</span>


### PR DESCRIPTION
### Fixes

- Remove comments counter from document teaser in overview pages.

### Test

- [x] As GM, go to a group library overview page
- [x] Make sure Document teasers don't show the number of comments