### PR TITLE
EICNET-2078: Pass comments body through basic_text filter and make us…

### DIFF
--- a/lib/modules/eic_groups/src/Controller/DiscussionController.php
+++ b/lib/modules/eic_groups/src/Controller/DiscussionController.php
@@ -600,15 +600,15 @@ class DiscussionController extends ControllerBase {
     return [
       'user_image' => $file_url,
       'user_id' => $user->id(),
-      'user_fullname' => $user->get('field_first_name')->value . ' ' . $user->get('field_last_name')->value,
+      'user_fullname' => $user->getDisplayName(),
       'user_url' => $user->toUrl()->toString(),
       'created_timestamp' => $comment->getCreatedTime(),
-      'text' => $comment->get('comment_body')->value,
+      'text' => check_markup($comment->get('comment_body')->value, 'basic_text'),
       'comment_id' => $comment->id(),
       'tagged_users' => array_map(function (UserInterface $user) {
         return [
           'uid' => $user->id(),
-          'name' => realname_load($user),
+          'name' => $user->getDisplayName(),
           'url' => $user->toUrl()->toString(),
         ];
       }, $tagged_users),


### PR DESCRIPTION
### Improvements

- Pass comment body through `basic_text` filter

### Tests

- [x] As TU, create a comment and paste a link and an email address in it (do not use the link button)
- [x] Make sure both the link and the email address are clickable on display