### PR TITLE
Feature/eicnet 2487 searc index sanitize text

### DIFF
--- a/config/sync/search_api.index.global.yml
+++ b/config/sync/search_api.index.global.yml
@@ -3,77 +3,77 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.group.field_date_range
-    - field.storage.group.field_location
-    - field.storage.group.field_event_registration_date
-    - field.storage.group.field_vocab_event_type
-    - field.storage.group.field_funding_source
     - field.storage.user.field_first_name
     - field.storage.user.field_last_name
     - field.storage.media.oe_media_image
     - field.storage.user.field_media
-    - field.storage.group.field_location_type
-    - field.storage.group.field_organisation_type
-    - field.storage.group.field_vocab_geo
-    - field.storage.group.field_vocab_services_products
-    - field.storage.group.field_vocab_target_markets
-    - field.storage.group.field_thumbnail
-    - field.storage.media.oe_media_file
-    - field.storage.group.field_image
-    - field.storage.group.field_vocab_topics
-    - field.storage.group.field_body
-    - field.storage.message.field_entity_type
-    - field.storage.message.field_group_ref
-    - field.storage.message.field_operation_type
-    - field.storage.message.field_referenced_comment
-    - field.storage.message.field_referenced_node
-    - field.storage.node.field_vocab_topics
-    - field.storage.node.field_discussion_type
-    - field.storage.message.field_share_message
-    - field.storage.message.field_source_group
-    - field.storage.node.field_body
     - field.storage.node.field_comments
-    - field.storage.node.field_document_type
-    - field.storage.media.field_media_file
-    - field.storage.node.field_document_media
     - field.storage.node.field_location
+    - field.storage.node.field_document_media
+    - field.storage.node.field_document_type
     - field.storage.node.field_vocab_event_type
+    - field.storage.node.field_body
+    - field.storage.node.field_date_range
+    - field.storage.node.field_discussion_type
+    - field.storage.node.field_location_type
+    - field.storage.node.field_subtitle
+    - field.storage.node.field_vocab_geo
+    - field.storage.node.field_vocab_topics
+    - field.storage.media.oe_media_file
+    - field.storage.node.field_gallery_slides
+    - field.storage.paragraph.field_gallery_slide_media
+    - field.storage.paragraph.field_gallery_slide_legend
     - field.storage.node.field_image
     - field.storage.node.field_introduction
     - field.storage.node.field_language
-    - field.storage.node.field_location_type
-    - field.storage.node.field_vocab_geo
-    - field.storage.node.field_gallery_slides
-    - field.storage.paragraph.field_gallery_slide_legend
-    - field.storage.paragraph.field_gallery_slide_media
-    - field.storage.node.field_date_range
-    - field.storage.node.field_subtitle
-    - field.storage.profile.field_body
+    - field.storage.message.field_referenced_node
+    - field.storage.group.field_funding_source
+    - field.storage.group.field_event_registration_date
+    - field.storage.group.field_image
+    - field.storage.message.field_share_message
+    - field.storage.media.field_media_file
+    - field.storage.group.field_date_range
+    - field.storage.group.field_location
+    - field.storage.group.field_vocab_event_type
+    - field.storage.group.field_body
+    - field.storage.group.field_location_type
+    - field.storage.group.field_organisation_type
+    - field.storage.group.field_vocab_geo
+    - field.storage.group.field_vocab_topics
+    - field.storage.message.field_group_ref
+    - field.storage.group.field_thumbnail
+    - field.storage.message.field_referenced_comment
+    - field.storage.message.field_operation_type
+    - field.storage.group.field_vocab_services_products
+    - field.storage.group.field_vocab_target_markets
+    - field.storage.message.field_source_group
+    - field.storage.message.field_entity_type
     - field.storage.profile.field_location_address
-    - field.storage.profile.field_vocab_job_title
+    - field.storage.profile.field_body
     - field.storage.profile.field_vocab_language
-    - field.storage.profile.field_social_links
-    - field.storage.profile.field_vocab_geo
     - field.storage.profile.field_vocab_topic_expertise
     - field.storage.profile.field_vocab_topic_interest
+    - field.storage.profile.field_vocab_geo
+    - field.storage.profile.field_vocab_job_title
+    - field.storage.profile.field_social_links
     - search_api.server.global
     - core.entity_view_mode.group.no_html
     - core.entity_view_mode.node.no_html
   module:
     - search_api_solr
-    - flag
-    - taxonomy
-    - group
+    - message
     - user
     - file
     - media
-    - content_moderation
-    - message
-    - comment
     - node
-    - eic_private_content
-    - path
+    - taxonomy
     - paragraphs
+    - eic_private_content
+    - content_moderation
+    - flag
+    - group
+    - comment
+    - path
     - profile
     - search_api
     - address
@@ -1692,6 +1692,25 @@ processor_settings:
   solr_date_range:
     weights:
       preprocess_index: 0
+  solr_regex_replace:
+    weights:
+      postprocess_query: 0
+      preprocess_index: -16
+      preprocess_query: -16
+    all_fields: false
+    fields:
+      - aggregated_search_spellcheck
+      - content_field_body_fulltext
+      - content_introduction_string
+      - group_field_body
+      - processed
+    regexes:
+      - '#(src="data:image/[^;]+;base64,.*")#iU'
+      - '#(src=".*image/[^%3B]+%3Bbase64%2C.*")#iU'
+    replacements:
+      - ''
+      - ''
+    preserve_original: false
 tracker_settings:
   default:
     indexing_order: fifo

--- a/config/sync/search_api.index.global.yml
+++ b/config/sync/search_api.index.global.yml
@@ -1705,11 +1705,11 @@ processor_settings:
       - group_field_body
       - processed
     regexes:
-      - '#(src="data:image/[^;]+;base64,.*")#iU'
-      - '#(src=".*image/[^%3B]+%3Bbase64%2C.*")#iU'
+      - '#(src=".*image/[^;"]+;base64,.*")#iU'
+      - '#(src=".*image/[^%3B"]+%3Bbase64%2C.*")#iU'
     replacements:
-      - ''
-      - ''
+      - '""'
+      - '""'
     preserve_original: false
 tracker_settings:
   default:

--- a/lib/modules/eic_search/src/Search/DocumentProcessor/DocumentProcessor.php
+++ b/lib/modules/eic_search/src/Search/DocumentProcessor/DocumentProcessor.php
@@ -90,8 +90,8 @@ abstract class DocumentProcessor implements DocumentProcessorInterface {
    */
   public function sanitizeFulltextString(string $text) {
     // Remove inline image src attribute (base64 encoded).
-    $text = preg_replace('#(src="data:image/[^;]+;base64,.*")#iU', '', $text);
-    $text = preg_replace('#(src=".*image/[^%3B]+%3Bbase64%2C.*")#iU', '', $text);
+    $text = preg_replace('#(src=".*image/[^;"]+;base64,.*")#iU', '', $text);
+    $text = preg_replace('#(src=".*image/[^%3B"]+%3Bbase64%2C.*")#iU', '', $text);
     return $text;
   }
 

--- a/lib/modules/eic_search/src/Search/DocumentProcessor/DocumentProcessor.php
+++ b/lib/modules/eic_search/src/Search/DocumentProcessor/DocumentProcessor.php
@@ -79,4 +79,20 @@ abstract class DocumentProcessor implements DocumentProcessorInterface {
     );
   }
 
+  /**
+   * Sanitizes the given string.
+   *
+   * @param string $text
+   *   The text to be sanitized.
+   *
+   * @return string
+   *   The sanitized string.
+   */
+  public function sanitizeFulltextString(string $text) {
+    // Remove inline image src attribute (base64 encoded).
+    $text = preg_replace('#(src="data:image/[^;]+;base64,.*")#iU', '', $text);
+    $text = preg_replace('#(src=".*image/[^%3B]+%3Bbase64%2C.*")#iU', '', $text);
+    return $text;
+  }
+
 }

--- a/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorDiscussion.php
+++ b/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorDiscussion.php
@@ -100,7 +100,9 @@ class ProcessorDiscussion extends DocumentProcessor {
       file_create_url($author_file->get('uri')->value)
     ) : NULL;
 
-    $document->addField('ss_discussion_last_comment_text', $comment->get('comment_body')->value);
+    // Sanitize text before indexing.
+    $comment_text = $this->sanitizeFulltextString($comment->get('comment_body')->value);
+    $document->addField('ss_discussion_last_comment_text', $comment_text);
     $document->addField('ss_discussion_last_comment_timestamp', $comment->getCreatedTime());
     $document->addField(
       'ss_discussion_last_comment_author',


### PR DESCRIPTION
### Improvements

- Added regexes replacement prior to indexing to strip out `src` attribute for inline images.

### Tests

- [x] Run `drush mim upgrade_d7_node_complete_discussion --idlist=11701:13188:und --update`. Once migrated, this should trigger the item indexing
- [x] Make sure you don't see any Search API related error