### PR TITLE
[EICNET-2045]feat:Resync also owner of the content when new content

### DIFF
--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -215,7 +215,7 @@ function eic_groups_group_content_insert(EntityInterface $entity) {
     /** @var \Drupal\eic_search\Service\SolrDocumentProcessor $solr_helper */
     $solr_helper = \Drupal::service('eic_search.solr_document_processor');
     // Reindex group parent to have correct most active score.
-    $solr_helper->lateReIndexEntities([$entity->getGroup()]);
+    $solr_helper->lateReIndexEntities([$entity->getGroup(), $entity->getOwner()]);
   }
 
   switch ($entity->bundle()) {

--- a/lib/modules/eic_groups/src/Plugin/QueueWorker/GroupContentSearchApi.php
+++ b/lib/modules/eic_groups/src/Plugin/QueueWorker/GroupContentSearchApi.php
@@ -13,6 +13,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @QueueWorker(
  *   id = "eic_groups_group_content_search_api",
  *   title = @Translation("Task worker: Update group content into search_api"),
+ *   cron = {"time" = 60}
  * )
  */
 class GroupContentSearchApi extends QueueWorkerBase implements ContainerFactoryPluginInterface {
@@ -20,7 +21,7 @@ class GroupContentSearchApi extends QueueWorkerBase implements ContainerFactoryP
   /**
    * The SOLR Document Processor service.
    *
-   * @var SolrDocumentProcessor $solrDocumentProcessor
+   * @var \Drupal\eic_search\Service\SolrDocumentProcessor
    */
   private $solrDocumentProcessor;
 
@@ -36,7 +37,7 @@ class GroupContentSearchApi extends QueueWorkerBase implements ContainerFactoryP
    *   The plugin_id for the plugin instance.
    * @param mixed $plugin_definition
    *   The plugin implementation definition.
-   * @param SolrDocumentProcessor $solr_document_processor
+   * @param \Drupal\eic_search\Service\SolrDocumentProcessor $solr_document_processor
    *   The SOLR Document Processor service.
    */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, SolrDocumentProcessor $solr_document_processor) {

--- a/lib/modules/eic_groups/src/Plugin/QueueWorker/ReIndexContentSearchApi.php
+++ b/lib/modules/eic_groups/src/Plugin/QueueWorker/ReIndexContentSearchApi.php
@@ -13,6 +13,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @QueueWorker(
  *   id = "eic_groups_reindex_content",
  *   title = @Translation("Task worker: Update content in search_api"),
+ *   cron = {"time" = 60}
  * )
  */
 class ReIndexContentSearchApi extends QueueWorkerBase implements ContainerFactoryPluginInterface {
@@ -20,7 +21,7 @@ class ReIndexContentSearchApi extends QueueWorkerBase implements ContainerFactor
   /**
    * The SOLR Document Processor service.
    *
-   * @var SolrDocumentProcessor $solrDocumentProcessor
+   * @var \Drupal\eic_search\Service\SolrDocumentProcessor
    */
   private $solrDocumentProcessor;
 
@@ -36,7 +37,7 @@ class ReIndexContentSearchApi extends QueueWorkerBase implements ContainerFactor
    *   The plugin_id for the plugin instance.
    * @param mixed $plugin_definition
    *   The plugin implementation definition.
-   * @param SolrDocumentProcessor $solr_document_processor
+   * @param \Drupal\eic_search\Service\SolrDocumentProcessor $solr_document_processor
    *   The SOLR Document Processor service.
    */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, SolrDocumentProcessor $solr_document_processor) {


### PR DESCRIPTION
How to test:

- [x] As a user, create a new group content
- [x] Run cron (as DA)
- [x] check if your activity_score has been updated in the /people (check solr field from request response)