### PR TITLE
EICNET-1321: Node 'Wiki page' migration (improvements phase 3)

### DIFF
--- a/config/sync/context.context.group_wiki_page.yml
+++ b/config/sync/context.context.group_wiki_page.yml
@@ -50,6 +50,21 @@ reactions:
         context_id: group_wiki_page
         context_mapping: {  }
         block_mode: null
+      aeb58613-6ab3-4d25-9c7f-c227ed46f54f:
+        uuid: aeb58613-6ab3-4d25-9c7f-c227ed46f54f
+        id: eic_groups_comments_from_discussion
+        label: 'EIC comments from discussion'
+        provider: eic_groups
+        label_display: '0'
+        region: content
+        weight: '0'
+        custom_id: eic_groups_comments_from_discussion
+        theme: eic_community
+        css_class: ''
+        unique: 0
+        context_id: group_wiki_page
+        context_mapping: {  }
+        third_party_settings: {  }
     include_default_blocks: 0
     saved: false
 weight: 0

--- a/config/sync/core.entity_form_display.node.wiki_page.default.yml
+++ b/config/sync/core.entity_form_display.node.wiki_page.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.wiki_page.field_body
+    - field.field.node.wiki_page.field_comments
     - field.field.node.wiki_page.field_language
     - field.field.node.wiki_page.field_related_downloads
     - field.field.node.wiki_page.field_related_media
@@ -13,6 +14,7 @@ dependencies:
     - node.type.wiki_page
     - workflows.workflow.default
   module:
+    - comment
     - content_moderation
     - eic_content
     - field_group
@@ -78,6 +80,7 @@ third_party_settings:
       children:
         - private
         - member_content_edit_access
+        - field_comments
       label: Settings
       region: content
       parent_name: group_wiki_page_details
@@ -108,6 +111,12 @@ content:
     settings:
       rows: 5
       placeholder: ''
+    third_party_settings: {  }
+  field_comments:
+    type: comment_default
+    weight: 3
+    region: content
+    settings: {  }
     third_party_settings: {  }
   field_language:
     type: options_select

--- a/config/sync/core.entity_view_display.node.wiki_page.default.yml
+++ b/config/sync/core.entity_view_display.node.wiki_page.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.wiki_page.field_body
+    - field.field.node.wiki_page.field_comments
     - field.field.node.wiki_page.field_language
     - field.field.node.wiki_page.field_related_downloads
     - field.field.node.wiki_page.field_related_media
@@ -22,14 +23,14 @@ content:
   content_moderation_control:
     settings: {  }
     third_party_settings: {  }
-    weight: -20
+    weight: 0
     region: content
   field_body:
     type: text_default
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 2
+    weight: 4
     region: content
   field_language:
     type: entity_reference_label
@@ -37,7 +38,7 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 12
+    weight: 9
     region: content
   field_related_downloads:
     type: entity_reference_entity_view
@@ -46,7 +47,7 @@ content:
       view_mode: download
       link: false
     third_party_settings: {  }
-    weight: 4
+    weight: 6
     region: content
   field_related_media:
     type: entity_reference_entity_view
@@ -55,7 +56,7 @@ content:
       view_mode: oe_theme_main_content
       link: false
     third_party_settings: {  }
-    weight: 3
+    weight: 5
     region: content
   field_tags:
     type: entity_reference_label
@@ -63,17 +64,17 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 11
+    weight: 8
     region: content
   flag_follow_content:
     settings: {  }
     third_party_settings: {  }
-    weight: 10
+    weight: 7
     region: content
   links:
     settings: {  }
     third_party_settings: {  }
-    weight: 0
+    weight: 1
     region: content
   member_content_edit_access:
     type: boolean
@@ -83,7 +84,7 @@ content:
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
-    weight: 1
+    weight: 2
     region: content
   private:
     type: boolean
@@ -93,10 +94,11 @@ content:
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
-    weight: 1
+    weight: 3
     region: content
 hidden:
   extra_field_eic_theme_helper_short_title_with_fallback: true
+  field_comments: true
   field_vocab_geo: true
   field_vocab_topics: true
   langcode: true

--- a/config/sync/core.entity_view_display.node.wiki_page.teaser.yml
+++ b/config/sync/core.entity_view_display.node.wiki_page.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.wiki_page.field_body
+    - field.field.node.wiki_page.field_comments
     - field.field.node.wiki_page.field_language
     - field.field.node.wiki_page.field_related_downloads
     - field.field.node.wiki_page.field_related_media
@@ -57,6 +58,7 @@ content:
 hidden:
   extra_field_eic_theme_helper_short_title_with_fallback: true
   field_body: true
+  field_comments: true
   field_language: true
   field_related_downloads: true
   field_related_media: true

--- a/config/sync/field.field.node.wiki_page.field_comments.yml
+++ b/config/sync/field.field.node.wiki_page.field_comments.yml
@@ -1,0 +1,33 @@
+uuid: b18fb5e9-79d9-49b5-aebf-d0c24c1faa61
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_comments
+    - node.type.wiki_page
+  module:
+    - comment
+id: node.wiki_page.field_comments
+field_name: field_comments
+entity_type: node
+bundle: wiki_page
+label: Comments
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    status: 2
+    cid: 0
+    last_comment_timestamp: 0
+    last_comment_name: null
+    last_comment_uid: 0
+    comment_count: 0
+default_value_callback: ''
+settings:
+  default_mode: 1
+  per_page: 50
+  anonymous: 0
+  form_location: true
+  preview: 0
+field_type: comment

--- a/config/sync/migrate_plus.migration.upgrade_d7_node_complete_event_site.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_node_complete_event_site.yml
@@ -270,10 +270,6 @@ process:
   field_smed_id: c4m_event_dashboard_id
   field_message_to_site_admin: field_message_to_site_admin
   field_tag_line: c4m_project_tag_line
-  features:
-    -
-      plugin: eic_group_features
-      group_bundle: event
 destination:
   plugin: 'entity_complete:group'
   default_bundle: event

--- a/config/sync/migrate_plus.migration.upgrade_d7_node_complete_group.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_node_complete_group.yml
@@ -121,10 +121,6 @@ process:
               - smed_thematics_topics_lvl2
               - smed_thematics_topics_lvl3
   field_message_to_site_admin: field_message_to_site_admin
-  features:
-    -
-      plugin: eic_group_features
-      group_bundle: group
 destination:
   plugin: 'entity_complete:group'
   default_bundle: group

--- a/config/sync/migrate_plus.migration.upgrade_d7_node_complete_organisation.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_node_complete_organisation.yml
@@ -68,10 +68,6 @@ process:
         - upgrade_d7_user
   revision_log_message: log
   revision_created: revision_timestamp
-  features:
-    -
-      plugin: eic_group_features
-      group_bundle: organisation
   field_address:
     -
       plugin: addressfield

--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -88,6 +88,7 @@ function eic_groups_theme($existing, $type, $theme, $path) {
         'is_anonymous' => TRUE,
         'can_view_comments' => FALSE,
         'highlighted_comment' => 0,
+        'no_container' => FALSE,
         'ckeditor_js_settings' => [],
       ],
     ],

--- a/lib/modules/eic_groups/src/Plugin/Block/CommentsFromDiscussionBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/CommentsFromDiscussionBlock.php
@@ -243,8 +243,9 @@ class CommentsFromDiscussionBlock extends BlockBase implements ContainerFactoryP
       $account->getRoles(TRUE)
     );
 
-    $contributors_data = [];;
-    if ($node->bundle() !== 'news') {
+    $disable_contributor_nodes = ['news', 'wiki_page'];
+    $contributors_data = [];
+    if (!in_array($node->bundle(), $disable_contributor_nodes)) {
       $contributors_data = $this->getContributors($node);
     }
 
@@ -424,6 +425,7 @@ class CommentsFromDiscussionBlock extends BlockBase implements ContainerFactoryP
       $cache_tags = array_merge($cache_tags, $group->getCacheTags());
     }
 
+    $no_container_nodes = ['wiki_page'];
     return $build + [
         '#cache' => [
           'contexts' => $cache_context,
@@ -437,6 +439,7 @@ class CommentsFromDiscussionBlock extends BlockBase implements ContainerFactoryP
         '#contributors' => $contributors_data,
         '#is_anonymous' => $current_user->isAnonymous(),
         '#can_view_comments' => $can_view_comments,
+        '#no_container' => in_array($node->bundle(), $no_container_nodes) ? TRUE : FALSE,
         '#ckeditor_js_settings' => $ckeditor_js_settings,
       ];
   }

--- a/lib/modules/eic_groups/templates/eic-group-comments-from-discussion.html.twig
+++ b/lib/modules/eic_groups/templates/eic-group-comments-from-discussion.html.twig
@@ -2,23 +2,25 @@
 
 {% if not is_anonymous and can_view_comments %}
   <div class="ecl-section-wrapper ecl-comment-overview">
-    <div class="ecl-container">
+    <div class="{{ no_container ? "" : "ecl-container" }}">
       <div class="ecl-editorial-article ecl-editorial-article--has-static-layout">
-        <div class="ecl-container">
+        <div class="class="{{ no_container ? "" : "ecl-container" }}"">
           <div class="ecl-editorial-article__wrapper">
             <div class="ecl-editorial-article__content">
               <div id="comments-discussion" data-ckeditor-settings="{{ ckeditor_js_settings | json_encode }}" data-highlighted-comment="{{ highlighted_comment}}" data-discussion-id="{{ discussion_id }}">{{ 'Comments' | t }}</div>
             </div>
-            <aside class="ecl-editorial-article__aside">
-              <div class="ecl-editorial-article__aside-wrapper">
-                {% block sidebar %}
-                  {% include "@theme/patterns/compositions/featured-contributors.html.twig" with contributors|default({})|merge({
-                    grid: true,
-                    title: "Contributors"|t
-                  }) only %}
-                {% endblock %}
-              </div>
-            </aside>
+            {% if contributors %}
+              <aside class="ecl-editorial-article__aside">
+                <div class="ecl-editorial-article__aside-wrapper">
+                  {% block sidebar %}
+                    {% include "@theme/patterns/compositions/featured-contributors.html.twig" with contributors|default({})|merge({
+                      grid: true,
+                      title: "Contributors"|t
+                    }) only %}
+                  {% endblock %}
+                </div>
+              </aside>
+            {% endif %}
           </div>
         </div>
       </div>

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_book.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_book.yml
@@ -49,4 +49,5 @@ migration_dependencies:
     - upgrade_d7_node_complete_book
     - upgrade_d7_node_complete_wiki_page
     - upgrade_d7_node_complete_group
+    - upgrade_d7_node_complete_event_site
   optional: {  }

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_event_site.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_event_site.yml
@@ -230,9 +230,9 @@ process:
   field_smed_id: c4m_event_dashboard_id
   field_message_to_site_admin: field_message_to_site_admin
   field_tag_line: c4m_project_tag_line
-  features:
-    - plugin: eic_group_features
-      group_bundle: event
+  # features:
+  #   - plugin: eic_group_features
+  #     group_bundle: event
 # No source for following fields.
 #  field_documents:
 #  field_event_registration_date:

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_group.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_group.yml
@@ -130,9 +130,9 @@ process:
               - smed_thematics_topics_lvl2
               - smed_thematics_topics_lvl3
   field_message_to_site_admin: field_message_to_site_admin
-  features:
-    - plugin: eic_group_features
-      group_bundle: group
+  # features:
+  #   - plugin: eic_group_features
+  #     group_bundle: group
   # TODO
 #  group_group:
 #    - plugin: get

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_organisation.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_organisation.yml
@@ -61,9 +61,9 @@ process:
         - upgrade_d7_user
   revision_log_message: log
   revision_created: revision_timestamp
-  features:
-    - plugin: eic_group_features
-      group_bundle: organisation
+  # features:
+  #   - plugin: eic_group_features
+  #     group_bundle: organisation
   field_address:
     - plugin: addressfield
       source: c4m_location_address

--- a/lib/modules/eic_migrate/eic_migrate.services.yml
+++ b/lib/modules/eic_migrate/eic_migrate.services.yml
@@ -1,7 +1,7 @@
 services:
   eic_migrate.post_migration_subscriber:
     class: '\Drupal\eic_migrate\EventSubscriber\PostMigrationSubscriber'
-    arguments: ['@migrate.lookup', '@entity_type.manager', '@group_flex.group_saver']
+    arguments: ['@migrate.lookup', '@entity_type.manager', '@group_flex.group_saver', '@oec_group_features.helper']
     tags:
       - { name: 'event_subscriber' }
   eic_migrate.og_membership_subscriber:

--- a/lib/modules/eic_migrate/eic_migrate.services.yml
+++ b/lib/modules/eic_migrate/eic_migrate.services.yml
@@ -1,7 +1,7 @@
 services:
   eic_migrate.post_migration_subscriber:
     class: '\Drupal\eic_migrate\EventSubscriber\PostMigrationSubscriber'
-    arguments: ['@migrate.lookup', '@entity_type.manager', '@group_flex.group_saver', '@oec_group_features.helper']
+    arguments: ['@migrate.lookup', '@entity_type.manager', '@group_flex.group_saver', '@?oec_group_features.helper']
     tags:
       - { name: 'event_subscriber' }
   eic_migrate.og_membership_subscriber:

--- a/lib/modules/eic_migrate/src/EventSubscriber/PostMigrationSubscriber.php
+++ b/lib/modules/eic_migrate/src/EventSubscriber/PostMigrationSubscriber.php
@@ -16,6 +16,7 @@ use Drupal\migrate\Event\MigrateEvents;
 use Drupal\migrate\Event\MigrateImportEvent;
 use Drupal\migrate\Event\MigratePostRowSaveEvent;
 use Drupal\migrate\MigrateLookup;
+use Drupal\oec_group_features\GroupFeatureHelper;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -26,6 +27,47 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class PostMigrationSubscriber implements EventSubscriberInterface {
 
   use StringTranslationTrait;
+
+  /**
+   * Maps the old group features names to the new ones.
+   *
+   * @var array
+   */
+  const GROUP_FEATURES_MAPPING = [
+    'event' => [
+      'c4m_features_og_documents' => 'eic_groups_files',
+      'c4m_features_og_highlights' => NULL,
+      'c4m_features_og_media' => 'eic_groups_files',
+      'c4m_features_og_members' => 'eic_groups_members',
+      'c4m_features_og_news' => 'eic_groups_news',
+      'c4m_features_og_wiki' => 'eic_groups_wiki',
+    ],
+    'group' => [
+      'c4m_features_og_discussions' => 'eic_groups_discussions',
+      'c4m_features_og_documents' => 'eic_groups_files',
+      'c4m_features_og_events' => 'eic_groups_group_events',
+      'c4m_features_og_highlights' => NULL,
+      'c4m_features_og_media' => 'eic_groups_files',
+      'c4m_features_og_members' => 'eic_groups_members',
+      'c4m_features_og_news' => 'eic_groups_news',
+      'c4m_features_og_wiki' => 'eic_groups_wiki',
+    ],
+    'organisation' => [
+      'c4m_features_og_events' => 'eic_groups_anchor_group_events',
+      'c4m_features_og_media' => NULL,
+      'c4m_features_og_members' => 'eic_groups_anchor_members',
+      'c4m_features_og_news' => 'eic_groups_anchor_news',
+    ],
+  ];
+
+  /**
+   * Group features that we enable by default.
+   *
+   * @var array
+   */
+  const GROUP_FEATURES_ENABLED_BY_DEFAULT = [
+    'eic_groups_latest_activity_stream',
+  ];
 
   /**
    * The database connection to the migrate DB.
@@ -56,6 +98,13 @@ class PostMigrationSubscriber implements EventSubscriberInterface {
   protected $groupFlexGroupSaver;
 
   /**
+   * The OEC Group feature helper.
+   *
+   * @var \Drupal\oec_group_features\GroupFeatureHelper
+   */
+  protected $groupFeatureHelper;
+
+  /**
    * Constructs a new MessageCreatorBase object.
    *
    * @param \Drupal\migrate\MigrateLookup $migrate_lookup
@@ -64,11 +113,14 @@ class PostMigrationSubscriber implements EventSubscriberInterface {
    *   The entity type manager.
    * @param \Drupal\group_flex\GroupFlexGroupSaver $group_flex_group_saver
    *   The Group Flex Group saver service.
+   * @param \Drupal\oec_group_features\GroupFeatureHelper $group_feature_helper
+   *   The entity storage.
    */
   public function __construct(
     MigrateLookup $migrate_lookup,
     EntityTypeManagerInterface $entity_type_manager,
-    GroupFlexGroupSaver $group_flex_group_saver
+    GroupFlexGroupSaver $group_flex_group_saver,
+    GroupFeatureHelper $group_feature_helper
   ) {
     $connection = Database::getConnection('default', 'migrate');
 
@@ -76,6 +128,7 @@ class PostMigrationSubscriber implements EventSubscriberInterface {
     $this->migrateLookup = $migrate_lookup;
     $this->entityTypeManager = $entity_type_manager;
     $this->groupFlexGroupSaver = $group_flex_group_saver;
+    $this->groupFeatureHelper = $group_feature_helper;
   }
 
   /**
@@ -124,6 +177,7 @@ class PostMigrationSubscriber implements EventSubscriberInterface {
         if ($group = $this->entityTypeManager->getStorage('group')->load($gid)) {
           $this->setGroupVisibility($group, $event);
           $this->setGroupJoiningMethod($group, $event);
+          $this->setGroupFeatures($group, $event);
         }
         break;
 
@@ -225,6 +279,93 @@ class PostMigrationSubscriber implements EventSubscriberInterface {
         break;
     }
 
+  }
+
+  /**
+   * Sets the group features after row has been saved.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The migrated group entity.
+   * @param \Drupal\migrate\Event\MigratePostRowSaveEvent $event
+   *   The post row save event object.
+   */
+  protected function setGroupFeatures(GroupInterface $group, MigratePostRowSaveEvent $event) {
+    /** @var \Drupal\migrate\Row $row */
+    $row = $event->getRow();
+
+    $group_bundle = $group->bundle();
+
+    $nid = $row->getSourceIdValues()['nid'];
+
+    $enabled_features = [];
+
+    $migrate_connection = Database::getConnection('default', 'migrate');
+    // Get the group features.
+    $d7_query = $migrate_connection->select('variable_store', 'vs');
+    $d7_query->fields('vs', ['value']);
+    $d7_query->condition('vs.realm', 'og');
+    $d7_query->condition('vs.realm_key', "node_$nid");
+    $d7_query->condition('vs.name', 'c4m_og_features_group');
+
+    $results = $d7_query->execute()->fetchAll(\PDO::FETCH_ASSOC);
+    if (count($results)) {
+      $record = reset($results);
+      $features = unserialize($record['value']);
+
+      // Add features that are enabled in the D7.
+      foreach ($features as $old_feature_name => $enabled) {
+        if ($enabled === $old_feature_name) {
+          $enabled_features[] = self::GROUP_FEATURES_MAPPING[$group_bundle][$old_feature_name];
+        }
+      }
+    }
+    else {
+      // If there is no record this means that all features are enabled by
+      // default.
+      $enabled_features = array_merge($enabled_features, array_values(self::GROUP_FEATURES_MAPPING[$group_bundle]));
+    }
+
+    // Filter out feature that are not available for this group type.
+    $group_type_allowed_features = array_keys($this->groupFeatureHelper->getGroupTypeAvailableFeatures(
+      $group_bundle)
+    );
+    foreach ($enabled_features as $index => $enabled_feature) {
+      if (!in_array($enabled_feature, $group_type_allowed_features)) {
+        unset($enabled_features[$index]);
+      }
+    }
+
+    // This will be the final features that will be enabled.
+    $final_enabled_features = array_merge($enabled_features, self::GROUP_FEATURES_ENABLED_BY_DEFAULT);
+
+    $is_all_features_enabled = TRUE;
+    $current_features = $group->get(GroupFeatureHelper::FEATURES_FIELD_NAME)->getValue();
+    if (!empty($current_features)) {
+      foreach ($current_features as $feature) {
+        if (!in_array($feature['value'], $final_enabled_features)) {
+          $is_all_features_enabled = FALSE;
+          break;
+        }
+      }
+    }
+
+    // If we are updating a group, we need to clear the group features before
+    // we save it again. We need this since there is logic to prevent updating
+    // group features if the enabled features didn't change.
+    if ($is_all_features_enabled) {
+      $group->set(
+        GroupFeatureHelper::FEATURES_FIELD_NAME,
+        []
+      );
+      $group->save();
+    }
+
+    // Updates group features that should be enabled by default.
+    $group->set(
+      GroupFeatureHelper::FEATURES_FIELD_NAME,
+      array_merge($enabled_features, self::GROUP_FEATURES_ENABLED_BY_DEFAULT)
+    );
+    $group->save();
   }
 
   /**

--- a/lib/modules/eic_migrate/src/Plugin/migrate/source/Book.php
+++ b/lib/modules/eic_migrate/src/Plugin/migrate/source/Book.php
@@ -158,7 +158,7 @@ class Book extends BookBase {
     $migrate_connection = Database::getConnection('default', 'default');
 
     $query = $migrate_connection->select('group_content_field_data', 'gp');
-    $query->condition('gp.type', 'group-group_node-book');
+    $query->condition('gp.type', '%group_node-book', 'LIKE');
     $query->condition('gp.gid', $group_id);
     $query->join('book', 'b', 'gp.entity_id = b.nid');
     $query->fields('b', ['bid', 'nid']);


### PR DESCRIPTION
### Improvements

- Create field comments in wiki pages.
- Fix migration of group features.
- Fix book migration source plugin so that it grabs group book pages for all group types.

### Todo FE

- [x] We need to remove the contributors from the wiki page comments.

### Test

Migration of groups:

- [x] Run `drush mim upgrade_d7_node_complete_group --update`
- [x] Go to `/groups/pitching-investors/wiki/scaleup-eu-eic-platform-matchmaking-investors` and make sure the Wiki link is visible in the group navigation.

Migration of books:

- ~Run `drush mim upgrade_d7_book --update`~
- ~Make sure wiki pages in global events have the book outline correctly migrated~

Wiki page comments:

- [x] Edit a wiki page and enable comments
- [x] Go to the wiki detail page and make sure the comments are visible at the bottom of the page