### PR TITLE
EICNET-2477: Content flags in sidebar look bigger than it should

### DIFF
--- a/lib/themes/eic_community/templates/content/node--document--full.html.twig
+++ b/lib/themes/eic_community/templates/content/node--document--full.html.twig
@@ -7,7 +7,7 @@
     {% block sidebar %}
       {{ eic_local_tasks }}
 
-      {% include "@theme/patterns/compositions/editorial-actions.html.twig" with editorial_actions|default({}) %}
+      {% include "@theme/patterns/components/flags.html.twig" with editorial_actions|default({}) %}
 
       {% include "@theme/patterns/compositions/social-share.html.twig" with social_share|default({})|merge({
         extra_classes: 'ecl-featured-list',

--- a/lib/themes/eic_community/templates/content/node--event--full.html.twig
+++ b/lib/themes/eic_community/templates/content/node--event--full.html.twig
@@ -18,7 +18,7 @@
     {% block sidebar %}
       {{ eic_local_tasks }}
 
-      {% include "@theme/patterns/compositions/editorial-actions.html.twig" with editorial_actions|default({}) %}
+      {% include "@theme/patterns/components/flags.html.twig" with editorial_actions|default({}) %}
 
       {% include "@theme/patterns/compositions/featured-topics.html.twig" with topics|default({}) %}
 

--- a/lib/themes/eic_community/templates/content/node--gallery--full.html.twig
+++ b/lib/themes/eic_community/templates/content/node--gallery--full.html.twig
@@ -22,7 +22,7 @@
   {% block sidebar %}
     {{ eic_local_tasks }}
 
-    {% include "@theme/patterns/compositions/editorial-actions.html.twig" with editorial_actions|default({}) %}
+    {% include "@theme/patterns/components/flags.html.twig" with editorial_actions|default({}) %}
 
     {% include "@theme/patterns/compositions/featured-topics.html.twig" with topics|default({}) %}
 

--- a/lib/themes/eic_community/templates/content/node--story--full.html.twig
+++ b/lib/themes/eic_community/templates/content/node--story--full.html.twig
@@ -20,7 +20,7 @@
 		{% block sidebar %}
 			{{ eic_local_tasks }}
 
-			{% include "@theme/patterns/compositions/editorial-actions.html.twig" with editorial_actions|default({}) %}
+			{% include "@theme/patterns/components/flags.html.twig" with editorial_actions|default({}) %}
 
 			{% include "@theme/patterns/compositions/featured-contributors.html.twig" with contributors|default({}) %}
 

--- a/lib/themes/eic_community/templates/content/node--video--full.html.twig
+++ b/lib/themes/eic_community/templates/content/node--video--full.html.twig
@@ -16,7 +16,7 @@
   {% block sidebar %}
     {{ eic_local_tasks }}
 
-    {% include "@theme/patterns/compositions/editorial-actions.html.twig" with editorial_actions|default({}) %}
+    {% include "@theme/patterns/components/flags.html.twig" with editorial_actions|default({}) %}
 
     {% include "@theme/patterns/compositions/featured-topics.html.twig" with topics|default({}) %}
 


### PR DESCRIPTION
### Fixes

- Fix sidebar flags in node full html twig templates.

### Test

- [x] As SA/SCM, check the detail page of every content type (event, news, story, discussion, document, gallery, video) and make sure the flags in the sidebar don't look too big.