### PR TITLE
Feature/eicnet 191 global events migration rework

### DIFF
--- a/config/sync/core.entity_form_display.group.event.default.yml
+++ b/config/sync/core.entity_form_display.group.event.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.group.event.field_additional_content
     - field.field.group.event.field_body
     - field.field.group.event.field_date_range
     - field.field.group.event.field_document_additional
@@ -37,6 +38,7 @@ dependencies:
     - field_group
     - link
     - media_library
+    - paragraphs
     - path
     - social_link_field
     - text
@@ -75,6 +77,7 @@ third_party_settings:
         - field_website_url
         - field_social_links
         - field_vocab_language
+        - field_additional_content
       label: Details
       region: content
       parent_name: group_event_details
@@ -178,6 +181,24 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_additional_content:
+    type: paragraphs
+    weight: 30
+    region: content
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: ''
+      features:
+        collapse_edit_all: collapse_edit_all
+        duplicate: duplicate
+    third_party_settings: {  }
   field_body:
     type: text_textarea
     weight: 3
@@ -194,7 +215,7 @@ content:
     third_party_settings: {  }
   field_document_additional:
     type: entity_reference_autocomplete
-    weight: 22
+    weight: 23
     region: content
     settings:
       match_operator: CONTAINS

--- a/config/sync/core.entity_view_display.group.event.default.yml
+++ b/config/sync/core.entity_view_display.group.event.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.group.event.field_additional_content
     - field.field.group.event.field_body
     - field.field.group.event.field_date_range
     - field.field.group.event.field_document_additional
@@ -31,6 +32,7 @@ dependencies:
   module:
     - address
     - datetime_range
+    - entity_reference_revisions
     - link
     - options
     - social_link_field
@@ -44,6 +46,15 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: -20
+    region: content
+  field_additional_content:
+    type: entity_reference_revisions_entity_view
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 35
     region: content
   field_body:
     type: text_default

--- a/config/sync/core.entity_view_display.group.event.small_teaser.yml
+++ b/config/sync/core.entity_view_display.group.event.small_teaser.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.group.small_teaser
+    - field.field.group.event.field_additional_content
     - field.field.group.event.field_body
     - field.field.group.event.field_date_range
     - field.field.group.event.field_document_additional
@@ -264,6 +265,7 @@ content:
 hidden:
   changed: true
   created: true
+  field_additional_content: true
   field_funding_source: true
   langcode: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.group.event.teaser.yml
+++ b/config/sync/core.entity_view_display.group.event.teaser.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.group.teaser
+    - field.field.group.event.field_additional_content
     - field.field.group.event.field_body
     - field.field.group.event.field_date_range
     - field.field.group.event.field_document_additional
@@ -264,6 +265,7 @@ content:
 hidden:
   changed: true
   created: true
+  field_additional_content: true
   field_funding_source: true
   langcode: true
   search_api_excerpt: true

--- a/config/sync/field.field.group.event.field_additional_content.yml
+++ b/config/sync/field.field.group.event.field_additional_content.yml
@@ -1,0 +1,67 @@
+uuid: 45ae0d96-91b3-434b-a2fb-d2cb79a7a33c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.group.field_additional_content
+    - group.type.event
+    - paragraphs.paragraphs_type.full_text_content
+  module:
+    - entity_reference_revisions
+id: group.event.field_additional_content
+field_name: field_additional_content
+entity_type: group
+bundle: event
+label: 'Additional content'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    target_bundles:
+      full_text_content: full_text_content
+    negate: 0
+    target_bundles_drag_drop:
+      announcement:
+        weight: 14
+        enabled: false
+      banner:
+        weight: 15
+        enabled: false
+      contributor:
+        weight: 16
+        enabled: false
+      cta_tile:
+        weight: 17
+        enabled: false
+      full_media_content:
+        weight: 18
+        enabled: false
+      full_text_content:
+        weight: 19
+        enabled: true
+      gallery_slide:
+        weight: 20
+        enabled: false
+      organisation_location:
+        weight: 21
+        enabled: false
+      organisation_member:
+        weight: 22
+        enabled: false
+      organisation_member_external:
+        weight: 23
+        enabled: false
+      quote:
+        weight: 24
+        enabled: false
+      text_and_media_content:
+        weight: 25
+        enabled: false
+      tiles_content:
+        weight: 26
+        enabled: false
+field_type: entity_reference_revisions

--- a/config/sync/field.storage.group.field_additional_content.yml
+++ b/config/sync/field.storage.group.field_additional_content.yml
@@ -1,0 +1,21 @@
+uuid: 4908e80a-f5b6-4b4c-905c-5efe3820e112
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - group
+    - paragraphs
+id: group.field_additional_content
+field_name: field_additional_content
+entity_type: group
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/migrate_plus.migration.upgrade_d7_node_complete_event_site.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_node_complete_event_site.yml
@@ -261,6 +261,61 @@ process:
               - smed_thematics_topics_lvl1
               - smed_thematics_topics_lvl2
               - smed_thematics_topics_lvl3
+  _c4m_left_column:
+    -
+      plugin: sub_process
+      source: c4m_left_column
+      process:
+        target_id: value
+        target_revision_id: revision_id
+  _c4m_right_column:
+    -
+      plugin: sub_process
+      source: c4m_right_column
+      process:
+        target_id: value
+        target_revision_id: revision_id
+  field_additional_content:
+    -
+      plugin: merge
+      source:
+        - '@_c4m_left_column'
+        - '@_c4m_right_column'
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          -
+            plugin: migration_lookup
+            source:
+              - target_id
+              - target_revision_id
+            migration:
+              - upgrade_d7_paragraph_text
+            no_stub: true
+          -
+            plugin: skip_on_empty
+            method: process
+          -
+            plugin: extract
+            index:
+              - '0'
+        target_revision_id:
+          -
+            plugin: migration_lookup
+            source:
+              - target_id
+              - target_revision_id
+            migration:
+              - upgrade_d7_paragraph_text
+            no_stub: true
+          -
+            plugin: skip_on_empty
+            method: process
+          -
+            plugin: extract
+            index:
+              - '1'
   field_link:
     -
       plugin: field_link

--- a/config/sync/migrate_plus.migration.upgrade_d7_paragraph_text.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_paragraph_text.yml
@@ -1,0 +1,30 @@
+uuid: 5aed611a-1ee3-4e03-8612-cd0baeb0fca7
+langcode: en
+status: true
+dependencies: {  }
+id: upgrade_d7_paragraph_text
+class: Drupal\migrate\Plugin\Migration
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags:
+  - 'Drupal 7'
+  - Content
+migration_group: migrate_drupal_7
+label: 'Text paragraphs'
+source:
+  plugin: eic_d7_paragraph_item
+  field_name:
+    - c4m_left_column
+    - c4m_right_column
+  bundle: c4m_paragraph_text
+  track_changes: true
+process:
+  field_title: c4m_heading
+  field_body/value: c4m_intro_text/0/value
+  field_body/format: c4m_intro_text/0/format
+destination:
+  plugin: 'entity_reference_revisions:paragraph'
+  default_bundle: full_text_content
+migration_dependencies:
+  required: {  }
+  optional: {  }

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_event_site.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_event_site.yml
@@ -218,6 +218,51 @@ process:
               - smed_thematics_topics_lvl1
               - smed_thematics_topics_lvl2
               - smed_thematics_topics_lvl3
+  _c4m_left_column:
+    - plugin: sub_process
+      source: c4m_left_column
+      process:
+        target_id: value
+        target_revision_id: revision_id
+  _c4m_right_column:
+    - plugin: sub_process
+      source: c4m_right_column
+      process:
+        target_id: value
+        target_revision_id: revision_id
+  field_additional_content:
+    - plugin: merge
+      source:
+        - '@_c4m_left_column'
+        - '@_c4m_right_column'
+    - plugin: sub_process
+      process:
+        target_id:
+          - plugin: migration_lookup
+            source:
+              - target_id
+              - target_revision_id
+            migration:
+              - upgrade_d7_paragraph_text
+            no_stub: true
+          - plugin: skip_on_empty
+            method: process
+          - plugin: extract
+            index:
+              - '0'
+        target_revision_id:
+          - plugin: migration_lookup
+            source:
+              - target_id
+              - target_revision_id
+            migration:
+              - upgrade_d7_paragraph_text
+            no_stub: true
+          - plugin: skip_on_empty
+            method: process
+          - plugin: extract
+            index:
+              - '1'
   # TODO: Blocked
 #  field_membership_open_request:
 #    - plugin: get

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_paragraph_text.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_paragraph_text.yml
@@ -1,0 +1,36 @@
+langcode: en
+status: true
+dependencies: {  }
+id: upgrade_d7_paragraph_text
+class: Drupal\migrate\Plugin\Migration
+migration_tags:
+  - 'Drupal 7'
+  - Content
+migration_group: migrate_drupal_7
+label: 'Text paragraphs'
+source:
+  plugin: eic_d7_paragraph_item
+  field_name:
+    - c4m_left_column
+    - c4m_right_column
+  bundle: c4m_paragraph_text
+#  ids:
+#    c4m_vocab_geo_tid:
+#      type: integer
+  track_changes: true
+process:
+  # TODO: Perhaps needed for creating the paragraphs with revisions instead of a new paragraph for each revision
+#  entity_id:
+#    - plugin: migration_lookup
+#      source: entity_id
+#      migration:
+#        - upgrade_d7_node_complete_article_internal_contributors_paragraph
+  field_title: c4m_heading
+  field_body/value: c4m_intro_text/0/value
+  field_body/format: c4m_intro_text/0/format
+destination:
+  plugin: 'entity_reference_revisions:paragraph'
+  default_bundle: full_text_content
+migration_dependencies:
+  required: { }
+  optional: { }

--- a/lib/modules/eic_migrate/src/Plugin/migrate/source/Paragraph.php
+++ b/lib/modules/eic_migrate/src/Plugin/migrate/source/Paragraph.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Drupal\eic_migrate\Plugin\migrate\source;
+
+use Drupal\migrate\Row;
+use Drupal\migrate_drupal\Plugin\migrate\source\d7\FieldableEntity;
+
+/**
+ * Paragraphs source plugin.
+ *
+ * Usage:
+ *
+ * @code
+ * source:
+ *   plugin: eic_d7_paragraph_item
+ *   field_name:
+ *     - my_field_name
+ *     - another_field
+ *   bundle: (optional) the paragraph bundle to filter on
+ * @endcode
+ *
+ * @MigrateSource(
+ *   id = "eic_d7_paragraph_item",
+ *   source_module = "paragraphs"
+ * )
+ */
+class Paragraph extends FieldableEntity {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    $field_names = is_array($this->configuration['field_name']) ? $this->configuration['field_name'] : [$this->configuration['field_name']];
+
+    $query = $this->select('paragraphs_item', 'pi')
+      ->fields('pi', [
+        'item_id',
+        'field_name',
+        'revision_id',
+      ]);
+    $query->condition('pi.field_name', $field_names, 'IN');
+
+    if (!empty($this->configuration['bundle'])) {
+      $query->condition('pi.bundle', $this->configuration['bundle']);
+    }
+
+    return $query;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function prepareRow(Row $row) {
+    $pid = $row->getSourceProperty('item_id');
+    $vid = $row->getSourceProperty('revision_id');
+    // Get Field API field values.
+    foreach ($this->getFields('paragraphs_item', $this->configuration['bundle']) as $field_name => $field) {
+      $row->setSourceProperty($field_name, $this->getFieldValues('paragraphs_item', $field_name, $pid, $vid, NULL));
+    }
+
+    return parent::prepareRow($row);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function fields() {
+    $fields = [
+      'item_id' => $this->t('Item ID'),
+      'revision_id' => $this->t('Revision ID'),
+      'field_name' => $this->t('Name of field'),
+    ];
+    return $fields;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getIds() {
+    $ids['item_id']['type'] = 'integer';
+    $ids['item_id']['alias'] = 'pi';
+    $ids['revision_id']['type'] = 'integer';
+    $ids['revision_id']['alias'] = 'pi';
+    return $ids;
+  }
+
+}


### PR DESCRIPTION
### Improvements

- Added a source plugin to migrate paragraph items

### Tests

- [ ] Run `drush mim upgrade_d7_node_complete_event_site --update`
- [ ] Make sure you have the text paragraphs that are migrated

### Remarks

- The text paragraphs are migrated to not lose content, but we do nothing with it for now
- The destination paragraph type deosn't allow formatted text, we'll need to decide what to do with it