### PR TITLE
EICNET-1312: File 'Video'/'Audio'/'Undefined' to Media migration (improvements phase 2)

### DIFF
--- a/config/sync/field.field.media.eic_document.field_media_file.yml
+++ b/config/sync/field.field.media.eic_document.field_media_file.yml
@@ -21,7 +21,7 @@ settings:
   handler: 'default:file'
   handler_settings: {  }
   file_directory: '[date:custom:Y]-[date:custom:m]'
-  file_extensions: 'txt pdf doc docx xls xlsx png bmp jpg jpeg pps ppsx ppt pptx odt ods odp odf gif pdt pdtx vsd vsdx zip'
+  file_extensions: 'txt pdf doc docx xls xlsx png bmp jpg jpeg pps ppsx ppt pptx odt ods odp odf gif pdt pdtx vsd vsdx zip 7z rar xml'
   max_filesize: ''
   description_field: false
 field_type: file


### PR DESCRIPTION
### Changes

- Allow file extensions 7z, rar and xml.

### Test

- [ ] Run `drush mim upgrade_d7_file_undefined_to_media --update`
- [ ] Make sure the following media document (XML) was migrated -> https://migration-eic-1305b32181e0.deltablue.io/community/admin/content/media?name=spoken-languages-en+%281%29.xml&type=All&status=All&langcode=All