### PR TITLE
EICNET-XXXX: Remove unneeded dependencies for upgrade_d7_taxonomy_term_c4m_vocab_tag migration.

### DIFF
--- a/config/sync/migrate_plus.migration.upgrade_d7_taxonomy_term_c4m_vocab_tag.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_taxonomy_term_c4m_vocab_tag.yml
@@ -38,8 +38,5 @@ destination:
   plugin: 'entity:taxonomy_term'
   default_bundle: tags
 migration_dependencies:
-  required:
-    - upgrade_d7_node_complete_group
-    - upgrade_d7_node_complete_organisation
-    - upgrade_d7_node_complete_event_site
+  required: {  }
   optional: {  }

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_taxonomy_term_c4m_vocab_tag.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_taxonomy_term_c4m_vocab_tag.yml
@@ -32,8 +32,5 @@ destination:
   plugin: 'entity:taxonomy_term'
   default_bundle: tags
 migration_dependencies:
-  required:
-    - upgrade_d7_node_complete_group
-    - upgrade_d7_node_complete_organisation
-    - upgrade_d7_node_complete_event_site
+  required: { }
   optional: { }


### PR DESCRIPTION
Nothing to test, just a mistake to fix.