### PR TITLE
[EICNET-1173]fix: Take the group budle into account

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/blocks/block--eic-group-header-block.inc
+++ b/lib/themes/eic_community/includes/preprocess/blocks/block--eic-group-header-block.inc
@@ -310,7 +310,7 @@ function eic_community_preprocess_eic_group_header_block(array &$variables) {
 
   }
 
-  if (in_array($group->bundle(), ['event', 'group'])) {
+  if (in_array($group->bundle(), ['event', 'group']) && !GroupsModerationHelper::isBlocked($group)) {
     $visibility = \Drupal::service('oec_group_flex.group_visibility.storage')->load($group->id());
     if ($visibility instanceof GroupVisibilityRecordInterface
       && $visibility->getType() === GroupVisibilityType::GROUP_VISIBILITY_PUBLIC) {

--- a/lib/themes/eic_community/includes/preprocess/content/node--discussion.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--discussion.inc
@@ -8,6 +8,7 @@
 use Drupal\Component\Utility\Xss;
 use Drupal\Core\Render\Markup;
 use Drupal\eic_groups\Constants\GroupVisibilityType;
+use Drupal\eic_groups\GroupsModerationHelper;
 use Drupal\group\Entity\GroupInterface;
 use Drupal\oec_group_flex\GroupVisibilityRecordInterface;
 
@@ -81,8 +82,11 @@ function _preprocess_discussion_full(&$variables, $discussion_type, $node) {
 
     $variables['#cache']['tags'] = array_merge($variables['#cache']['tags'], $group->getCacheTags());
     $visibility = \Drupal::service('oec_group_flex.group_visibility.storage')->load($group->id());
-    if ($visibility instanceof GroupVisibilityRecordInterface
-      && $visibility->getType() === GroupVisibilityType::GROUP_VISIBILITY_PUBLIC) {
+    if (in_array($group->bundle(), ['event', 'group'])
+      && !GroupsModerationHelper::isBlocked($group)
+      && $visibility instanceof GroupVisibilityRecordInterface
+      && $visibility->getType() === GroupVisibilityType::GROUP_VISIBILITY_PUBLIC
+    ) {
       $flags['social_share']['content'] = _eic_community_get_social_share_block();
     }
   }

--- a/lib/themes/eic_community/includes/preprocess/content/node--document.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--document.inc
@@ -6,6 +6,7 @@
  */
 
 use Drupal\eic_groups\Constants\GroupVisibilityType;
+use Drupal\eic_groups\GroupsModerationHelper;
 use Drupal\eic_media\MediaHelper;
 use Drupal\file\Entity\File;
 use Drupal\group\Entity\GroupInterface;
@@ -174,7 +175,7 @@ function eic_community_preprocess_node__document(array &$variables) {
 
         $variables['#cache']['tags'] = array_merge($variables['#cache']['tags'], $group->getCacheTags());
         $visibility = \Drupal::service('oec_group_flex.group_visibility.storage')->load($group->id());
-        if ($visibility instanceof GroupVisibilityRecordInterface
+        if (in_array($group->bundle(), ['event', 'group']) && !GroupsModerationHelper::isBlocked($group) && $visibility instanceof GroupVisibilityRecordInterface
           && $visibility->getType() === GroupVisibilityType::GROUP_VISIBILITY_PUBLIC) {
           $variables['editorial_actions']['items'][]['content'] = _eic_community_get_social_share_block();
         }

--- a/lib/themes/eic_community/includes/preprocess/content/node--gallery.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--gallery.inc
@@ -9,6 +9,7 @@ use Drupal\Component\Utility\Xss;
 use Drupal\Core\Render\Markup;
 use Drupal\eic_community\ValueObject\ImageValueObject;
 use Drupal\eic_groups\Constants\GroupVisibilityType;
+use Drupal\eic_groups\GroupsModerationHelper;
 use Drupal\eic_media\MediaHelper;
 use Drupal\file\Entity\File;
 use Drupal\group\Entity\GroupInterface;
@@ -36,7 +37,7 @@ function eic_community_preprocess_node__gallery(array &$variables) {
 
         $variables['#cache']['tags'] = array_merge($variables['#cache']['tags'], $group->getCacheTags());
         $visibility = \Drupal::service('oec_group_flex.group_visibility.storage')->load($group->id());
-        if ($visibility instanceof GroupVisibilityRecordInterface
+        if (in_array($group->bundle(), ['event', 'group']) && !GroupsModerationHelper::isBlocked($group) && $visibility instanceof GroupVisibilityRecordInterface
           && $visibility->getType() === GroupVisibilityType::GROUP_VISIBILITY_PUBLIC) {
           $variables['editorial_actions']['items'][]['content'] = _eic_community_get_social_share_block();
         }

--- a/lib/themes/eic_community/includes/preprocess/content/node--news--story.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--news--story.inc
@@ -6,9 +6,13 @@
  */
 
 use Drupal\eic_community\ValueObject\ImageValueObject;
+use Drupal\eic_groups\Constants\GroupVisibilityType;
+use Drupal\eic_groups\GroupsModerationHelper;
 use Drupal\eic_media\MediaHelper;
 use Drupal\eic_private_content\PrivateContentConst;
 use Drupal\file\Entity\File;
+use Drupal\group\Entity\GroupInterface;
+use Drupal\oec_group_flex\GroupVisibilityRecordInterface;
 
 /**
  * Implements hook_preprocess_node__story() for story node.
@@ -122,14 +126,22 @@ function _eic_community_preprocess_node_news_story(array &$variables) {
     // Sidebar elements.
     _eic_community_display_flags($variables);
 
-    if (
-      $node->hasField(PrivateContentConst::FIELD_NAME)
-      && !$node->get(PrivateContentConst::FIELD_NAME)->value
-    ) {
-      if ($share_block = _eic_community_get_social_share_block()) {
-        $variables['editorial_actions']['items'][]['content'] = $share_block;
+    $group = \Drupal::service('eic_groups.helper')->getGroupFromRoute();
+    if (!$group && $node->hasField(PrivateContentConst::FIELD_NAME)
+      && !$node->get(PrivateContentConst::FIELD_NAME)->value) {
+      $variables['editorial_actions']['items'][]['content'] = _eic_community_get_social_share_block();
+    }
+    elseif ($group instanceof GroupInterface) {
+      $visibility = \Drupal::service('oec_group_flex.group_visibility.storage')->load($group->id());
+      if (in_array($group->bundle(), ['event', 'group'])
+        && !GroupsModerationHelper::isBlocked($group)
+        && $visibility instanceof GroupVisibilityRecordInterface
+        && $visibility->getType() === GroupVisibilityType::GROUP_VISIBILITY_PUBLIC
+      ) {
+        $variables['editorial_actions']['items'][]['content'] = _eic_community_get_social_share_block();
       }
     }
+
 
     _eic_community_display_contributors($variables);
     _eic_community_display_topics($variables);

--- a/lib/themes/eic_community/includes/preprocess/content/node--video.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--video.inc
@@ -7,6 +7,7 @@
 
 use Drupal\eic_community\ValueObject\ImageValueObject;
 use Drupal\eic_groups\Constants\GroupVisibilityType;
+use Drupal\eic_groups\GroupsModerationHelper;
 use Drupal\group\Entity\GroupInterface;
 use Drupal\oec_group_flex\GroupVisibilityRecordInterface;
 
@@ -31,7 +32,7 @@ function eic_community_preprocess_node__video(array &$variables) {
 
         $variables['#cache']['tags'] = array_merge($variables['#cache']['tags'], $group->getCacheTags());
         $visibility = \Drupal::service('oec_group_flex.group_visibility.storage')->load($group->id());
-        if ($visibility instanceof GroupVisibilityRecordInterface
+        if (in_array($group->bundle(), ['event', 'group']) && !GroupsModerationHelper::isBlocked($group) && $visibility instanceof GroupVisibilityRecordInterface
           && $visibility->getType() === GroupVisibilityType::GROUP_VISIBILITY_PUBLIC) {
           $variables['editorial_actions']['items'][]['content'] = _eic_community_get_social_share_block();
         }

--- a/lib/themes/eic_community/includes/preprocess/events.inc
+++ b/lib/themes/eic_community/includes/preprocess/events.inc
@@ -9,6 +9,7 @@ use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\eic_groups\Constants\GroupVisibilityType;
 use Drupal\eic_groups\EICGroupsHelper;
+use Drupal\eic_groups\GroupsModerationHelper;
 use Drupal\eic_media\MediaHelper;
 use Drupal\file\Entity\File;
 use Drupal\group\Entity\GroupInterface;
@@ -51,7 +52,7 @@ function _eic_community_render_event_detail_page(array &$variables, EntityInterf
     $existing_tags = $variables['#cache']['tags'] ?? [];
     $variables['#cache']['tags'] = array_merge($existing_tags, $group->getCacheTags());
     $visibility = \Drupal::service('oec_group_flex.group_visibility.storage')->load($group->id());
-    if ($visibility instanceof GroupVisibilityRecordInterface
+    if (in_array($group->bundle(), ['event', 'group']) && !GroupsModerationHelper::isBlocked($group) && $visibility instanceof GroupVisibilityRecordInterface
       && $visibility->getType() === GroupVisibilityType::GROUP_VISIBILITY_PUBLIC) {
       $variables['editorial_actions']['items'][]['content'] = _eic_community_get_social_share_block();
     }


### PR DESCRIPTION
## To Test

- [x] Create a news in an organisation -> Share button shouldn't be visible
- [x] Create a news in a private global event -> Share button shouldn't be visible