### PR TITLE
EICNET-2513: Editing a comment with user tag makes that user disappear after saving

### DIFF
--- a/lib/modules/eic_groups/src/Controller/DiscussionController.php
+++ b/lib/modules/eic_groups/src/Controller/DiscussionController.php
@@ -358,7 +358,7 @@ class DiscussionController extends ControllerBase {
         'field_tagged_users',
         array_map(function ($tagged_user) {
           return [
-            'target_id' => $tagged_user['tid'],
+            'target_id' => $tagged_user['uid'],
           ];
         }, $tagged_users)
       );


### PR DESCRIPTION
### Fixes

- Fix issue where tagged users were removed after editing a comment.

### Test

- [x] As SA/SCM, add a comment in a discussion and tag a user
- [x] Edit the comment and make sure the tagged user remains there