### PR TITLE
EICNET-2164: Group permission fix

### DIFF
--- a/config/sync/eic_groups.group_features.eic_groups_anchor_group_events.yml
+++ b/config/sync/eic_groups.group_features.eic_groups_anchor_group_events.yml
@@ -10,5 +10,6 @@ roles:
   - group-member
   - group-admin
   - group-owner
+  - organisation-member
   - organisation-admin
   - organisation-owner

--- a/config/sync/eic_groups.group_features.eic_groups_anchor_members.yml
+++ b/config/sync/eic_groups.group_features.eic_groups_anchor_members.yml
@@ -8,5 +8,6 @@ roles:
   - group-member
   - group-admin
   - group-owner
+  - organisation-member
   - organisation-admin
   - organisation-owner

--- a/config/sync/eic_groups.group_features.eic_groups_anchor_news.yml
+++ b/config/sync/eic_groups.group_features.eic_groups_anchor_news.yml
@@ -10,5 +10,6 @@ roles:
   - group-member
   - group-admin
   - group-owner
+  - organisation-member
   - organisation-admin
   - organisation-owner

--- a/lib/modules/eic_webservices/src/Utility/SmedTaxonomyHelper.php
+++ b/lib/modules/eic_webservices/src/Utility/SmedTaxonomyHelper.php
@@ -21,6 +21,7 @@ class SmedTaxonomyHelper {
    */
   protected const SMED_VOCABULARIES = [
     'global_event_type',
+    'target_markets',
     'job_titles',
     'languages',
     'topics',

--- a/lib/modules/oec_group_features/oec_group_features.info.yml
+++ b/lib/modules/oec_group_features/oec_group_features.info.yml
@@ -1,9 +1,10 @@
 name: OEC Group Features
 type: module
-description: The description.
+description: Provides a mechanism to enable custom defined features for groups.
 package: Open Europa Communities
 core: 8.x
 core_version_requirement: ^8 || ^9
 php: 7.3
 dependencies:
   - group:group
+  - group_permissions:group_permissions

--- a/lib/modules/oec_group_features/oec_group_features.services.yml
+++ b/lib/modules/oec_group_features/oec_group_features.services.yml
@@ -4,4 +4,4 @@ services:
     parent: default_plugin_manager
   oec_group_features.helper:
     class: Drupal\oec_group_features\GroupFeatureHelper
-    arguments: ['@config.factory', '@plugin.manager.group_feature']
+    arguments: ['@config.factory', '@plugin.manager.group_feature', '@group_permission.group_permissions_manager']

--- a/lib/modules/oec_group_features/src/Hooks/EntityOperations.php
+++ b/lib/modules/oec_group_features/src/Hooks/EntityOperations.php
@@ -7,7 +7,6 @@ use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Logger\LoggerChannelTrait;
 use Drupal\Core\Routing\RouteMatchInterface;
-use Drupal\Core\Session\AccountSwitcherInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\group\Entity\Group;
 use Drupal\group_permissions\GroupPermissionsManagerInterface;

--- a/lib/modules/oec_group_features/src/Hooks/EntityOperations.php
+++ b/lib/modules/oec_group_features/src/Hooks/EntityOperations.php
@@ -107,14 +107,14 @@ class EntityOperations implements ContainerInjectionInterface {
    *   The group entity being created.
    */
   public function groupInsert(Group $group) {
-    $this->manageFeatures($group);
-
     // Make sure group permission entity is created.
     $groupPermission = $this->groupFeatureHelper->getGroupPermissionObject($group);
     if ($groupPermission->isNew()) {
       $groupPermission->setValidationRequired(FALSE);
       $groupPermission->save();
     }
+
+    $this->manageFeatures($group);
   }
 
   /**


### PR DESCRIPTION
### Improvements

- Create the Group Permission entity when a new group is created through code (fixtures and webservice)

### Tests

- [ ] Run `drush fixtures:reload OrganisationGenerator` (make sure `eic_default_content` module is enabled)
- [ ] Check `group_permission` table to see if entries have created for the generated groups