### PR TITLE
EICNET-2512: Ignore duplicated entries when migrating path redirects from URL alias

### DIFF
--- a/config/sync/migrate_plus.migration.upgrade_d7_node_with_group_url_alias_to_path_redirect.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_node_with_group_url_alias_to_path_redirect.yml
@@ -10,7 +10,7 @@ migration_tags:
   - 'Drupal 7'
   - Content
 migration_group: migrate_drupal_7
-label: 'Node Url Alias to Path Redirect'
+label: 'Node Url Alias to Path Redirect (including group prefix)'
 source:
   plugin: eic_d7_url_alias_to_path_redirect
   track_changes: true
@@ -89,6 +89,13 @@ process:
     -
       plugin: get
       source: status_code
+  _redirect_exists:
+    - plugin: eic_d7_duplicated_redirect
+      source: source_with_group_prefix
+    - plugin: skip_on_value
+      value: true
+      method: row
+      message: 'Duplicated redirect entry.'
 destination:
   plugin: 'entity:redirect'
 migration_dependencies:

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_with_group_url_alias_to_path_redirect.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_with_group_url_alias_to_path_redirect.yml
@@ -10,7 +10,7 @@ migration_tags:
   - 'Drupal 7'
   - Content
 migration_group: migrate_drupal_7
-label: 'Node Url Alias to Path Redirect'
+label: 'Node Url Alias to Path Redirect (including group prefix)'
 source:
   plugin: eic_d7_url_alias_to_path_redirect
   track_changes: true
@@ -89,6 +89,13 @@ process:
     -
       plugin: get
       source: status_code
+  _redirect_exists:
+    - plugin: eic_d7_duplicated_redirect
+      source: source_with_group_prefix
+    - plugin: skip_on_value
+      value: true
+      method: row
+      message: 'Duplicated redirect entry.'
 destination:
   plugin: 'entity:redirect'
 migration_dependencies:

--- a/lib/modules/eic_migrate/src/Plugin/migrate/process/DuplicatedRedirect.php
+++ b/lib/modules/eic_migrate/src/Plugin/migrate/process/DuplicatedRedirect.php
@@ -74,7 +74,7 @@ class DuplicatedRedirect extends ProcessPluginBase implements ContainerFactoryPl
     }
 
     $ids = $this->entityTypeManager->getStorage('redirect')->getQuery()
-      ->condition('redirect_source.path', $value, 'LIKE')
+      ->condition('redirect_source.path', $value)
       ->execute();
 
     return !empty($ids);

--- a/lib/modules/eic_migrate/src/Plugin/migrate/process/DuplicatedRedirect.php
+++ b/lib/modules/eic_migrate/src/Plugin/migrate/process/DuplicatedRedirect.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Drupal\eic_migrate\Plugin\migrate\process;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides an eic_d7_duplicated_redirect plugin.
+ *
+ * This module helps to check if a redirect already exists.
+ *
+ * Usage:
+ *
+ * @code
+ * process:
+ *   bar:
+ *     plugin: eic_d7_duplicated_redirect
+ *     source: source
+ * @endcode
+ *
+ * @MigrateProcessPlugin(
+ *   id = "eic_d7_duplicated_redirect"
+ * )
+ */
+class DuplicatedRedirect extends ProcessPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    array $plugin_definition,
+    EntityTypeManagerInterface $entity_type_manager
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    if (empty($value)) {
+      return FALSE;
+    }
+
+    if (!is_string($value)) {
+      return FALSE;
+    }
+
+    $ids = $this->entityTypeManager->getStorage('redirect')->getQuery()
+      ->condition('redirect_source.path', $value, 'LIKE')
+      ->execute();
+
+    return !empty($ids);
+  }
+
+}


### PR DESCRIPTION
### Improvements

- Fix URL redirect migration in order to skip duplicated rows instead of throwing an error.
- Create new processor plugin to search for duplicated redirects.

### Test

- [x] Run drush mim upgrade_d7_node_with_group_url_alias_to_path_redirect --update
- [x] Check if remaining redirects of group content includes also group prefix from D7 PURL module. In the D9 try to go to `/amorph-systems_93/documents/press-release-partnership-announcement` and make sure you get redirected to `/organisations/amorph-systems-gmbh/library/press-release-partnership-announcement`