### PR TITLE
EICNET-2519: Enable entity tree widget in language fields

### DIFF
--- a/config/sync/core.entity_form_display.node.discussion.default.yml
+++ b/config/sync/core.entity_form_display.node.discussion.default.yml
@@ -159,10 +159,22 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_language:
-    type: options_select
+    type: entity_tree
     weight: 7
     region: content
-    settings: {  }
+    settings:
+      match_top_level_limit: '0'
+      load_all: '1'
+      items_to_load: '25'
+      selected_terms_label: 'Your selected languages'
+      search_label: 'Select a language'
+      search_placeholder: Search
+      disable_top_choices: 0
+      can_create_tag: 0
+      auto_select_parents: 0
+      ignore_current_user: 0
+      target_bundles: {  }
+      is_required: false
     third_party_settings: {  }
   field_post_activity:
     weight: 4

--- a/config/sync/core.entity_form_display.node.document.default.yml
+++ b/config/sync/core.entity_form_display.node.document.default.yml
@@ -111,10 +111,10 @@ content:
       selected_terms_label: 'Your selected document types'
       search_label: 'Select a document type'
       search_placeholder: Search
-      auto_select_parents: '1'
       disable_top_choices: 0
       load_all: 0
       can_create_tag: 0
+      auto_select_parents: 0
       ignore_current_user: 0
       target_bundles: {  }
       is_required: false
@@ -132,12 +132,12 @@ content:
     region: content
     settings:
       match_top_level_limit: '0'
-      items_to_load: '100'
+      load_all: '1'
+      items_to_load: '25'
       selected_terms_label: 'Your selected languages'
       search_label: 'Select a language'
       search_placeholder: Search
       disable_top_choices: 0
-      load_all: 0
       can_create_tag: 0
       auto_select_parents: 0
       ignore_current_user: 0

--- a/config/sync/core.entity_form_display.node.event.default.yml
+++ b/config/sync/core.entity_form_display.node.event.default.yml
@@ -200,10 +200,22 @@ content:
       media_types: {  }
     third_party_settings: {  }
   field_language:
-    type: options_select
+    type: entity_tree
     weight: 44
     region: content
-    settings: {  }
+    settings:
+      match_top_level_limit: '0'
+      load_all: '1'
+      items_to_load: '25'
+      selected_terms_label: 'Your selected languages'
+      search_label: 'Select a language'
+      search_placeholder: Search
+      disable_top_choices: 0
+      can_create_tag: 0
+      auto_select_parents: 0
+      ignore_current_user: 0
+      target_bundles: {  }
+      is_required: false
     third_party_settings: {  }
   field_link:
     type: link_default

--- a/config/sync/core.entity_form_display.node.gallery.default.yml
+++ b/config/sync/core.entity_form_display.node.gallery.default.yml
@@ -134,10 +134,22 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_document_type:
-    type: options_select
+    type: entity_tree
     weight: 22
     region: content
-    settings: {  }
+    settings:
+      match_top_level_limit: '0'
+      items_to_load: '25'
+      selected_terms_label: 'Your selected document types'
+      search_label: 'Select a document type'
+      search_placeholder: Search
+      disable_top_choices: 0
+      load_all: 0
+      can_create_tag: 0
+      auto_select_parents: 0
+      ignore_current_user: 0
+      target_bundles: {  }
+      is_required: false
     third_party_settings: {  }
   field_gallery_slides:
     type: entity_reference_paragraphs
@@ -152,10 +164,22 @@ content:
       default_paragraph_type: ''
     third_party_settings: {  }
   field_language:
-    type: options_select
+    type: entity_tree
     weight: 23
     region: content
-    settings: {  }
+    settings:
+      match_top_level_limit: '0'
+      load_all: '1'
+      items_to_load: '25'
+      selected_terms_label: 'Your selected languages'
+      search_label: 'Select a language'
+      search_placeholder: Search
+      disable_top_choices: 0
+      can_create_tag: 0
+      auto_select_parents: 0
+      ignore_current_user: 0
+      target_bundles: {  }
+      is_required: false
     third_party_settings: {  }
   field_post_activity:
     weight: 4

--- a/config/sync/core.entity_form_display.node.news.default.yml
+++ b/config/sync/core.entity_form_display.node.news.default.yml
@@ -221,10 +221,22 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_language:
-    type: options_select
+    type: entity_tree
     weight: 43
     region: content
-    settings: {  }
+    settings:
+      match_top_level_limit: '0'
+      load_all: '1'
+      items_to_load: '25'
+      selected_terms_label: 'Your selected languages'
+      search_label: 'Select a language'
+      search_placeholder: Search
+      disable_top_choices: 0
+      can_create_tag: 0
+      auto_select_parents: 0
+      ignore_current_user: 0
+      target_bundles: {  }
+      is_required: false
     third_party_settings: {  }
   field_news_paragraphs:
     type: entity_reference_paragraphs

--- a/config/sync/core.entity_form_display.node.story.default.yml
+++ b/config/sync/core.entity_form_display.node.story.default.yml
@@ -225,10 +225,22 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_language:
-    type: options_select
+    type: entity_tree
     weight: 10
     region: content
-    settings: {  }
+    settings:
+      match_top_level_limit: '0'
+      load_all: '1'
+      items_to_load: '25'
+      selected_terms_label: 'Your selected languages'
+      search_label: 'Select a language'
+      search_placeholder: Search
+      disable_top_choices: 0
+      can_create_tag: 0
+      auto_select_parents: 0
+      ignore_current_user: 0
+      target_bundles: {  }
+      is_required: false
     third_party_settings: {  }
   field_post_activity:
     weight: 5

--- a/config/sync/core.entity_form_display.node.video.default.yml
+++ b/config/sync/core.entity_form_display.node.video.default.yml
@@ -134,10 +134,22 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_document_type:
-    type: options_select
+    type: entity_tree
     weight: 6
     region: content
-    settings: {  }
+    settings:
+      match_top_level_limit: '0'
+      items_to_load: '25'
+      selected_terms_label: 'Your selected document types'
+      search_label: 'Select a document type'
+      search_placeholder: Search
+      disable_top_choices: 0
+      load_all: 0
+      can_create_tag: 0
+      auto_select_parents: 0
+      ignore_current_user: 0
+      target_bundles: {  }
+      is_required: false
     third_party_settings: {  }
   field_image:
     type: media_library_widget
@@ -147,10 +159,22 @@ content:
       media_types: {  }
     third_party_settings: {  }
   field_language:
-    type: options_select
+    type: entity_tree
     weight: 7
     region: content
-    settings: {  }
+    settings:
+      match_top_level_limit: '0'
+      load_all: '1'
+      items_to_load: '25'
+      selected_terms_label: 'Your selected languages'
+      search_label: 'Select a language'
+      search_placeholder: Search
+      disable_top_choices: 0
+      can_create_tag: 0
+      auto_select_parents: 0
+      ignore_current_user: 0
+      target_bundles: {  }
+      is_required: false
     third_party_settings: {  }
   field_post_activity:
     weight: 5

--- a/config/sync/core.entity_form_display.node.wiki_page.default.yml
+++ b/config/sync/core.entity_form_display.node.wiki_page.default.yml
@@ -110,10 +110,22 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_language:
-    type: options_select
+    type: entity_tree
     weight: 10
     region: content
-    settings: {  }
+    settings:
+      match_top_level_limit: '0'
+      load_all: '1'
+      items_to_load: '25'
+      selected_terms_label: 'Your selected languages'
+      search_label: 'Select a language'
+      search_placeholder: Search
+      disable_top_choices: 0
+      can_create_tag: 0
+      auto_select_parents: 0
+      ignore_current_user: 0
+      target_bundles: {  }
+      is_required: false
     third_party_settings: {  }
   field_post_activity:
     weight: 4


### PR DESCRIPTION
### Improvements

- Enable and configure entity tree widget for language field in all content types.

### Test

- [x] Try to create content in a group (discussion, document, event, gallery, video and wiki pages) and make sure the field "Language" uses the entity tree widget
- [x] Try to create a News and a Story and also make sure the "Language" field uses the entity tree widget