### PR TITLE
EICNET-1982: TU can access "all entities for (organisation here)"

### DIFF
--- a/lib/modules/eic_groups/modules/eic_group_membership/eic_group_membership.module
+++ b/lib/modules/eic_groups/modules/eic_group_membership/eic_group_membership.module
@@ -16,6 +16,7 @@ use Drupal\eic_user\UserHelper;
 use Drupal\group\Access\GroupAccessResult;
 use Drupal\group\Entity\Form\GroupContentForm;
 use Drupal\group\Entity\GroupInterface;
+use Drupal\group\GroupMembership;
 use Drupal\oec_group_flex\GroupVisibilityRecordInterface;
 use Drupal\message\Entity\Message;
 
@@ -323,12 +324,17 @@ function eic_group_membership_group_content_access(EntityInterface $entity, $ope
       // permission to administer group members.
       $access = GroupAccessResult::forbiddenIf(
           !UserHelper::isPowerUser($account) &&
+          $current_member instanceof GroupMembership &&
           !$current_member->hasPermission('administer members')
         )
         ->addCacheableDependency($account)
-        ->addCacheableDependency($current_member)
         ->addCacheableDependency($entity)
         ->addCacheableDependency($group);
+
+      // Adds group membership as cacheable dependency.
+      if ($current_member instanceof GroupMembership) {
+        $access->addCacheableDependency($current_member);
+      }
       break;
 
   }


### PR DESCRIPTION
### Fixes

- Fix access check on group membership delete
- Remove permission to access all group content overview in organisations.

### Test

Note that this will work only for new organisations. Old organisations will need to rebuild permissions.

- [ ] As TU (non-member), try to access organisation group content overview page -> `/organisations/organisation-name/content`