### PR TITLE
EICNET-1320: Node 'Story' migration (improvements phase 2)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3298,7 +3298,9 @@
                     "2918537 - Cannot save unpublished versions of published content for users without manage book privileges": "https://www.drupal.org/files/issues/2021-11-16/2918537-68.patch",
                     "2473873 - Views entity operations lack cacheability support, resulting in incorrect dropbuttons": "https://www.drupal.org/files/issues/2021-11-23/2473873-97.patch",
                     "2766369 - Add skip-method option to file_copy and download process plugins": "https://www.drupal.org/files/issues/2022-03-31/2766369-30.patch",
-                    "2760983 - array_flip(): Can only flip STRING and INTEGER values! EntityStorageBase.php:227": "https://www.drupal.org/files/issues/2020-02-06/2760983-8.patch"
+                    "2760983 - array_flip(): Can only flip STRING and INTEGER values! EntityStorageBase.php:227": "https://www.drupal.org/files/issues/2020-02-06/2760983-8.patch",
+                    "2329253 - Allow the ChangedItem to skip updating the entity's \"changed\" timestamp when synchronizing (f.e. when migrating)": "https://www.drupal.org/files/issues/2022-05-30/2329253-90.patch",
+                    "3052115 - Mark an entity as 'syncing' during a migration update": "https://www.drupal.org/files/issues/2022-05-12/3052115-47.patch"
                 }
             },
             "autoload": {
@@ -12589,6 +12591,7 @@
                     "type": "tidelift"
                 }
             ],
+            "abandoned": "symfony/error-handler",
             "time": "2022-04-12T15:19:55+00:00"
         },
         {

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -6,7 +6,9 @@
       "2918537 - Cannot save unpublished versions of published content for users without manage book privileges": "https://www.drupal.org/files/issues/2021-11-16/2918537-68.patch",
       "2473873 - Views entity operations lack cacheability support, resulting in incorrect dropbuttons": "https://www.drupal.org/files/issues/2021-11-23/2473873-97.patch",
       "2766369 - Add skip-method option to file_copy and download process plugins": "https://www.drupal.org/files/issues/2022-03-31/2766369-30.patch",
-      "2760983 - array_flip(): Can only flip STRING and INTEGER values! EntityStorageBase.php:227": "https://www.drupal.org/files/issues/2020-02-06/2760983-8.patch"
+      "2760983 - array_flip(): Can only flip STRING and INTEGER values! EntityStorageBase.php:227": "https://www.drupal.org/files/issues/2020-02-06/2760983-8.patch",
+      "2329253 - Allow the ChangedItem to skip updating the entity's \"changed\" timestamp when synchronizing (f.e. when migrating)": "https://www.drupal.org/files/issues/2022-05-30/2329253-90.patch",
+      "3052115 - Mark an entity as 'syncing' during a migration update": "https://www.drupal.org/files/issues/2022-05-12/3052115-47.patch"
     },
     "drupal/address": {
       "2812659 - Integrate Address with Search API (adds a Search API processor to convert country code to full country name)": "https://www.drupal.org/files/issues/2021-06-14/integrate-address-searchapi-2812659-57_0.patch"

--- a/config/sync/core.entity_form_display.node.story.default.yml
+++ b/config/sync/core.entity_form_display.node.story.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.node.story.field_image_caption
     - field.field.node.story.field_introduction
     - field.field.node.story.field_language
+    - field.field.node.story.field_related_groups
     - field.field.node.story.field_related_stories
     - field.field.node.story.field_story_paragraphs
     - field.field.node.story.field_tags
@@ -38,6 +39,7 @@ third_party_settings:
         - group_details
         - group_documents
         - group_related_stories
+        - group_related_groups
         - group_contributors
         - group_topics_countries_tags
         - group_settings
@@ -110,7 +112,7 @@ third_party_settings:
       label: 'Topics, countries & tags'
       region: content
       parent_name: group_story_details
-      weight: 24
+      weight: 25
       format_type: tab
       format_settings:
         classes: ''
@@ -126,7 +128,7 @@ third_party_settings:
       label: Settings
       region: content
       parent_name: group_story_details
-      weight: 25
+      weight: 26
       format_type: tab
       format_settings:
         classes: ''
@@ -139,6 +141,21 @@ third_party_settings:
       children:
         - field_story_paragraphs
       label: Contributors
+      region: content
+      parent_name: group_story_details
+      weight: 24
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_related_groups:
+      children:
+        - field_related_groups
+      label: 'Related groups'
       region: content
       parent_name: group_story_details
       weight: 23
@@ -234,6 +251,16 @@ content:
     weight: 5
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_related_groups:
+    type: entity_reference_autocomplete
+    weight: 31
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_related_stories:
     type: entity_reference_autocomplete

--- a/config/sync/core.entity_view_display.node.story.default.yml
+++ b/config/sync/core.entity_view_display.node.story.default.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.story.field_image_caption
     - field.field.node.story.field_introduction
     - field.field.node.story.field_language
+    - field.field.node.story.field_related_groups
     - field.field.node.story.field_related_stories
     - field.field.node.story.field_story_paragraphs
     - field.field.node.story.field_tags
@@ -102,6 +103,14 @@ content:
       link: true
     third_party_settings: {  }
     weight: 21
+    region: content
+  field_related_groups:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 22
     region: content
   field_related_stories:
     type: entity_reference_label

--- a/config/sync/core.entity_view_display.node.story.mail_teaser.yml
+++ b/config/sync/core.entity_view_display.node.story.mail_teaser.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.story.field_image_caption
     - field.field.node.story.field_introduction
     - field.field.node.story.field_language
+    - field.field.node.story.field_related_groups
     - field.field.node.story.field_related_stories
     - field.field.node.story.field_story_paragraphs
     - field.field.node.story.field_tags
@@ -64,6 +65,7 @@ hidden:
   field_image: true
   field_image_caption: true
   field_language: true
+  field_related_groups: true
   field_related_stories: true
   field_story_paragraphs: true
   field_tags: true

--- a/config/sync/core.entity_view_display.node.story.teaser.yml
+++ b/config/sync/core.entity_view_display.node.story.teaser.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.story.field_image_caption
     - field.field.node.story.field_introduction
     - field.field.node.story.field_language
+    - field.field.node.story.field_related_groups
     - field.field.node.story.field_related_stories
     - field.field.node.story.field_story_paragraphs
     - field.field.node.story.field_tags
@@ -95,6 +96,7 @@ hidden:
   field_image_caption: true
   field_introduction: true
   field_language: true
+  field_related_groups: true
   field_related_stories: true
   field_story_paragraphs: true
   field_tags: true

--- a/config/sync/field.field.node.story.field_related_groups.yml
+++ b/config/sync/field.field.node.story.field_related_groups.yml
@@ -1,0 +1,29 @@
+uuid: 025d0a95-1373-468c-b281-9dd35a41c6fe
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_related_groups
+    - group.type.group
+    - node.type.story
+id: node.story.field_related_groups
+field_name: field_related_groups
+entity_type: node
+bundle: story
+label: 'Related groups'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:group'
+  handler_settings:
+    target_bundles:
+      group: group
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: group
+field_type: entity_reference

--- a/config/sync/field.field.node.story.field_vocab_geo.yml
+++ b/config/sync/field.field.node.story.field_vocab_geo.yml
@@ -12,7 +12,7 @@ entity_type: node
 bundle: story
 label: 'Regions & Countries'
 description: ''
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/lib/modules/eic_migrate/src/EventSubscriber/PostMigrationSubscriber.php
+++ b/lib/modules/eic_migrate/src/EventSubscriber/PostMigrationSubscriber.php
@@ -456,10 +456,10 @@ class PostMigrationSubscriber implements EventSubscriberInterface {
     $changed = $entity->getChangedTime();
     $entity->set($field_name, array_unique(array_merge($entity->get($field_name)->getValue(), $values)));
     $entity->setNewRevision(FALSE);
-    $entity->save();
-
     // Preserve the changed timestamp.
     $entity->setChangedTime($changed);
+    // We enable syncing to avoid creating new revisions.
+    $entity->setSyncing(TRUE);
     $entity->save();
   }
 

--- a/lib/modules/eic_migrate/src/EventSubscriber/PostMigrationSubscriber.php
+++ b/lib/modules/eic_migrate/src/EventSubscriber/PostMigrationSubscriber.php
@@ -295,12 +295,12 @@ class PostMigrationSubscriber implements EventSubscriberInterface {
       $migrated_row = $migration->getIdMap()->getRowBySource($source_ids);
       $parent_migrated_row = $migration->getIdMap()->getRowBySource($parent_source_ids);
       // Populate the node values.
-      $node_values[$parent_migrated_row['destid1']][] = $migrated_row['destid1'];
+      $node_values[$parent_migrated_row['destid2']][] = $migrated_row['destid1'];
     }
 
     // Set the values for each row.
     foreach ($node_values as $parent_id => $items) {
-      if ($group = $this->entityTypeManager->getStorage('group')->load($parent_id)) {
+      if ($group = $this->entityTypeManager->getStorage('group')->loadRevision($parent_id)) {
         $this->updateEntityReferenceValue($group, 'field_related_groups', $items);
       }
     }

--- a/lib/modules/eic_migrate/src/EventSubscriber/PostMigrationSubscriber.php
+++ b/lib/modules/eic_migrate/src/EventSubscriber/PostMigrationSubscriber.php
@@ -97,6 +97,7 @@ class PostMigrationSubscriber implements EventSubscriberInterface {
     switch ($event->getMigration()->getBaseId()) {
       case 'upgrade_d7_node_complete_group':
         $this->completeRelatedGroups($event);
+        $this->completeStoriesRelatedGroups($event);
         break;
 
       case 'upgrade_d7_node_complete_article':
@@ -350,6 +351,87 @@ class PostMigrationSubscriber implements EventSubscriberInterface {
         $this->updateEntityReferenceValue($node, 'field_related_stories', $items);
       }
     }
+  }
+
+  /**
+   * Sets the correct entity references for field_related_groups field.
+   *
+   * @param \Drupal\migrate\Event\MigrateImportEvent $event
+   *   The import event object.
+   */
+  protected function completeStoriesRelatedGroups(MigrateImportEvent $event) {
+    $migration = $event->getMigration();
+
+    // Get the original nodes for which we have related groups.
+    $d7_query = $this->connection->select('field_data_c4m_related_group', 'rg');
+    $d7_query->innerJoin('node', 'n', 'n.nid = rg.c4m_related_group_target_id');
+    $d7_query->fields('n', ['nid', 'vid', 'language']);
+    $d7_query->fields('rg', ['c4m_related_group_target_id', 'entity_id']);
+    $d7_query->addField('rg', 'revision_id', 'parent_vid');
+    $d7_query->addField('rg', 'language', 'parent_language');
+    $d7_query->condition('rg.entity_type', 'node')
+      ->condition('rg.bundle', 'article');
+
+    // Gather all items for each row.
+    // Since we are using the node_complete migration, we assume that source ID
+    // is always:
+    // - destid1: nid.
+    // - destid2: vid.
+    // - destid3: langcode.
+    $node_values = [];
+    foreach ($d7_query->execute()->fetchAll(\PDO::FETCH_ASSOC) as $result) {
+      $source_ids = [$result['nid'], $result['vid'], $result['language']];
+      $parent_source_ids = [
+        $result['entity_id'],
+        $result['parent_vid'],
+        $result['parent_language'],
+      ];
+      $migrated_row = $migration->getIdMap()->getRowBySource($source_ids);
+      $parent_migrated_row = $migration->getIdMap()->getRowBySource($parent_source_ids);
+      $parent_migrated_row = $this->migrateLookup->lookup(
+        [
+          'upgrade_d7_node_complete_article',
+        ],
+        [
+          $result['entity_id'],
+          $result['parent_vid'],
+          $result['parent_language'],
+        ]
+      );
+
+      if (empty($migrated_row) || empty($parent_migrated_row)) {
+        continue;
+      }
+      // Populate the node values.
+      $node_values[$parent_migrated_row[0]['vid']][] = $migrated_row['destid1'];
+    }
+
+    $related_story_node_ids = [];
+    // Set the values for each row.
+    foreach ($node_values as $parent_id => $items) {
+      if ($node = $this->entityTypeManager->getStorage('node')->loadRevision($parent_id)) {
+        $this->updateEntityReferenceValue($node, 'field_related_groups', $items);
+      }
+      $related_story_node_ids[$node->id()] = $node->id();
+    }
+
+    // @todo We need to check if it's necessary to migrate the related stories
+    // into the group or if we can just keep the related groups in stories.
+    // $group_related_stories = [];
+    // foreach ($related_story_node_ids as $node_id) {
+    //   if ($node = $this->entityTypeManager->getStorage('node')->load($node_id)) {
+    //     if ($related_groups = $node->field_related_groups->referencedEntities()) {
+    //       foreach ($related_groups as $group) {
+    //         $group_related_stories[$group->id()][] = $node_id;
+    //       }
+    //     }
+    //   }
+    // }
+    // foreach ($group_related_stories as $group_id => $node_ids) {
+    //   if ($group = $this->entityTypeManager->getStorage('group')->load($group_id)) {
+    //     $this->updateEntityReferenceValue($group, 'field_related_news_stories', $node_ids);
+    //   }
+    // }
   }
 
   /**

--- a/lib/modules/eic_migrate/src/EventSubscriber/PostMigrationSubscriber.php
+++ b/lib/modules/eic_migrate/src/EventSubscriber/PostMigrationSubscriber.php
@@ -341,12 +341,12 @@ class PostMigrationSubscriber implements EventSubscriberInterface {
       $migrated_row = $migration->getIdMap()->getRowBySource($source_ids);
       $parent_migrated_row = $migration->getIdMap()->getRowBySource($parent_source_ids);
       // Populate the node values.
-      $node_values[$parent_migrated_row['destid1']][] = $migrated_row['destid1'];
+      $node_values[$parent_migrated_row['destid2']][] = $migrated_row['destid1'];
     }
 
     // Set the values for each row.
     foreach ($node_values as $parent_nid => $items) {
-      if ($node = $this->entityTypeManager->getStorage('node')->load($parent_nid)) {
+      if ($node = $this->entityTypeManager->getStorage('node')->loadRevision($parent_nid)) {
         $this->updateEntityReferenceValue($node, 'field_related_stories', $items);
       }
     }


### PR DESCRIPTION
### Improvements

- Fix migration of related stories when running the story migration (there were duplicated values because we were updating only the latest revision);
- Fix migration of related groups in stories;
- Create field "Related groups" in Story;
- Fix migration of related groups in groups.

### To discuss

- Migrate related groups from Story into Groups. Before the relationship was done via the story and now is done in the group. The logic has been done but it's commented in the code. We need to decide if it makes sense to migrate the related stories in groups instead of the related groups in stories.

### To do

- Fix the body format in story migration. Some users cannot use the full_html format and therefore we need to replace it with filtered_html otherwise the users will not be able to edit the body.

### Test

If you are already working with a migrated DB, please rollback the stories used in the following testing scenario: `drush mr upgrade_d7_node_complete_article --idlist=14007:16759:und,14007:16691:und,14007:16664:und,14007:16667:und,14007:16692:und,14007:16695:und,14007:16167:und,14007:16758:und,14007:16690:und,14007:16686:und,14007:16699:und,14007:16166:und`

- [x] Run `drush mim upgrade_d7_node_complete_article --update` or `drush mim upgrade_d7_node_complete_article --idlist=14007:16759:und,14007:16691:und,14007:16664:und,14007:16667:und,14007:16692:und,14007:16695:und,14007:16167:und,14007:16758:und,14007:16690:und,14007:16686:und,14007:16699:und,14007:16166:und --update --limit=12`
- [x] Run `drush mim upgrade_d7_node_complete_group --update` or `drush mim upgrade_d7_node_complete_group --idlist=2564:2854:und,2564:2872:und,2564:2989:und,2564:2990:und,2564:2991:und,2564:6580:und,2564:8466:und,2564:10988:und,2564:11021:und --update`
- [x] Go to -> `/stories/open-call-introduce-new-digital-solutions-pharma-supply-chain/edit` and make sure the fields related stories and related groups were correctly migrated. Compare it with D7 https://eic.accp.eismea.eu/community7/articles/open-call-introduce-new-digital-solutions-pharma-supply-chain. Also make sure the field "Regions and Countries" is not required anymore.
- [x] Go to -> `/groups/ict4water-actor-awareness-water-digital/edit` and make sure the fields related stories and related groups were correctly migrated. Compare it with D7 https://eic.accp.eismea.eu/community7/ict4water---actor-awareness-water-digital-aw-/node/10912/edit