### PR TITLE
[EICNET-1173] Do not display the social share button on private contents

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/blocks/block--eic-group-header-block.inc
+++ b/lib/themes/eic_community/includes/preprocess/blocks/block--eic-group-header-block.inc
@@ -7,9 +7,11 @@
 
 use Drupal\Core\Url;
 use Drupal\eic_community\ValueObject\ImageValueObject;
+use Drupal\eic_groups\Constants\GroupVisibilityType;
 use Drupal\eic_groups\GroupsModerationHelper;
 use Drupal\eic_overviews\GlobalOverviewPages;
 use Drupal\eic_search\SearchHelper;
+use Drupal\oec_group_flex\GroupVisibilityRecordInterface;
 
 /**
  * Implements hook_preprocess_eic_group_header_block().
@@ -187,7 +189,6 @@ function eic_community_preprocess_eic_group_header_block(array &$variables) {
   }
 
   $variables['group_values']['flags'] = $flags;
-  $variables['group_values']['social_share'] = _eic_community_get_social_share_block();
   // Prepare group statistics values to send to the template.
   $stats = [];
   foreach ($variables['group_values']['stats'] as $stat_type => $statistic) {
@@ -239,6 +240,11 @@ function eic_community_preprocess_eic_group_header_block(array &$variables) {
         'label' => $visibility,
         'id' => strtolower($visibility),
       ];
+      $visibility = \Drupal::service('oec_group_flex.group_visibility.storage')->load($group->id());
+      if ($visibility instanceof GroupVisibilityRecordInterface
+        && $visibility->getType() === GroupVisibilityType::GROUP_VISIBILITY_PUBLIC) {
+        $variables['group_values']['social_share'] = _eic_community_get_social_share_block();
+      }
       break;
     case 'organisation':
       $types = $group->get('field_organisation_type')->referencedEntities();

--- a/lib/themes/eic_community/includes/preprocess/blocks/block--eic-group-header-block.inc
+++ b/lib/themes/eic_community/includes/preprocess/blocks/block--eic-group-header-block.inc
@@ -137,10 +137,6 @@ function eic_community_preprocess_eic_group_header_block(array &$variables) {
       $icon_name = '';
 
       switch ($action['url']->getRouteName()) {
-        case 'entity.group.request_delete_form':
-          $icon_name = '';
-          break;
-
         case 'entity.group.leave':
           $icon_name = 'leave';
           break;
@@ -240,11 +236,6 @@ function eic_community_preprocess_eic_group_header_block(array &$variables) {
         'label' => $visibility,
         'id' => strtolower($visibility),
       ];
-      $visibility = \Drupal::service('oec_group_flex.group_visibility.storage')->load($group->id());
-      if ($visibility instanceof GroupVisibilityRecordInterface
-        && $visibility->getType() === GroupVisibilityType::GROUP_VISIBILITY_PUBLIC) {
-        $variables['group_values']['social_share'] = _eic_community_get_social_share_block();
-      }
       break;
     case 'organisation':
       $types = $group->get('field_organisation_type')->referencedEntities();
@@ -315,6 +306,15 @@ function eic_community_preprocess_eic_group_header_block(array &$variables) {
       break;
 
   }
+
+  if (in_array($group->bundle(), ['event', 'group'])) {
+    $visibility = \Drupal::service('oec_group_flex.group_visibility.storage')->load($group->id());
+    if ($visibility instanceof GroupVisibilityRecordInterface
+      && $visibility->getType() === GroupVisibilityType::GROUP_VISIBILITY_PUBLIC) {
+      $variables['group_values']['social_share'] = _eic_community_get_social_share_block();
+    }
+  }
+
   // Adds url to navigate back to the list of groups.
   $back_url = GlobalOverviewPages::getGlobalOverviewPageLink(
     $overview_id

--- a/lib/themes/eic_community/includes/preprocess/content/node--discussion.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--discussion.inc
@@ -7,7 +7,9 @@
 
 use Drupal\Component\Utility\Xss;
 use Drupal\Core\Render\Markup;
+use Drupal\eic_groups\Constants\GroupVisibilityType;
 use Drupal\group\Entity\GroupInterface;
+use Drupal\oec_group_flex\GroupVisibilityRecordInterface;
 
 /**
  * Implements hook_preprocess_node() for discussion node.
@@ -75,6 +77,13 @@ function _preprocess_discussion_full(&$variables, $discussion_type, $node) {
       $group,
       $node
     );
+
+    $variables['#cache']['tags'] = array_merge($variables['#cache']['tags'], $group->getCacheTags());
+    $visibility = \Drupal::service('oec_group_flex.group_visibility.storage')->load($group->id());
+    if ($visibility instanceof GroupVisibilityRecordInterface
+      && $visibility->getType() === GroupVisibilityType::GROUP_VISIBILITY_PUBLIC) {
+      $flags['social_share']['content'] = _eic_community_get_social_share_block();
+    }
   }
 
   $variables['flags']['items'] = $flags;

--- a/lib/themes/eic_community/includes/preprocess/content/node--document.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--document.inc
@@ -5,15 +5,17 @@
  * Prepares variables for node document templates.
  */
 
+use Drupal\eic_groups\Constants\GroupVisibilityType;
 use Drupal\eic_media\MediaHelper;
 use Drupal\file\Entity\File;
 use Drupal\group\Entity\GroupInterface;
+use Drupal\oec_group_flex\GroupVisibilityRecordInterface;
 
 /**
  * Implements hook_preprocess_node() for document node.
  */
 function eic_community_preprocess_node__document(array &$variables) {
-  /** @var \Drupal\Core\Entity\EntityInterface $node */
+  /** @var \Drupal\node\NodeInterface $node */
   $node = $variables['node'];
 
   switch ($variables['view_mode']) {
@@ -161,13 +163,19 @@ function eic_community_preprocess_node__document(array &$variables) {
           'content' => $flag,
         ];
       }
-      $variables['editorial_actions']['items'][]['content'] = _eic_community_get_social_share_block();
+
       $group = \Drupal::service('eic_groups.helper')->getGroupFromRoute();
       if ($group instanceof GroupInterface) {
         $variables['editorial_actions']['items'][]['content'] = _eic_community_get_share_group_content_link(
           $group,
           $node
         );
+
+        $visibility = \Drupal::service('oec_group_flex.group_visibility.storage')->load($group->id());
+        if ($visibility instanceof GroupVisibilityRecordInterface
+          && $visibility->getType() === GroupVisibilityType::GROUP_VISIBILITY_PUBLIC) {
+          $variables['editorial_actions']['items'][]['content'] = _eic_community_get_social_share_block();
+        }
       }
       _eic_community_display_topics($variables);
       break;

--- a/lib/themes/eic_community/includes/preprocess/content/node--document.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--document.inc
@@ -171,6 +171,7 @@ function eic_community_preprocess_node__document(array &$variables) {
           $node
         );
 
+        $variables['#cache']['tags'] = array_merge($variables['#cache']['tags'], $group->getCacheTags());
         $visibility = \Drupal::service('oec_group_flex.group_visibility.storage')->load($group->id());
         if ($visibility instanceof GroupVisibilityRecordInterface
           && $visibility->getType() === GroupVisibilityType::GROUP_VISIBILITY_PUBLIC) {

--- a/lib/themes/eic_community/includes/preprocess/content/node--event.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--event.inc
@@ -166,7 +166,7 @@ function eic_community_preprocess_node__event(array &$variables) {
           'name' => 'views',
         ],
         'label' => t('Views'),
-        'value' => $stats_views
+        'value' => $stats_views,
       ];
 
       // Remove unwanted items.

--- a/lib/themes/eic_community/includes/preprocess/content/node--gallery.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--gallery.inc
@@ -6,10 +6,12 @@
  */
 
 use Drupal\eic_community\ValueObject\ImageValueObject;
+use Drupal\eic_groups\Constants\GroupVisibilityType;
 use Drupal\eic_media\MediaHelper;
 use Drupal\file\Entity\File;
 use Drupal\group\Entity\GroupInterface;
 use Drupal\image\Entity\ImageStyle;
+use Drupal\oec_group_flex\GroupVisibilityRecordInterface;
 
 /**
  * Implements hook_preprocess_node__bundle() for gallery node.
@@ -23,13 +25,18 @@ function eic_community_preprocess_node__gallery(array &$variables) {
       _eic_community_display_flags($variables);
       _eic_community_display_topics($variables);
       _eic_community_display_document_contributors($variables);
-      $variables['editorial_actions']['items'][]['content'] = _eic_community_get_social_share_block();
       $group = \Drupal::service('eic_groups.helper')->getGroupFromRoute();
       if ($group instanceof GroupInterface) {
         $variables['editorial_actions']['items'][]['content'] = _eic_community_get_share_group_content_link(
           $group,
           $node
         );
+        
+        $visibility = \Drupal::service('oec_group_flex.group_visibility.storage')->load($group->id());
+        if ($visibility instanceof GroupVisibilityRecordInterface
+          && $visibility->getType() === GroupVisibilityType::GROUP_VISIBILITY_PUBLIC) {
+          $variables['editorial_actions']['items'][]['content'] = _eic_community_get_social_share_block();
+        }
       }
 
       $node = $variables['node'];

--- a/lib/themes/eic_community/includes/preprocess/content/node--gallery.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--gallery.inc
@@ -31,7 +31,8 @@ function eic_community_preprocess_node__gallery(array &$variables) {
           $group,
           $node
         );
-        
+
+        $variables['#cache']['tags'] = array_merge($variables['#cache']['tags'], $group->getCacheTags());
         $visibility = \Drupal::service('oec_group_flex.group_visibility.storage')->load($group->id());
         if ($visibility instanceof GroupVisibilityRecordInterface
           && $visibility->getType() === GroupVisibilityType::GROUP_VISIBILITY_PUBLIC) {

--- a/lib/themes/eic_community/includes/preprocess/content/node--video.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--video.inc
@@ -24,16 +24,16 @@ function eic_community_preprocess_node__video(array &$variables) {
       _eic_community_display_document_contributors($variables);
       $group = \Drupal::service('eic_groups.helper')->getGroupFromRoute();
       if ($group instanceof GroupInterface) {
+        $variables['editorial_actions']['items'][]['content'] = _eic_community_get_share_group_content_link(
+          $group,
+          $node
+        );
+
         $visibility = \Drupal::service('oec_group_flex.group_visibility.storage')->load($group->id());
         if ($visibility instanceof GroupVisibilityRecordInterface
           && $visibility->getType() === GroupVisibilityType::GROUP_VISIBILITY_PUBLIC) {
           $variables['editorial_actions']['items'][]['content'] = _eic_community_get_social_share_block();
         }
-        
-        $variables['editorial_actions']['items'][]['content'] = _eic_community_get_share_group_content_link(
-          $group,
-          $node
-        );
       }
       break;
 

--- a/lib/themes/eic_community/includes/preprocess/content/node--video.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--video.inc
@@ -6,7 +6,9 @@
  */
 
 use Drupal\eic_community\ValueObject\ImageValueObject;
+use Drupal\eic_groups\Constants\GroupVisibilityType;
 use Drupal\group\Entity\GroupInterface;
+use Drupal\oec_group_flex\GroupVisibilityRecordInterface;
 
 /**
  * Implements hook_preprocess_node__bundle() for vide node.
@@ -20,9 +22,14 @@ function eic_community_preprocess_node__video(array &$variables) {
       _eic_community_display_flags($variables);
       _eic_community_display_topics($variables);
       _eic_community_display_document_contributors($variables);
-      $variables['editorial_actions']['items'][]['content'] = _eic_community_get_social_share_block();
       $group = \Drupal::service('eic_groups.helper')->getGroupFromRoute();
       if ($group instanceof GroupInterface) {
+        $visibility = \Drupal::service('oec_group_flex.group_visibility.storage')->load($group->id());
+        if ($visibility instanceof GroupVisibilityRecordInterface
+          && $visibility->getType() === GroupVisibilityType::GROUP_VISIBILITY_PUBLIC) {
+          $variables['editorial_actions']['items'][]['content'] = _eic_community_get_social_share_block();
+        }
+        
         $variables['editorial_actions']['items'][]['content'] = _eic_community_get_share_group_content_link(
           $group,
           $node

--- a/lib/themes/eic_community/includes/preprocess/content/node--video.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--video.inc
@@ -29,6 +29,7 @@ function eic_community_preprocess_node__video(array &$variables) {
           $node
         );
 
+        $variables['#cache']['tags'] = array_merge($variables['#cache']['tags'], $group->getCacheTags());
         $visibility = \Drupal::service('oec_group_flex.group_visibility.storage')->load($group->id());
         if ($visibility instanceof GroupVisibilityRecordInterface
           && $visibility->getType() === GroupVisibilityType::GROUP_VISIBILITY_PUBLIC) {

--- a/lib/themes/eic_community/includes/preprocess/events.inc
+++ b/lib/themes/eic_community/includes/preprocess/events.inc
@@ -40,12 +40,15 @@ function _eic_community_render_event_detail_page(array &$variables, EntityInterf
   _eic_community_display_topics($variables);
   _eic_community_display_flags($variables);
   $group = \Drupal::service('eic_groups.helper')->getGroupFromRoute();
-  if ($group instanceof GroupInterface && 'node' === $entity_type) {
-    $variables['editorial_actions']['items'][]['content'] = _eic_community_get_share_group_content_link(
-      $group,
-      $entity
-    );
+  if ($group instanceof GroupInterface) {
+    if ('node' === $entity_type) {
+      $variables['editorial_actions']['items'][]['content'] = _eic_community_get_share_group_content_link(
+        $group,
+        $entity
+      );
+    }
 
+    $variables['#cache']['tags'] = array_merge($variables['#cache']['tags'], $group->getCacheTags());
     $visibility = \Drupal::service('oec_group_flex.group_visibility.storage')->load($group->id());
     if ($visibility instanceof GroupVisibilityRecordInterface
       && $visibility->getType() === GroupVisibilityType::GROUP_VISIBILITY_PUBLIC) {
@@ -88,7 +91,8 @@ function _eic_community_render_event_detail_page(array &$variables, EntityInterf
   if ('group' === $entity_type && $signup_link = $entity->get('field_link')->getString()) {
     $action = [
       'title' => t('Sign up to this event', [], ['context' => 'eic_community']),
-      'text' => t('Get notified of the latest changes and take part in the discussion linked to this event.', [], ['context' => 'eic_community']),
+      'text' => t('Get notified of the latest changes and take part in the discussion linked to this event.', [],
+        ['context' => 'eic_community']),
       'action' => [
         'label' => t('Sign up now', [], ['context' => 'eic_community']),
         'url' => $signup_link,

--- a/lib/themes/eic_community/includes/preprocess/events.inc
+++ b/lib/themes/eic_community/includes/preprocess/events.inc
@@ -88,8 +88,7 @@ function _eic_community_render_event_detail_page(array &$variables, EntityInterf
   if ('group' === $entity_type && $signup_link = $entity->get('field_link')->getString()) {
     $action = [
       'title' => t('Sign up to this event', [], ['context' => 'eic_community']),
-      'text' => t('Get notified of the latest changes and take part in the discussion linked to this event.', [],
-        ['context' => 'eic_community']),
+      'text' => t('Get notified of the latest changes and take part in the discussion linked to this event.', [], ['context' => 'eic_community']),
       'action' => [
         'label' => t('Sign up now', [], ['context' => 'eic_community']),
         'url' => $signup_link,

--- a/lib/themes/eic_community/includes/preprocess/events.inc
+++ b/lib/themes/eic_community/includes/preprocess/events.inc
@@ -7,10 +7,12 @@
 
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\eic_groups\Constants\GroupVisibilityType;
 use Drupal\eic_groups\EICGroupsHelper;
 use Drupal\eic_media\MediaHelper;
 use Drupal\file\Entity\File;
 use Drupal\group\Entity\GroupInterface;
+use Drupal\oec_group_flex\GroupVisibilityRecordInterface;
 use Drupal\taxonomy\Entity\Term;
 
 /**
@@ -43,6 +45,12 @@ function _eic_community_render_event_detail_page(array &$variables, EntityInterf
       $group,
       $entity
     );
+
+    $visibility = \Drupal::service('oec_group_flex.group_visibility.storage')->load($group->id());
+    if ($visibility instanceof GroupVisibilityRecordInterface
+      && $visibility->getType() === GroupVisibilityType::GROUP_VISIBILITY_PUBLIC) {
+      $variables['editorial_actions']['items'][]['content'] = _eic_community_get_social_share_block();
+    }
   }
 
   if ($entity->bundle() !== 'event') {
@@ -80,7 +88,8 @@ function _eic_community_render_event_detail_page(array &$variables, EntityInterf
   if ('group' === $entity_type && $signup_link = $entity->get('field_link')->getString()) {
     $action = [
       'title' => t('Sign up to this event', [], ['context' => 'eic_community']),
-      'text' => t('Get notified of the latest changes and take part in the discussion linked to this event.', [], ['context' => 'eic_community']),
+      'text' => t('Get notified of the latest changes and take part in the discussion linked to this event.', [],
+        ['context' => 'eic_community']),
       'action' => [
         'label' => t('Sign up now', [], ['context' => 'eic_community']),
         'url' => $signup_link,
@@ -187,14 +196,8 @@ function _eic_community_render_event_detail_page(array &$variables, EntityInterf
 
   $variables['event_infos'] = $event_infos;
 
-  // Provide the Social Share block.
-  if ($share_block = _eic_community_get_social_share_block()) {
-    $variables['editorial_actions']['items'][]['content'] = $share_block;
-  }
-
   $files = $entity->get($fields_map[$entity_type]['documents'])->referencedEntities();
   $files_list = [];
-
   foreach ($files as $file) {
     $download = File::load($file->field_media_file->getValue()[0]['target_id']);
     $download_url = MediaHelper::formatMediaDownloadLink($file)


### PR DESCRIPTION
## To Test

- [x] Create a private group & global event
- [x] Create a content on the group also (discussion, gallery, video)
- [x] Check that social share links are not displayed on the group header but also actions at content level