### PR TITLE
EICNET-2269: Help and guidance edit button is aligned all the way to the left

### DIFF
--- a/config/sync/context.context.node_local_tasks.yml
+++ b/config/sync/context.context.node_local_tasks.yml
@@ -19,16 +19,6 @@ conditions:
     uuid: 617b7388-6f0c-4dc1-abc0-5e9751ff626c
     context_mapping: {  }
     routes: entity.node.canonical
-  node_type:
-    id: node_type
-    negate: false
-    uuid: 65c2cb9e-9f35-4f74-bbb1-440e9500ebaf
-    context_mapping:
-      node: '@node.node_route_context:node'
-    bundles:
-      book: book
-      page: page
-      wiki_page: wiki_page
   group_type:
     id: group_type
     group_types:
@@ -38,6 +28,14 @@ conditions:
     uuid: 06419a13-1abe-47ba-b1cd-c28e13d21700
     context_mapping:
       group: '@group.group_route_context:group'
+  'entity_bundle:node':
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: 4857945d-eee0-4c4d-9c20-dc1eeb0a00ed
+    context_mapping:
+      node: '@node.node_route_context:node'
+    bundles:
+      page: page
 reactions:
   blocks:
     id: blocks

--- a/lib/modules/eic_content/modules/eic_content_book/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_content/modules/eic_content_book/src/Hooks/EntityOperations.php
@@ -100,7 +100,7 @@ class EntityOperations implements ContainerInjectionInterface {
             // If child book page.
             $build['link_add_current_level_book_page_renderable'] = Link::fromTextAndUrl($this->t('Add page on same level'), $add_book_page_urls['add_current_level_book_page'])->toRenderable();
             $build['link_add_current_level_book_page_renderable']['#suffix'] = '<br>';
-            $build['link_add_child_book_page_renderable'] = Link::fromTextAndUrl($this->t('Add a new page below this page'), $add_book_page_urls['add_child_book_page'])->toRenderable();
+            $build['link_add_child_book_page_renderable'] = Link::fromTextAndUrl($this->t('Add a child page'), $add_book_page_urls['add_child_book_page'])->toRenderable();
           }
         }
         break;

--- a/lib/themes/eic_community/templates/content/node--book--full.html.twig
+++ b/lib/themes/eic_community/templates/content/node--book--full.html.twig
@@ -40,7 +40,7 @@
     </div>
   {% else %}
     {% if actions is not empty %}
-      <section class="ecl-editorial-article__header">
+      <section class="ecl-editorial-article__header ecl-editorial-article__header--wiki">
       {% include "@theme/patterns/components/inline-actions.html.twig" with actions|default({})|merge({
         items: actions.items ? actions.items|map(i => i|merge({
           extra_classes: i.extra_classes|default('') ~ ' ecl-link--button ecl-link--button-primary'

--- a/lib/themes/eic_community/templates/content/node--book--full.html.twig
+++ b/lib/themes/eic_community/templates/content/node--book--full.html.twig
@@ -40,13 +40,14 @@
     </div>
   {% else %}
     {% if actions is not empty %}
-        <section class="ecl-editorial-article__header">
-        {% include "@theme/patterns/components/inline-actions.html.twig" with actions|default({})|merge({
-          items: actions.items ? actions.items|map(i => i|merge({
-            extra_classes: i.extra_classes|default('') ~ ' ecl-link--button ecl-link--button-primary'
-          }))
-        }) %}
-        </section>
+      <section class="ecl-editorial-article__header">
+      {% include "@theme/patterns/components/inline-actions.html.twig" with actions|default({})|merge({
+        items: actions.items ? actions.items|map(i => i|merge({
+          extra_classes: i.extra_classes|default('') ~ ' ecl-link--button ecl-link--button-primary'
+        }))
+      }) %}
+      {{ eic_local_tasks }}
+      </section>
     {% endif %}
       <section class="ecl-editorial-article__content">
       {{ content }}


### PR DESCRIPTION
### Improvements

- Move manage content dropdown next to the buttons to add book pages.

### Test

- [ ] As SA/SCM, create a new book page
- [ ] Make sure the "Manage content" dropdown is shown next to the add buttons (same as wiki pages)