### PR TITLE
EICNET-284: Make body and language fields optional in media type document

### DIFF
--- a/config/sync/field.field.media.eic_document.field_body.yml
+++ b/config/sync/field.field.media.eic_document.field_body.yml
@@ -13,7 +13,7 @@ entity_type: media
 bundle: eic_document
 label: Body
 description: ''
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/config/sync/field.field.media.eic_document.field_language.yml
+++ b/config/sync/field.field.media.eic_document.field_language.yml
@@ -12,7 +12,7 @@ entity_type: media
 bundle: eic_document
 label: Language
 description: ''
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''


### PR DESCRIPTION
### Changes

- Make body and language fields optional in media type document.

### Test

- [x] Try to create a new document in a group
- [x] Try to upload a new media document for the content and make sure the body and language field are optional