### PR TITLE
[EICNET-2511]fix: Interepret correctly the HTML on featured comment

### DIFF
--- a/lib/modules/eic_comments/src/CommentsHelper.php
+++ b/lib/modules/eic_comments/src/CommentsHelper.php
@@ -3,8 +3,10 @@
 namespace Drupal\eic_comments;
 
 use Drupal\comment\CommentInterface;
+use Drupal\Component\Utility\Xss;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Field\FieldFilteredMarkup;
 
 /**
  * Service that provides helper functions for comments.
@@ -55,6 +57,16 @@ class CommentsHelper {
     $query->count();
     $results = $query->execute();
     return (int) $results;
+  }
+
+  /**
+   * @param string $body
+   *
+   * @return string
+   */
+  public static function formatHtmlComment(string $body): string {
+    $allowed_tags = array_merge(FieldFilteredMarkup::allowedTags(), ['u', 's']);
+    return Xss::filter($body, $allowed_tags);
   }
 
 }

--- a/lib/modules/eic_groups/src/Controller/DiscussionController.php
+++ b/lib/modules/eic_groups/src/Controller/DiscussionController.php
@@ -16,6 +16,7 @@ use Drupal\Core\Field\FieldFilteredMarkup;
 use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
+use Drupal\eic_comments\CommentsHelper;
 use Drupal\eic_content\Constants\DefaultContentModerationStates;
 use Drupal\eic_flags\RequestStatus;
 use Drupal\eic_search\Service\SolrDocumentProcessor;
@@ -137,8 +138,7 @@ class DiscussionController extends ControllerBase {
 
     $user = User::load($this->currentUser()->id());
     $content = json_decode($request->getContent(), TRUE);
-    $allowed_tags = array_merge(FieldFilteredMarkup::allowedTags(), ['u', 's']);
-    $text = Xss::filter($content['text'], $allowed_tags);
+    $text = CommentsHelper::formatHtmlComment($content['text']);
     $tagged_users = $content['taggedUsers'] ?? NULL;
     $parent_id = $content['parentId'];
 
@@ -262,8 +262,7 @@ class DiscussionController extends ControllerBase {
     }
 
     $content = json_decode($request->getContent(), TRUE);
-    $allowed_tags = array_merge(FieldFilteredMarkup::allowedTags(), ['u', 's']);
-    $text = Xss::filter($content['text'], $allowed_tags);
+    $text = CommentsHelper::formatHtmlComment($content['text']);
 
     try {
       if ('like_comment' === $flag) {
@@ -324,8 +323,7 @@ class DiscussionController extends ControllerBase {
    */
   public function editComment(Request $request, int $discussion_id, $comment_id) {
     $content = json_decode($request->getContent(), TRUE);
-    $allowed_tags = array_merge(FieldFilteredMarkup::allowedTags(), ['u', 's']);
-    $text = Xss::filter($content['text'], $allowed_tags);
+    $text = CommentsHelper::formatHtmlComment($content['text']);
 
     $comment = Comment::load($comment_id);
 

--- a/lib/themes/eic_community/includes/preprocess/content/node--discussion.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--discussion.inc
@@ -5,11 +5,10 @@
  * Prepares variables for node discussion templates.
  */
 
-use Drupal\Component\Utility\Xss;
-use Drupal\Core\Render\Markup;
 use Drupal\eic_groups\Constants\GroupVisibilityType;
 use Drupal\group\Entity\GroupInterface;
 use Drupal\oec_group_flex\GroupVisibilityRecordInterface;
+use Drupal\eic_comments\CommentsHelper;
 
 /**
  * Implements hook_preprocess_node() for discussion node.
@@ -103,7 +102,7 @@ function _preprocess_discussion_full(&$variables, $discussion_type, $node) {
  */
 function _preprocess_discussion_teaser(&$variables, $discussion_type, $node) {
   $teaser = _eic_community_prepare_node_teaser_array($node);
-  $teaser['description'] = Markup::create(Xss::filter($node->get('field_body')->value));
+  $teaser['description'] = CommentsHelper::formatHtmlComment($node->get('field_body')->value);
   $teaser['type'] = $discussion_type;
 
   // Remove unwanted items.
@@ -117,7 +116,7 @@ function _preprocess_discussion_teaser(&$variables, $discussion_type, $node) {
   // Add last comment if there is one.
   if ($last_comment = _eic_community_get_entity_last_comment($node)) {
     $teaser['featured'] = [
-      'comment' => $last_comment->get('comment_body')->value,
+      'comment' => CommentsHelper::formatHtmlComment($last_comment->get('comment_body')->value),
       'comment_id' => $last_comment->id(),
       'author' => eic_community_get_teaser_user_display($last_comment->getOwner()),
       'timestamp' => eic_community_get_teaser_time_display($last_comment->getCreatedTime()),

--- a/lib/themes/eic_community/patterns/compositions/comment/comment-base.html.twig
+++ b/lib/themes/eic_community/patterns/compositions/comment/comment-base.html.twig
@@ -134,7 +134,7 @@
 
     <div class="ecl-comment__main">
       <div class="ecl-editable-wrapper">
-        {{ comment }}
+        {{ comment | raw }}
       </div>
 
       {% if attachments is not empty %}


### PR DESCRIPTION
How to test:

- [x] Go to a discussion from group
- [x] Add comment with HTMl tags
- [x] Go to the group overview (the detail group page)
- [x] See if the featured discussion show correctly the last comment with interpreted html and not show it as string