### PR TITLE
EICNET-2031: Group type notification - group invitation (anonymous user notification)

### DIFF
--- a/config/sync/mailsystem.settings.yml
+++ b/config/sync/mailsystem.settings.yml
@@ -1,6 +1,6 @@
 _core:
   default_config_hash: IhwTepsVwtbtbcT5GzQKhCXDCRvbk3MNkWqPiuiZ10s
-theme: current
+theme: eic_community
 defaults:
   sender: SMTPMailSystem
   formatter: mime_mail


### PR DESCRIPTION
### Fixes

- Force using eic_community theme on email templates (ginvite emails were using the admin theme).

### Test

- [x] As SA/SCM, go to a group and try to invite an anonymous user
- [x] Make sure a notification has been sent to the user and it is styled