### PR TITLE
EICNET-226: Migrate "image" media type (Improvements)

### DIFF
--- a/config/sync/migrate_plus.migration.upgrade_d7_node_photo_to_media.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_node_photo_to_media.yml
@@ -12,7 +12,7 @@ migration_tags:
 migration_group: migrate_drupal_7
 label: 'Node (Photo) to Media'
 source:
-  plugin: d7_node
+  plugin: eic_d7_node_complete_photo
   node_type: photo
   track_changes: true
   batch_size: 100
@@ -62,7 +62,21 @@ process:
       plugin: array_pop
   name: '@_media_title'
   oe_media_image/0/target_id: '@_media/0/target_id'
-  oe_media_image/0/alt: '@_media_title'
+  oe_media_image/0/alt:
+    -
+      plugin: callback
+      source:
+        - '@_media_title'
+        - field_file_image_alt_text_value
+      callable:
+        - \Drupal\eic_migrate\Constants\Misc
+        - getImageAltText
+  oe_media_image/0/title:
+    -
+      plugin: default_value
+      source: field_file_image_title_text_value
+      strict: true
+      default_value: ''
 destination:
   plugin: 'entity:media'
   default_bundle: image

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_photo_to_media.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_photo_to_media.yml
@@ -10,7 +10,7 @@ migration_tags:
 migration_group: migrate_drupal_7
 label: 'Node (Photo) to Media'
 source:
-  plugin: d7_node
+  plugin: eic_d7_node_complete_photo
   node_type: photo
   track_changes: true
   batch_size: 100
@@ -69,7 +69,21 @@ process:
       plugin: array_pop
   name: '@_media_title'
   oe_media_image/0/target_id: '@_media/0/target_id'
-  oe_media_image/0/alt: '@_media_title'
+  oe_media_image/0/alt:
+    -
+      plugin: callback
+      source:
+        - '@_media_title'
+        - field_file_image_alt_text_value
+      callable:
+        - \Drupal\eic_migrate\Constants\Misc
+        - getImageAltText
+  oe_media_image/0/title:
+    -
+      plugin: default_value
+      source: field_file_image_title_text_value
+      strict: true
+      default_value: ''
 #        title: title
 #        width: width
 #        height: height

--- a/lib/modules/eic_migrate/src/Constants/Misc.php
+++ b/lib/modules/eic_migrate/src/Constants/Misc.php
@@ -34,4 +34,23 @@ final class Misc {
     return self::TEXT_FORMAT_MAPPINGS[$text_format_id] ?? FALSE;
   }
 
+  /**
+   * Maps old text formats to new ones.
+   *
+   * @param array $text
+   *   Array composed by 2 items:
+   *   - default value for the image alt text
+   *   - alt text to override the default value.
+   *
+   * @return false|mixed|string
+   *   The new text format or FALSE if not found.
+   */
+  public static function getImageAltText(array $text = []) {
+    if (count($text) <= 0) {
+      return FALSE;
+    }
+    return !empty($text[1]) ? $text[1] :
+      (!empty($text[0]) ? $text[0] : FALSE);
+  }
+
 }

--- a/lib/modules/eic_migrate/src/Plugin/migrate/source/NodeCompletePhoto.php
+++ b/lib/modules/eic_migrate/src/Plugin/migrate/source/NodeCompletePhoto.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Drupal\eic_migrate\Plugin\migrate\source;
+
+use Drupal\migrate\Row;
+use Drupal\node\Plugin\migrate\source\d7\Node;
+
+/**
+ * Drupal 7 all node photo.
+ *
+ * @MigrateSource(
+ *   id = "eic_d7_node_complete_photo",
+ *   source_module = "node"
+ * )
+ */
+class NodeCompletePhoto extends Node {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    $query = parent::query();
+
+    $query->leftJoin('field_data_c4m_media', 'm', 'n.nid = m.entity_id AND m.bundle = :photo_bundle', [':photo_bundle' => 'photo']);
+    // Include image alt and title text.
+    $query->leftJoin('field_data_field_file_image_alt_text', 'a', 'm.c4m_media_fid = a.entity_id');
+    $query->leftJoin('field_data_field_file_image_title_text', 't', 'm.c4m_media_fid = t.entity_id');
+    $query->fields('a', ['field_file_image_alt_text_value']);
+    $query->fields('t', ['field_file_image_title_text_value']);
+
+    return $query;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function prepareRow(Row $row) {
+    $alt_text = $row->getSourceProperty('field_file_image_alt_text_value');
+    if (empty($alt_text)) {
+      $row->setSourceProperty('field_file_image_alt_text_value', NULL);
+    }
+    $title_text = $row->getSourceProperty('field_file_image_title_text_value');
+    if (empty($title_text)) {
+      $row->setSourceProperty('field_file_image_title_text_value', NULL);
+    }
+
+    return parent::prepareRow($row);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function fields() {
+    $fields = parent::fields();
+    $fields['field_file_image_alt_text_value'] = $this->t('Photo alt text.');
+    $fields['field_file_image_alt_text_value'] = $this->t('Photo title text.');
+    return $fields;
+  }
+
+}


### PR DESCRIPTION
### Improvements

- Fix migration of alt texts for node photo to media migration.

### Test

- [x] Run `drush mim upgrade_d7_node_photo_to_media --update`
- [x] Check if the following 4 medias have an alt text: **solar_energie.jpg**, **aqrate1.jpg**, **unnamed_gallery.jpg**, **unnamed_gallery_0.jpg**