### PR TITLE
EICNET-1313: Node 'Photo' migration (improvements phase 3)

### DIFF
--- a/config/sync/migrate_plus.migration.upgrade_d7_node_complete_photoalbum.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_node_complete_photoalbum.yml
@@ -63,15 +63,21 @@ process:
   node_comment/0/status: comment
   field_body/0/format:
     -
-      plugin: callback
+      plugin: default_value
       source: c4m_body/0/format
+      default_value: filtered_html
+    -
+      plugin: callback
       callable:
         - \Drupal\eic_migrate\Constants\Misc
         - getTextFormat
   field_body/0/value:
     -
-      plugin: eic_html_sanitizer
+      plugin: skip_on_empty
       source: c4m_body/0/value
+      method: process
+    -
+      plugin: eic_html_sanitizer
     -
       plugin: eic_media_wysiwyg_filter
       media_migrations:

--- a/config/sync/migrate_plus.migration.upgrade_d7_node_photo_to_media.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_node_photo_to_media.yml
@@ -27,7 +27,7 @@ process:
   status: status
   created: created
   changed: timestamp
-  oe_media_image:
+  _media:
     -
       plugin: sub_process
       source: c4m_media
@@ -42,6 +42,8 @@ process:
           -
             plugin: skip_on_empty
             method: row
+  oe_media_image/0/target_id: '@_media/0/target_id'
+  oe_media_image/0/alt: title
 destination:
   plugin: 'entity:media'
   default_bundle: image

--- a/config/sync/migrate_plus.migration.upgrade_d7_node_photo_to_media.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_node_photo_to_media.yml
@@ -17,7 +17,6 @@ source:
   track_changes: true
   batch_size: 100
 process:
-  name: title
   uid:
     -
       plugin: migration_lookup
@@ -42,8 +41,28 @@ process:
           -
             plugin: skip_on_empty
             method: row
+  _media_title:
+    -
+      plugin: entity_value
+      source: '@_media/0/target_id'
+      entity_type: file
+      field_name: uri
+    -
+      plugin: extract
+      index:
+        - 0
+    -
+      plugin: extract
+      index:
+        - value
+    -
+      plugin: explode
+      delimiter: '/'
+    -
+      plugin: array_pop
+  name: '@_media_title'
   oe_media_image/0/target_id: '@_media/0/target_id'
-  oe_media_image/0/alt: title
+  oe_media_image/0/alt: '@_media_title'
 destination:
   plugin: 'entity:media'
   default_bundle: image

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_photoalbum.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_photoalbum.yml
@@ -55,14 +55,19 @@ process:
   content_translation_source: source_langcode
   node_comment/0/status: comment
   field_body/0/format:
+    - plugin: default_value
+      source: c4m_body/0/format
+      default_value: filtered_html
     - plugin: callback
       source: c4m_body/0/format
       callable:
         - '\Drupal\eic_migrate\Constants\Misc'
         - getTextFormat
   field_body/0/value:
-    - plugin: eic_html_sanitizer
+    - plugin: skip_on_empty
       source: c4m_body/0/value
+      method: process
+    - plugin: eic_html_sanitizer
     - plugin: eic_media_wysiwyg_filter
       media_migrations:
         - upgrade_d7_file_audio_to_media

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_photo_to_media.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_photo_to_media.yml
@@ -15,7 +15,6 @@ source:
   track_changes: true
   batch_size: 100
 process:
-  name: '@_media_title'
   uid:
     - plugin: migration_lookup
       source: node_uid
@@ -49,8 +48,28 @@ process:
           -
             plugin: skip_on_empty
             method: row
+  _media_title:
+    -
+      plugin: entity_value
+      source: '@_media/0/target_id'
+      entity_type: file
+      field_name: uri
+    -
+      plugin: extract
+      index:
+        - 0
+    -
+      plugin: extract
+      index:
+        - value
+    -
+      plugin: explode
+      delimiter: '/'
+    -
+      plugin: array_pop
+  name: '@_media_title'
   oe_media_image/0/target_id: '@_media/0/target_id'
-  oe_media_image/0/alt: title
+  oe_media_image/0/alt: '@_media_title'
 #        title: title
 #        width: width
 #        height: height

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_photo_to_media.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_photo_to_media.yml
@@ -15,7 +15,7 @@ source:
   track_changes: true
   batch_size: 100
 process:
-  name: title
+  name: '@_media_title'
   uid:
     - plugin: migration_lookup
       source: node_uid
@@ -34,19 +34,23 @@ process:
 #        - upgrade_d7_file_image_to_media
 #        - upgrade_d7_file_undefined_to_media
 #        - upgrade_d7_file_video_to_media
-  oe_media_image:
-    - plugin: sub_process
+  _media:
+    -
+      plugin: sub_process
       source: c4m_media
       process:
         target_id:
-          - plugin: migration_lookup
+          -
+            plugin: migration_lookup
             source: fid
             migration:
               - upgrade_d7_file
               - upgrade_d7_file_private
-          - plugin: skip_on_empty
+          -
+            plugin: skip_on_empty
             method: row
-#        alt: alt
+  oe_media_image/0/target_id: '@_media/0/target_id'
+  oe_media_image/0/alt: title
 #        title: title
 #        width: width
 #        height: height

--- a/lib/modules/eic_migrate/src/Plugin/migrate/source/NodeCompletePhotoalbum.php
+++ b/lib/modules/eic_migrate/src/Plugin/migrate/source/NodeCompletePhotoalbum.php
@@ -37,7 +37,7 @@ class NodeCompletePhotoalbum extends NodeCompleteWithSMEDIds {
    * Get node gallery relationships.
    *
    * @param int $ngid
-   *   Node gallery ID
+   *   Node gallery ID.
    *
    * @return array
    *   Array of ngid and nid.
@@ -45,7 +45,9 @@ class NodeCompletePhotoalbum extends NodeCompleteWithSMEDIds {
   protected function getNodeGalleryRelationships(int $ngid) {
     $nodeGalleryRelationshipsQuery = $this->select('node_gallery_relationship', 'ngr')
       ->fields('ngr', ['ngid', 'nid'])
-      ->where('ngr.ngid = :ngid', [':ngid' => $ngid]);
+      ->where('ngr.ngid = :ngid', [':ngid' => $ngid])
+      ->orderBy('ngr.weight')
+      ->orderBy('ngr.nid');
     $nodeGalleryRelationships = $nodeGalleryRelationshipsQuery->execute()->fetchAll();
 
     return $nodeGalleryRelationships;

--- a/lib/modules/eic_migrate/src/Plugin/migrate/source/PhotoalbumPhotoRelationship.php
+++ b/lib/modules/eic_migrate/src/Plugin/migrate/source/PhotoalbumPhotoRelationship.php
@@ -26,7 +26,9 @@ class PhotoalbumPhotoRelationship extends SqlBase {
    */
   public function query() {
     $query = $this->select('node_gallery_relationship', 'ngr')
-      ->fields('ngr');
+      ->fields('ngr')
+      ->orderBy('ngr.weight')
+      ->orderBy('ngr.nid');
     return $query;
   }
 

--- a/lib/themes/eic_community/includes/preprocess/content/node--gallery.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--gallery.inc
@@ -49,9 +49,15 @@ function eic_community_preprocess_node__gallery(array &$variables) {
         $media = $file->get('field_gallery_slide_media')->referencedEntities()[0];
         $download = File::load($media->oe_media_image->getValue()[0]['target_id']);
         $download_url = MediaHelper::formatMediaDownloadLink($media)->toString();
+        $explode_file_name = explode('/', $download->getFileUri());
+        // We grab the filename based on the file URI.
+        $file_name = end($explode_file_name);
+        // We use the filename based on the file URI if it has the same name as
+        // the media entity.
+        $file_name = $media->getName() === $file_name ? $file_name : $download->getFilename();
 
         $files_list[] = [
-          'name' => $download->getFileName(),
+          'name' => $file_name,
           'type' => t('Image', [], ['context' => 'eic_community']),
           'stats' => [
             [
@@ -73,12 +79,12 @@ function eic_community_preprocess_node__gallery(array &$variables) {
           'path' => $download_url,
           'image' => [
             'src' => ImageStyle::load('oe_theme_ratio_3_2_medium')->buildUrl($download->getFileUri()),
-            'alt' => $download->getFileName(),
+            'alt' => $file_name,
           ],
         ];
 
         $slide = [
-          'name' => $download->getFileName(),
+          'name' => $file_name,
           'stats' => [
             [
               'hide_label' => TRUE,
@@ -99,11 +105,11 @@ function eic_community_preprocess_node__gallery(array &$variables) {
           'path' => $download_url,
           'image' => [
             'src' => ImageStyle::load('oe_theme_small_2x_no_crop')->buildUrl($download->getFileUri()),
-            'alt' => $download->getFileName(),
+            'alt' => $file_name,
           ],
           'thumb' => [
             'src' => ImageStyle::load('media_library')->buildUrl($download->getFileUri()),
-            'alt' => $download->getFileName(),
+            'alt' => $file_name,
           ],
         ];
 


### PR DESCRIPTION
### Improvements

- Fix image alt text in photo migration.

### Test

- [x] Run `drush upgrade_d7_node_photo_to_media --update`
- [x] Check if the alt text of medias has been correctly migrated. In the D7 photo nodes don't have an alt text and therefore we used the filename as the alt text. Check example in D9 -> `/media/9524/edit` or go to `/admin/content/media` and search for "**eoliwind_urban_wind_turbine_-_eoli_fps_next_level_performance.jpg**"
- [x] Check if the order of the gallery slides match the same order as on the D7. Compare the D9 (`/organisations/reaccion-uptheworld-sl/library/eoliwind-urban-wind-turbine-eoli-fps-next-level`) with D7 (https://eic.accp.eismea.eu/community7/uptheworld_3062/photo-albums/eoliwind-urban-wind-turbine-eoli-fps-next-level-performance)