### PR TITLE
EICNET-2141: regression - error when trying to publish a book

### DIFF
--- a/lib/modules/eic_default_content/src/Generator/BlockContentGenerator.php
+++ b/lib/modules/eic_default_content/src/Generator/BlockContentGenerator.php
@@ -118,11 +118,7 @@ class BlockContentGenerator extends CoreGenerator {
         'format' => 'full_html',
       ],
       'field_title' => "Didn't find what you were looking for?",
-      'field_cta_button' => [
-        'uri' => Url::fromRoute('contact.site_page')->toString(),
-        'title' => 'Contact us',
-        'link_type' => 'default',
-      ],
+      'field_cta_button' => $this->getLink('internal:/contact', 'Contact us', 'default'),
     ]);
     $block->save();
   }


### PR DESCRIPTION
### Fixes

- Fix contact box block when generating with fixtures.

### Test

- [x] Run a site install
- [x] As SA/SCM, try to create a new book page and make sure you get no error when viewing the book page