### PR TITLE
Feature/eicnet 2492 migration sanitise text

### DIFF
--- a/config/sync/migrate_plus.migration.upgrade_d7_node_complete_article.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_node_complete_article.yml
@@ -78,10 +78,19 @@ process:
             source: fid
             migration:
               - upgrade_d7_file_image_to_media
-  field_body:
+  field_body/0/format:
+    -
+      plugin: callback
+      source: c4m_body/0/format
+      callable:
+        - \Drupal\eic_migrate\Constants\Misc
+        - getTextFormat
+  field_body/0/value:
+    -
+      plugin: eic_html_sanitizer
+      source: c4m_body/0/value
     -
       plugin: eic_media_wysiwyg_filter
-      source: c4m_body
       media_migrations:
         - upgrade_d7_file_audio_to_media
         - upgrade_d7_file_document_to_media

--- a/config/sync/migrate_plus.migration.upgrade_d7_node_complete_book.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_node_complete_book.yml
@@ -57,10 +57,19 @@ process:
   revision_timestamp: timestamp
   content_translation_source: source_langcode
   node_comment/0/status: comment
-  field_body:
+  field_body/0/format:
+    -
+      plugin: callback
+      source: c4m_body/0/format
+      callable:
+        - \Drupal\eic_migrate\Constants\Misc
+        - getTextFormat
+  field_body/0/value:
+    -
+      plugin: eic_html_sanitizer
+      source: c4m_body/0/value
     -
       plugin: eic_media_wysiwyg_filter
-      source: c4m_body
       media_migrations:
         - upgrade_d7_file_audio_to_media
         - upgrade_d7_file_document_to_media

--- a/config/sync/migrate_plus.migration.upgrade_d7_node_complete_discussion.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_node_complete_discussion.yml
@@ -61,10 +61,19 @@ process:
   revision_timestamp: timestamp
   content_translation_source: source_langcode
   node_comment/0/status: comment
-  field_body:
+  field_body/0/format:
+    -
+      plugin: callback
+      source: c4m_body/0/format
+      callable:
+        - \Drupal\eic_migrate\Constants\Misc
+        - getTextFormat
+  field_body/0/value:
+    -
+      plugin: eic_html_sanitizer
+      source: c4m_body/0/value
     -
       plugin: eic_media_wysiwyg_filter
-      source: c4m_body
       media_migrations:
         - upgrade_d7_file_audio_to_media
         - upgrade_d7_file_document_to_media

--- a/config/sync/migrate_plus.migration.upgrade_d7_node_complete_document.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_node_complete_document.yml
@@ -61,10 +61,19 @@ process:
   revision_timestamp: timestamp
   content_translation_source: source_langcode
   node_comment/0/status: comment
-  field_body:
+  field_body/0/format:
+    -
+      plugin: callback
+      source: c4m_body/0/format
+      callable:
+        - \Drupal\eic_migrate\Constants\Misc
+        - getTextFormat
+  field_body/0/value:
+    -
+      plugin: eic_html_sanitizer
+      source: c4m_body/0/value
     -
       plugin: eic_media_wysiwyg_filter
-      source: c4m_body
       media_migrations:
         - upgrade_d7_file_audio_to_media
         - upgrade_d7_file_document_to_media

--- a/config/sync/migrate_plus.migration.upgrade_d7_node_complete_event.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_node_complete_event.yml
@@ -73,10 +73,19 @@ process:
       map:
         - draft
         - published
-  field_body:
+  field_body/0/format:
+    -
+      plugin: callback
+      source: c4m_body/0/format
+      callable:
+        - \Drupal\eic_migrate\Constants\Misc
+        - getTextFormat
+  field_body/0/value:
+    -
+      plugin: eic_html_sanitizer
+      source: c4m_body/0/value
     -
       plugin: eic_media_wysiwyg_filter
-      source: c4m_body
       media_migrations:
         - upgrade_d7_file_audio_to_media
         - upgrade_d7_file_document_to_media

--- a/config/sync/migrate_plus.migration.upgrade_d7_node_complete_news.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_node_complete_news.yml
@@ -68,10 +68,19 @@ process:
   revision_timestamp: timestamp
   content_translation_source: source_langcode
   node_comment/0/status: comment
-  field_body:
+  field_body/0/format:
+    -
+      plugin: callback
+      source: c4m_body/0/format
+      callable:
+        - \Drupal\eic_migrate\Constants\Misc
+        - getTextFormat
+  field_body/0/value:
+    -
+      plugin: eic_html_sanitizer
+      source: c4m_body/0/value
     -
       plugin: eic_media_wysiwyg_filter
-      source: c4m_body
       media_migrations:
         - upgrade_d7_file_audio_to_media
         - upgrade_d7_file_document_to_media

--- a/config/sync/migrate_plus.migration.upgrade_d7_node_complete_organisation.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_node_complete_organisation.yml
@@ -96,29 +96,25 @@ process:
       from_format: 'Y-m-d H:i:s'
       to_format: 'Y'
       source: c4m_date_est/0/value
-  field_body:
+  field_body/0/format:
+    -
+      plugin: callback
+      source: field_c4m_about_us/0/format
+      callable:
+        - \Drupal\eic_migrate\Constants\Misc
+        - getTextFormat
+  field_body/0/value:
+    -
+      plugin: eic_html_sanitizer
+      source: field_c4m_about_us/0/value
     -
       plugin: eic_media_wysiwyg_filter
-      source: field_c4m_about_us
       media_migrations:
         - upgrade_d7_file_audio_to_media
         - upgrade_d7_file_document_to_media
         - upgrade_d7_file_image_to_media
         - upgrade_d7_file_undefined_to_media
         - upgrade_d7_file_video_to_media
-        - upgrade_d7_file_youtube_video_to_media
-  field_body/0/format:
-    -
-      plugin: static_map
-      source: field_c4m_about_us/0/format
-      bypass: true
-      map:
-        full_html: full_html
-        filtered_html: filtered_html
-        plain_text: plain_text
-    -
-      plugin: default_value
-      default_value: filtered_html
   field_email: c4m_email
   field_organisation_link: c4m_link
   field_smed_id: c4m_organisation_dashboard_id

--- a/config/sync/migrate_plus.migration.upgrade_d7_node_complete_photoalbum.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_node_complete_photoalbum.yml
@@ -61,10 +61,19 @@ process:
   revision_timestamp: timestamp
   content_translation_source: source_langcode
   node_comment/0/status: comment
-  field_body:
+  field_body/0/format:
+    -
+      plugin: callback
+      source: c4m_body/0/format
+      callable:
+        - \Drupal\eic_migrate\Constants\Misc
+        - getTextFormat
+  field_body/0/value:
+    -
+      plugin: eic_html_sanitizer
+      source: c4m_body/0/value
     -
       plugin: eic_media_wysiwyg_filter
-      source: c4m_body
       media_migrations:
         - upgrade_d7_file_audio_to_media
         - upgrade_d7_file_document_to_media

--- a/config/sync/migrate_plus.migration.upgrade_d7_node_complete_wiki_page.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_node_complete_wiki_page.yml
@@ -69,10 +69,19 @@ process:
   revision_timestamp: timestamp
   content_translation_source: source_langcode
   node_comment/0/status: comment
-  field_body:
+  field_body/0/format:
+    -
+      plugin: callback
+      source: c4m_body/0/format
+      callable:
+        - \Drupal\eic_migrate\Constants\Misc
+        - getTextFormat
+  field_body/0/value:
+    -
+      plugin: eic_html_sanitizer
+      source: c4m_body/0/value
     -
       plugin: eic_media_wysiwyg_filter
-      source: c4m_body
       media_migrations:
         - upgrade_d7_file_audio_to_media
         - upgrade_d7_file_document_to_media

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get -o Acquire::Check-Valid-Until=false -o Acquire::Check-Date=false upd
   && apt-get -y install apt-transport-https apt-utils build-essential xorg \
     libssl-dev libxrender-dev wget gdebi \
     libzip-dev libpng-dev libjpeg-dev libfreetype6-dev \
-    zip unzip libicu-dev g++ git
+    zip unzip libicu-dev g++ git libxml2-dev
 
 # Install extensions
 RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
@@ -24,7 +24,8 @@ RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
   && pecl install -o -f redis \
   && docker-php-ext-enable redis \
   && docker-php-ext-configure intl \
-  && docker-php-ext-install intl
+  && docker-php-ext-install intl \
+  && docker-php-ext-install xml
 
 RUN apt-get update -y; \
     apt-get install mariadb-client -y; \

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_article.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_article.yml
@@ -73,9 +73,16 @@ process:
 #        title: title
 #        width: width
 #        height: height
-  field_body:
+  field_body/0/format:
+    - plugin: callback
+      source: c4m_body/0/format
+      callable:
+        - '\Drupal\eic_migrate\Constants\Misc'
+        - getTextFormat
+  field_body/0/value:
+    - plugin: eic_html_sanitizer
+      source: c4m_body/0/value
     - plugin: eic_media_wysiwyg_filter
-      source: c4m_body
       media_migrations:
         - upgrade_d7_file_audio_to_media
         - upgrade_d7_file_document_to_media

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_book.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_book.yml
@@ -50,9 +50,16 @@ process:
   revision_timestamp: timestamp
   content_translation_source: source_langcode
   node_comment/0/status: comment
-  field_body:
+  field_body/0/format:
+    - plugin: callback
+      source: c4m_body/0/format
+      callable:
+        - '\Drupal\eic_migrate\Constants\Misc'
+        - getTextFormat
+  field_body/0/value:
+    - plugin: eic_html_sanitizer
+      source: c4m_body/0/value
     - plugin: eic_media_wysiwyg_filter
-      source: c4m_body
       media_migrations:
         - upgrade_d7_file_audio_to_media
         - upgrade_d7_file_document_to_media

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_discussion.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_discussion.yml
@@ -54,9 +54,16 @@ process:
   revision_timestamp: timestamp
   content_translation_source: source_langcode
   node_comment/0/status: comment
-  field_body:
+  field_body/0/format:
+    - plugin: callback
+      source: c4m_body/0/format
+      callable:
+        - '\Drupal\eic_migrate\Constants\Misc'
+        - getTextFormat
+  field_body/0/value:
+    - plugin: eic_html_sanitizer
+      source: c4m_body/0/value
     - plugin: eic_media_wysiwyg_filter
-      source: c4m_body
       media_migrations:
         - upgrade_d7_file_audio_to_media
         - upgrade_d7_file_document_to_media

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_document.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_document.yml
@@ -55,9 +55,16 @@ process:
   revision_timestamp: timestamp
   content_translation_source: source_langcode
   node_comment/0/status: comment
-  field_body:
+  field_body/0/format:
+    - plugin: callback
+      source: c4m_body/0/format
+      callable:
+        - '\Drupal\eic_migrate\Constants\Misc'
+        - getTextFormat
+  field_body/0/value:
+    - plugin: eic_html_sanitizer
+      source: c4m_body/0/value
     - plugin: eic_media_wysiwyg_filter
-      source: c4m_body
       media_migrations:
         - upgrade_d7_file_audio_to_media
         - upgrade_d7_file_document_to_media

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_event.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_event.yml
@@ -65,9 +65,16 @@ process:
       map:
         0: draft
         1: published
-  field_body:
+  field_body/0/format:
+    - plugin: callback
+      source: c4m_body/0/format
+      callable:
+        - '\Drupal\eic_migrate\Constants\Misc'
+        - getTextFormat
+  field_body/0/value:
+    - plugin: eic_html_sanitizer
+      source: c4m_body/0/value
     - plugin: eic_media_wysiwyg_filter
-      source: c4m_body
       media_migrations:
         - upgrade_d7_file_audio_to_media
         - upgrade_d7_file_document_to_media

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_news.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_news.yml
@@ -61,9 +61,16 @@ process:
   revision_timestamp: timestamp
   content_translation_source: source_langcode
   node_comment/0/status: comment
-  field_body:
+  field_body/0/format:
+    - plugin: callback
+      source: c4m_body/0/format
+      callable:
+        - '\Drupal\eic_migrate\Constants\Misc'
+        - getTextFormat
+  field_body/0/value:
+    - plugin: eic_html_sanitizer
+      source: c4m_body/0/value
     - plugin: eic_media_wysiwyg_filter
-      source: c4m_body
       media_migrations:
         - upgrade_d7_file_audio_to_media
         - upgrade_d7_file_document_to_media

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_organisation.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_organisation.yml
@@ -83,26 +83,22 @@ process:
       from_format: 'Y-m-d H:i:s'
       to_format: 'Y'
       source: c4m_date_est/0/value
-  field_body:
+  field_body/0/format:
+    - plugin: callback
+      source: field_c4m_about_us/0/format
+      callable:
+        - '\Drupal\eic_migrate\Constants\Misc'
+        - getTextFormat
+  field_body/0/value:
+    - plugin: eic_html_sanitizer
+      source: field_c4m_about_us/0/value
     - plugin: eic_media_wysiwyg_filter
-      source: field_c4m_about_us
       media_migrations:
         - upgrade_d7_file_audio_to_media
         - upgrade_d7_file_document_to_media
         - upgrade_d7_file_image_to_media
         - upgrade_d7_file_undefined_to_media
         - upgrade_d7_file_video_to_media
-        - upgrade_d7_file_youtube_video_to_media
-  field_body/0/format:
-    - plugin: static_map
-      source: field_c4m_about_us/0/format
-      bypass: true
-      map:
-        full_html: full_html
-        filtered_html: filtered_html
-        plain_text: plain_text
-    - plugin: default_value
-      default_value: filtered_html
   field_email: c4m_email
   field_organisation_link: c4m_link
   #field_vocab_services_products:

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_photoalbum.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_photoalbum.yml
@@ -54,9 +54,16 @@ process:
   revision_timestamp: timestamp
   content_translation_source: source_langcode
   node_comment/0/status: comment
-  field_body:
+  field_body/0/format:
+    - plugin: callback
+      source: c4m_body/0/format
+      callable:
+        - '\Drupal\eic_migrate\Constants\Misc'
+        - getTextFormat
+  field_body/0/value:
+    - plugin: eic_html_sanitizer
+      source: c4m_body/0/value
     - plugin: eic_media_wysiwyg_filter
-      source: c4m_body
       media_migrations:
         - upgrade_d7_file_audio_to_media
         - upgrade_d7_file_document_to_media

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_wiki_page.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_wiki_page.yml
@@ -61,9 +61,16 @@ process:
   revision_timestamp: timestamp
   content_translation_source: source_langcode
   node_comment/0/status: comment
-  field_body:
+  field_body/0/format:
+    - plugin: callback
+      source: c4m_body/0/format
+      callable:
+        - '\Drupal\eic_migrate\Constants\Misc'
+        - getTextFormat
+  field_body/0/value:
+    - plugin: eic_html_sanitizer
+      source: c4m_body/0/value
     - plugin: eic_media_wysiwyg_filter
-      source: c4m_body
       media_migrations:
         - upgrade_d7_file_audio_to_media
         - upgrade_d7_file_document_to_media

--- a/lib/modules/eic_migrate/src/Constants/Misc.php
+++ b/lib/modules/eic_migrate/src/Constants/Misc.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\eic_migrate\Constants;
+
+/**
+ * Defines miscellaneous constants.
+ *
+ * @package Drupal\eic_migrate\Constants
+ */
+final class Misc {
+
+  /**
+   * Text format mappings.
+   *
+   * @var string[]
+   */
+  protected const TEXT_FORMAT_MAPPINGS = [
+    'full_html' => 'full_html',
+    'filtered_html' => 'filtered_html',
+    'plain_text' => 'plain_text',
+    'mail' => 'basic_text',
+  ];
+
+  /**
+   * Maps old text formats to new ones.
+   *
+   * @param string $text_format_id
+   *   The old text format.
+   *
+   * @return false|mixed|string
+   *   The new text format or FALSE if not found.
+   */
+  public static function getTextFormat(string $text_format_id) {
+    return self::TEXT_FORMAT_MAPPINGS[$text_format_id] ?? FALSE;
+  }
+
+}

--- a/lib/modules/eic_migrate/src/Plugin/migrate/process/HtmlSanitizer.php
+++ b/lib/modules/eic_migrate/src/Plugin/migrate/process/HtmlSanitizer.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Drupal\eic_migrate\Plugin\migrate\process;
+
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+
+/**
+ * Sanitizes the given html string.
+ *
+ * @endcode
+ * process:
+ *   bar:
+ *     plugin: eic_html_sanitizer
+ * @endcode
+ *
+ * @MigrateProcessPlugin(
+ *   id = "eic_html_sanitizer"
+ * )
+ */
+class HtmlSanitizer extends ProcessPluginBase {
+
+  /**
+   * List of disallowed HTML attributes.
+   *
+   * @var string[]
+   */
+  protected const DISALLOWED_ATTRIBUTES = [
+    'aria-setsize',
+    'data-aria-level',
+    'data-aria-posinset',
+    'data-font',
+    'data-leveltext',
+    'data-listid',
+    'paraeid',
+    'paraid',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    return $this->stripAttributes($value, self::DISALLOWED_ATTRIBUTES);
+  }
+
+  /**
+   * Removes the HTML attributes for the given string.
+   *
+   * @param string $html
+   *   The HTML to sanitize.
+   * @param array $attributes
+   *   Array of attributes to remove.
+   *
+   * @return string
+   *   The sanitized HTML.
+   */
+  public function stripAttributes(string $html, array $attributes) {
+    // Find all nodes that contain the attribute and remove it.
+    $html = '<div>' . $html . '</div>';
+    $dom = new \DOMDocument();
+    $dom->loadHTML('<?xml encoding="utf-8" ?>' . $html, LIBXML_NOERROR);
+    $xPath = new \DOMXPath($dom);
+    foreach ($attributes as $attribute) {
+      $nodes = $xPath->query('//*[@' . $attribute . ']');
+      foreach ($nodes as $node) {
+        $node->removeAttribute($attribute);
+      }
+    }
+    return substr($dom->saveHTML($dom->getElementsByTagName('div')->item(0)), 5, -6);
+  }
+
+}

--- a/lib/modules/eic_migrate/src/Plugin/migrate/process/MediaWysiwygFilter.php
+++ b/lib/modules/eic_migrate/src/Plugin/migrate/process/MediaWysiwygFilter.php
@@ -154,18 +154,6 @@ class MediaWysiwygFilter extends ProcessPluginBase implements ConfigurableInterf
   ];
 
   /**
-   * Text format mappings.
-   *
-   * @var string[]
-   */
-  protected const TEXT_FORMAT_MAPPINGS = [
-    'full_html' => 'full_html',
-    'filtered_html' => 'filtered_html',
-    'plain_text' => 'plain_text',
-    'mail' => 'basic_text',
-  ];
-
-  /**
    * The migration entity.
    *
    * @var \Drupal\migrate\Plugin\MigrationInterface
@@ -280,9 +268,6 @@ class MediaWysiwygFilter extends ProcessPluginBase implements ConfigurableInterf
 
   /**
    * {@inheritdoc}
-   *
-   * @SuppressWarnings(PHPMD.CyclomaticComplexity)
-   * @SuppressWarnings(PHPMD.NPathComplexity)
    */
   public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
     // If Media WYSIWYG wasn't enabled on the source site, we don't have to do
@@ -299,8 +284,6 @@ class MediaWysiwygFilter extends ProcessPluginBase implements ConfigurableInterf
       throw new MigrateException("The embed token's destination filter plugin ID is invalid.");
     }
 
-    // Update format with the one defined in the mappings.
-    $value['format'] = self::TEXT_FORMAT_MAPPINGS[$value['format']];
     $pattern = '/\[\[\s*(?<tag_info>\{.+\})\s*\]\]/sU';
     $decoder = new JsonDecode(TRUE);
     $entity_type_id = explode(':', $this->migration->getDestinationConfiguration()['plugin'])[1];
@@ -310,7 +293,7 @@ class MediaWysiwygFilter extends ProcessPluginBase implements ConfigurableInterf
     }
     $source_identifier = implode(', ', $source_identifier);
 
-    $value['value'] = preg_replace_callback($pattern, function ($matches) use ($decoder, $entity_type_id, $source_identifier) {
+    $value = preg_replace_callback($pattern, function ($matches) use ($decoder, $entity_type_id, $source_identifier) {
       // Replace line breaks with a single space for valid JSON.
       $matches['tag_info'] = preg_replace('/\s+/', ' ', $matches['tag_info']);
 
@@ -373,13 +356,13 @@ class MediaWysiwygFilter extends ProcessPluginBase implements ConfigurableInterf
       catch (\LogicException $e) {
         return $matches[0];
       }
-    }, $value['value']);
+    }, $value);
 
     // Update fid and token in regex /file/{fid}/download?token={token}.
     if ($this->configuration['file_migrations']) {
       $pattern = '#\/file\/([0-9]*)\/download\?token=([a-zA-Z0-9]*)#';
       $replacement_template = '/file/%s/download?token=%s';
-      $value['value'] = preg_replace_callback($pattern, function ($matches) use ($replacement_template) {
+      $value = preg_replace_callback($pattern, function ($matches) use ($replacement_template) {
         $oldId = $matches[1];
         $newId = $this->findDestId($oldId, $this->configuration['file_migrations']);
         $newToken = '';
@@ -396,7 +379,7 @@ class MediaWysiwygFilter extends ProcessPluginBase implements ConfigurableInterf
         }
 
         return sprintf($replacement_template, $newId, $newToken);
-      }, $value['value']);
+      }, $value);
     }
 
     return $value;


### PR DESCRIPTION
### Improvements

- Created `HtmlSanitizer` process plugin
- Created a helper function to map text formats

### Prerequisistes

First you need update the php container:

- `docker compose build php`
- `docker compose up -d`

### Tests

- [x] Run `drush mim upgrade_d7_node_complete_article --idlist=17985:25187:und --update`
- [x] Check `/stories/open-call-reminder-eic-x-cefic-chemistry-4eu-enhanced-cooperation-pitching-front-11-key/edit` and see if the disallowed attributes are gone? You can compare with https://eic.accp.eismea.eu/community7/node/17985/edit
