### PR TITLE
EICNET-1316: Node 'Document' migration (Improvements)

### DIFF
--- a/config/sync/core.entity_form_display.node.document.default.yml
+++ b/config/sync/core.entity_form_display.node.document.default.yml
@@ -102,10 +102,22 @@ content:
       media_types: {  }
     third_party_settings: {  }
   field_document_type:
-    type: options_select
+    type: entity_tree
     weight: 8
     region: content
-    settings: {  }
+    settings:
+      match_top_level_limit: '0'
+      items_to_load: '25'
+      selected_terms_label: 'Your selected document types'
+      search_label: 'Select a document type'
+      search_placeholder: Search
+      auto_select_parents: '1'
+      disable_top_choices: 0
+      load_all: 0
+      can_create_tag: 0
+      ignore_current_user: 0
+      target_bundles: {  }
+      is_required: false
     third_party_settings: {  }
   field_image:
     type: media_library_widget
@@ -115,10 +127,22 @@ content:
       media_types: {  }
     third_party_settings: {  }
   field_language:
-    type: options_select
+    type: entity_tree
     weight: 9
     region: content
-    settings: {  }
+    settings:
+      match_top_level_limit: '0'
+      items_to_load: '100'
+      selected_terms_label: 'Your selected languages'
+      search_label: 'Select a language'
+      search_placeholder: Search
+      disable_top_choices: 0
+      load_all: 0
+      can_create_tag: 0
+      auto_select_parents: 0
+      ignore_current_user: 0
+      target_bundles: {  }
+      is_required: false
     third_party_settings: {  }
   field_post_activity:
     weight: 7

--- a/config/sync/field.field.node.document.field_body.yml
+++ b/config/sync/field.field.node.document.field_body.yml
@@ -13,7 +13,7 @@ entity_type: node
 bundle: document
 label: Body
 description: ''
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/config/sync/field.field.node.document.field_language.yml
+++ b/config/sync/field.field.node.document.field_language.yml
@@ -12,7 +12,7 @@ entity_type: node
 bundle: document
 label: Language
 description: ''
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/config/sync/field.storage.node.field_document_type.yml
+++ b/config/sync/field.storage.node.field_document_type.yml
@@ -13,7 +13,7 @@ settings:
   target_type: taxonomy_term
 module: core
 locked: false
-cardinality: 1
+cardinality: -1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/config/sync/field.storage.node.field_language.yml
+++ b/config/sync/field.storage.node.field_language.yml
@@ -13,7 +13,7 @@ settings:
   target_type: taxonomy_term
 module: core
 locked: false
-cardinality: 1
+cardinality: -1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/config/sync/migrate_plus.migration.upgrade_d7_node_with_group_url_alias_to_path_redirect.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_node_with_group_url_alias_to_path_redirect.yml
@@ -1,0 +1,103 @@
+uuid: 5539ac71-8c4f-452c-9c0f-559fd34a5e48
+langcode: en
+status: true
+dependencies: {  }
+id: upgrade_d7_node_with_group_url_alias_to_path_redirect
+class: Drupal\migrate\Plugin\Migration
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags:
+  - 'Drupal 7'
+  - Content
+migration_group: migrate_drupal_7
+label: 'Node Url Alias to Path Redirect'
+source:
+  plugin: eic_d7_url_alias_to_path_redirect
+  track_changes: true
+  constants:
+    entity_type: node
+    group_content_only: true
+  batch_size: 100
+process:
+  uid:
+    -
+      plugin: default_value
+      default_value: 1
+  redirect_source/path:
+    -
+      plugin: get
+      source: source_with_group_prefix
+    -
+      plugin: skip_on_empty
+      method: row
+      message: 'Group prefix could not be found or this is a duplicated item.'
+  redirect_source/query:
+    -
+      plugin: d7_redirect_source_query
+      source: source_options
+  _node_redirect_nid:
+    -
+      plugin: explode
+      source: redirect
+      delimiter: /
+    -
+      plugin: extract
+      index:
+        - 1
+    -
+      plugin: migration_lookup
+      migration:
+        - upgrade_d7_node_complete_article
+        - upgrade_d7_node_complete_discussion
+        - upgrade_d7_node_complete_document
+        - upgrade_d7_node_complete_news
+        - upgrade_d7_node_complete_wiki_page
+        - upgrade_d7_node_complete_event
+        - upgrade_d7_node_complete_photoalbum
+    -
+      plugin: node_complete_node_translation_lookup
+    -
+      plugin: skip_on_empty
+      method: row
+  _node_redirect_uri:
+    -
+      plugin: concat
+      source:
+        - constants/entity_type
+        - '@_node_redirect_nid/0'
+      delimiter: /
+    -
+      plugin: skip_on_empty
+      method: row
+  redirect_redirect/uri:
+    -
+      plugin: d7_path_redirect
+      source:
+        - '@_node_redirect_uri'
+        - redirect_options
+  language:
+    -
+      plugin: static_map
+      source: language
+      bypass: true
+      map:
+        und: en
+    -
+      plugin: default_value
+      default_value: en
+  status_code:
+    -
+      plugin: get
+      source: status_code
+destination:
+  plugin: 'entity:redirect'
+migration_dependencies:
+  required:
+    - upgrade_d7_node_complete_article
+    - upgrade_d7_node_complete_discussion
+    - upgrade_d7_node_complete_document
+    - upgrade_d7_node_complete_news
+    - upgrade_d7_node_complete_wiki_page
+    - upgrade_d7_node_complete_event
+    - upgrade_d7_node_complete_photoalbum
+  optional: {  }

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_with_group_url_alias_to_path_redirect.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_with_group_url_alias_to_path_redirect.yml
@@ -1,0 +1,103 @@
+uuid: 5539ac71-8c4f-452c-9c0f-559fd34a5e48
+langcode: en
+status: true
+dependencies: {  }
+id: upgrade_d7_node_with_group_url_alias_to_path_redirect
+class: Drupal\migrate\Plugin\Migration
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags:
+  - 'Drupal 7'
+  - Content
+migration_group: migrate_drupal_7
+label: 'Node Url Alias to Path Redirect'
+source:
+  plugin: eic_d7_url_alias_to_path_redirect
+  track_changes: true
+  constants:
+    entity_type: node
+    group_content_only: true
+  batch_size: 100
+process:
+  uid:
+    -
+      plugin: default_value
+      default_value: 1
+  redirect_source/path:
+    -
+      plugin: get
+      source: source_with_group_prefix
+    -
+      plugin: skip_on_empty
+      method: row
+      message: 'Group prefix could not be found or this is a duplicated item.'
+  redirect_source/query:
+    -
+      plugin: d7_redirect_source_query
+      source: source_options
+  _node_redirect_nid:
+    -
+      plugin: explode
+      source: redirect
+      delimiter: /
+    -
+      plugin: extract
+      index:
+        - 1
+    -
+      plugin: migration_lookup
+      migration:
+        - upgrade_d7_node_complete_article
+        - upgrade_d7_node_complete_discussion
+        - upgrade_d7_node_complete_document
+        - upgrade_d7_node_complete_news
+        - upgrade_d7_node_complete_wiki_page
+        - upgrade_d7_node_complete_event
+        - upgrade_d7_node_complete_photoalbum
+    -
+      plugin: node_complete_node_translation_lookup
+    -
+      plugin: skip_on_empty
+      method: row
+  _node_redirect_uri:
+    -
+      plugin: concat
+      source:
+        - constants/entity_type
+        - '@_node_redirect_nid/0'
+      delimiter: /
+    -
+      plugin: skip_on_empty
+      method: row
+  redirect_redirect/uri:
+    -
+      plugin: d7_path_redirect
+      source:
+        - '@_node_redirect_uri'
+        - redirect_options
+  language:
+    -
+      plugin: static_map
+      source: language
+      bypass: true
+      map:
+        und: en
+    -
+      plugin: default_value
+      default_value: en
+  status_code:
+    -
+      plugin: get
+      source: status_code
+destination:
+  plugin: 'entity:redirect'
+migration_dependencies:
+  required:
+    - upgrade_d7_node_complete_article
+    - upgrade_d7_node_complete_discussion
+    - upgrade_d7_node_complete_document
+    - upgrade_d7_node_complete_news
+    - upgrade_d7_node_complete_wiki_page
+    - upgrade_d7_node_complete_event
+    - upgrade_d7_node_complete_photoalbum
+  optional: {  }

--- a/lib/modules/eic_migrate/src/Plugin/migrate/source/UrlAliasToPathRedirect.php
+++ b/lib/modules/eic_migrate/src/Plugin/migrate/source/UrlAliasToPathRedirect.php
@@ -2,6 +2,11 @@
 
 namespace Drupal\eic_migrate\Plugin\migrate\source;
 
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\State\StateInterface;
+use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\migrate\Row;
+
 /**
  * Drupal 7 path redirect source from database.
  *
@@ -13,6 +18,29 @@ namespace Drupal\eic_migrate\Plugin\migrate\source;
 class UrlAliasToPathRedirect extends PathRedirect {
 
   /**
+   * TWether or not this migration should only include items with group prefix.
+   *
+   * @var bool
+   */
+  protected $includeGroupPrefix;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    MigrationInterface $migration,
+    StateInterface $state,
+    EntityTypeManagerInterface $entity_type_manager
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $migration, $state, $entity_type_manager);
+
+    $this->includeGroupPrefix = !empty($configuration['constants']['group_content_only']) ?? FALSE;
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function query() {
@@ -21,6 +49,14 @@ class UrlAliasToPathRedirect extends PathRedirect {
     // Only url alias from the configured entity type.
     if (!empty($this->entityType)) {
       $query->condition('ua.source', $this->entityType . '/%', 'LIKE');
+
+      // Include group prefix.
+      if ($this->entityType === 'node' && $this->includeGroupPrefix) {
+        $substr_limit = strlen($this->entityType) + 2;
+        $query->innerJoin('og_membership', 'ogm', "ogm.etid = SUBSTRING(ua.source, {$substr_limit}) AND ogm.entity_type = 'node'");
+        $query->innerJoin('purl', 'p', 'p.id = ogm.gid');
+        $query->addField('p', 'value', 'group_prefix');
+      }
     }
 
     $query->addField('ua', 'pid', 'rid');
@@ -29,6 +65,26 @@ class UrlAliasToPathRedirect extends PathRedirect {
     $query->addField('ua', 'language');
 
     return $query;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function prepareRow(Row $row) {
+    $result = parent::prepareRow($row);
+
+    $group_prefix = $row->getSourceProperty('group_prefix');
+    if (
+      !empty($group_prefix) &&
+      strpos($row->getSourceProperty('group_prefix'), "$group_prefix/") === FALSE
+    ) {
+      $row->setSourceProperty(
+        'source_with_group_prefix',
+        $group_prefix . '/' . $row->getSourceProperty('source')
+      );
+    }
+
+    return $result;
   }
 
 }


### PR DESCRIPTION
### Improvements

- Make body and language fields optional in content type document;
- Make language and document type fields unlimited and use entity tree widget in form display;
- Create migration to import node URL redirects (from URL alias) including group prefix from PURL module.

### Tests

- [x] Run `drush mim upgrade_d7_node_complete_document --update`
- [x] Go to `/organisations/amorph-systems-gmbh/library/press-release-partnership-announcement/edit` and make sure the Document types and Languages are correct. Compare it with D7 -> https://eic.accp.eismea.eu/community7/amorph-systems_93/documents/press-release-partnership-announcement
- [x] Run `drush mim upgrade_d7_node_with_group_url_alias_to_path_redirect --update`
- [x] Check if remaining redirects of group content includes also group prefix from D7 PURL module. In the D9 try to go to `/amorph-systems_93/documents/press-release-partnership-announcement` and make sure you get redirected to `/organisations/amorph-systems-gmbh/library/press-release-partnership-announcement`