### PR TITLE
EICNET-2466: Member statistic for organizations does not show the accurate number

### DIFF
--- a/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.module
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/eic_group_statistics.module
@@ -22,13 +22,15 @@ function eic_group_statistics_group_delete(EntityInterface $entity) {
  * Implements hook_ENTITY_TYPE_insert().
  */
 function eic_group_statistics_group_content_insert(EntityInterface $entity) {
+  $group_type = $entity->getGroup()->bundle();
+
   switch ($entity->bundle()) {
-    case 'group-group_membership':
-    case 'group-group_node-discussion':
-    case 'group-group_node-document':
-    case 'group-group_node-event':
-    case 'group-group_node-gallery':
-    case 'group-group_node-wiki_page':
+    case "$group_type-group_membership":
+    case "$group_type-group_node-discussion":
+    case "$group_type-group_node-document":
+    case "$group_type-group_node-event":
+    case "$group_type-group_node-gallery":
+    case "$group_type-group_node-wiki_page":
       \Drupal::classResolver(EntityOperations::class)
         ->groupContentInsert($entity);
       break;
@@ -40,8 +42,10 @@ function eic_group_statistics_group_content_insert(EntityInterface $entity) {
  * Implements hook_ENTITY_TYPE_delete().
  */
 function eic_group_statistics_group_content_delete(EntityInterface $entity) {
+  $group_type = $entity->getGroup()->bundle();
+
   switch ($entity->bundle()) {
-    case 'group-group_membership':
+    case "$group_type-group_membership":
       \Drupal::classResolver(EntityOperations::class)
         ->groupContentDelete($entity);
       break;
@@ -52,7 +56,7 @@ function eic_group_statistics_group_content_delete(EntityInterface $entity) {
 /**
  * Implements hook_ENTITY_TYPE_predelete().
  */
-function eic_group_statistics_entity_predelete(EntityInterface $entity) {
+function eic_group_statistics_node_predelete(EntityInterface $entity) {
   switch ($entity->bundle()) {
     case 'discussion':
     case 'document':
@@ -146,9 +150,9 @@ function eic_group_statistics_comment_delete(EntityInterface $entity) {
 }
 
 /**
- * Implements hook_ENTITY_TYPE_update().
+ * Implements hook_ENTITY_TYPE_presave().
  */
-function eic_group_statistics_entity_presave(EntityInterface $entity) {
+function eic_group_statistics_node_presave(EntityInterface $entity) {
   switch ($entity->bundle()) {
     case 'discussion':
     case 'document':

--- a/lib/modules/eic_statistics/modules/eic_group_statistics/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_statistics/modules/eic_group_statistics/src/Hooks/EntityOperations.php
@@ -150,20 +150,21 @@ class EntityOperations implements ContainerInjectionInterface {
    */
   public function groupContentInsert(GroupContentInterface $entity) {
     $group = $entity->getGroup();
+    $group_type = $group->bundle();
 
     $re_index = TRUE;
 
     switch ($entity->bundle()) {
-      case 'group-group_membership':
+      case "$group_type-group_membership":
         // Increments number of members in the group statistics.
         $this->groupStatisticsStorage->increment($group, GroupStatisticTypes::STAT_TYPE_MEMBERS);
         break;
 
-      case 'group-group_node-discussion':
-      case 'group-group_node-document':
-      case 'group-group_node-event':
-      case 'group-group_node-wiki_page':
-      case 'group-group_node-gallery':
+      case "$group_type-group_node-discussion":
+      case "$group_type-group_node-document":
+      case "$group_type-group_node-event":
+      case "$group_type-group_node-gallery":
+      case "$group_type-group_node-wiki_page":
         if ('group-group_node-event' === $entity->bundle()) {
           $event_count = $this->groupStatisticsStorage->calculateGroupEventsStatistics($group);
           $this->groupStatisticsStorage->increment($group, GroupStatisticTypes::STAT_TYPE_EVENTS, $event_count);
@@ -200,11 +201,11 @@ class EntityOperations implements ContainerInjectionInterface {
    */
   public function groupContentDelete(GroupContentInterface $entity) {
     $group = $entity->getGroup();
-
+    $group_type = $group->bundle();
     $re_index = TRUE;
 
     switch ($entity->bundle()) {
-      case 'group-group_membership':
+      case "$group_type-group_membership":
         // Decrements number of members in the group statistics.
         $this->groupStatisticsStorage->decrement($group, GroupStatisticTypes::STAT_TYPE_MEMBERS);
         break;


### PR DESCRIPTION
### Fixes

- Fix group statistics for group type Event and Organisation.

### Test group statistics in Events and Organisations

- [ ] As TU, try to join an Event and Organisation
- [ ] Make sure the number of members in the group header shows the correct number
- [ ] Try to add documents and make sure the number of files is updating correctly
- [ ] Try to add some comments in discussions and make sure the number of comments is updated 