### PR TITLE
[EICNET-2524]fix: Generate temporary url on select users in tagging comment

### DIFF
--- a/lib/themes/eic_community/react/components/Block/CommentsDiscussion/Partials/CommentForm.js
+++ b/lib/themes/eic_community/react/components/Block/CommentsDiscussion/Partials/CommentForm.js
@@ -77,7 +77,7 @@ class CommentForm extends React.Component {
                   placeholder={getTranslation('comment_placeholder')}
                 />
                 </div>
-                <TaggedUsers taggedUsers={this.state.taggedUsers} />
+                <TaggedUsers taggedUsers={this.state.taggedUsers} generateTemporaryUrl={true} />
               </div>
               <div className="ecl-comment-form__toolbar">
                 <div className="ecl-comment-form__toolbar-main">

--- a/lib/themes/eic_community/react/components/Block/CommentsDiscussion/Partials/TaggedUsers.js
+++ b/lib/themes/eic_community/react/components/Block/CommentsDiscussion/Partials/TaggedUsers.js
@@ -1,12 +1,12 @@
 import React from 'react';
 
-const TaggedUsers = ({taggedUsers}) => {
+const TaggedUsers = ({taggedUsers, generateTemporaryUrl = false}) => {
   if (taggedUsers.length === 0) {
     return <></>;
   }
   return <div>
     With: <span
-    dangerouslySetInnerHTML={{__html: taggedUsers.map(user => `<a href="${user.url}" class="ecl-comment__author-name">${user.name}</a>`).join(', ')}}
+    dangerouslySetInnerHTML={{__html: taggedUsers.map(user => `<a href="${generateTemporaryUrl ? '/user/' + user.tid : user.url}" class="ecl-comment__author-name">${user.name}</a>`).join(', ')}}
   />
   </div>
 }


### PR DESCRIPTION
How to test:

- [ ] Go to discussion detail
- [ ] Tag users, on the modal confirm the tagging users
- [ ] Do not submit the comment
- [ ] Check if the tagged users links redirect to correct user detail page