### PR TITLE
Feature/eicnet xxxx various migration fixes

### DIFF
--- a/config/sync/migrate_plus.migration.upgrade_d7_taxonomy_term_c4m_vocab_tag.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_taxonomy_term_c4m_vocab_tag.yml
@@ -38,8 +38,5 @@ destination:
   plugin: 'entity:taxonomy_term'
   default_bundle: tags
 migration_dependencies:
-  required:
-    - upgrade_d7_node_complete_group
-    - upgrade_d7_node_complete_organisation
-    - upgrade_d7_node_complete_event_site
+  required: {  }
   optional: {  }

--- a/lib/modules/eic_default_content/eic_default_content.services.yml
+++ b/lib/modules/eic_default_content/eic_default_content.services.yml
@@ -1,33 +1,4 @@
 services:
-  eic_default_content.user_generator:
-    class: Drupal\eic_default_content\Generator\UserGenerator
-    arguments: [ '@entity_type.manager' ]
-    tags:
-      - { name: data_fixtures, priority: -1 }
-  eic_default_content.term_generator:
-    class: Drupal\eic_default_content\Generator\TaxonomyGenerator
-    tags:
-      - { name: data_fixtures, priority: -2 }
-  eic_default_content.group_generator:
-    class: Drupal\eic_default_content\Generator\GroupGenerator
-    tags:
-      - { name: data_fixtures }
-  eic_default_content.group_type_event_generator:
-    class: Drupal\eic_default_content\Generator\GroupTypeEventGenerator
-    tags:
-      - { name: data_fixtures }
-  eic_default_content.organisation_generator:
-    class: Drupal\eic_default_content\Generator\OrganisationGenerator
-    tags:
-      - { name: data_fixtures }
-  eic_default_content.story_generator:
-    class: Drupal\eic_default_content\Generator\StoryGenerator
-    tags:
-      - { name: data_fixtures }
-  eic_default_content.news_generator:
-    class: Drupal\eic_default_content\Generator\NewsGenerator
-    tags:
-      - { name: data_fixtures }
   eic_default_content.menu_generator:
     class: Drupal\eic_default_content\Generator\MenuGenerator
     tags:

--- a/lib/modules/eic_default_content/modules/eic_dummy_content/eic_dummy_content.info.yml
+++ b/lib/modules/eic_default_content/modules/eic_dummy_content/eic_dummy_content.info.yml
@@ -1,9 +1,10 @@
-name: EIC Default Content
+name: EIC Dummy Content
 type: module
-description: Provides default content to use for all environments.
+description: Provides dummy content to use on local/development environments.
 package: European Innovation Council
 core: 8.x
 php: 7.3
 core_version_requirement: ^8 || ^9
 dependencies:
   - data_fixtures:data_fixtures
+  - eic_default_content:eic_default_content

--- a/lib/modules/eic_default_content/modules/eic_dummy_content/eic_dummy_content.services.yml
+++ b/lib/modules/eic_default_content/modules/eic_dummy_content/eic_dummy_content.services.yml
@@ -1,0 +1,30 @@
+services:
+  eic_default_content.user_generator:
+    class: Drupal\eic_dummy_content\Generator\UserGenerator
+    arguments: [ '@entity_type.manager' ]
+    tags:
+      - { name: data_fixtures, priority: -1 }
+  eic_default_content.term_generator:
+    class: Drupal\eic_dummy_content\Generator\TaxonomyGenerator
+    tags:
+      - { name: data_fixtures, priority: -2 }
+  eic_default_content.group_generator:
+    class: Drupal\eic_dummy_content\Generator\GroupGenerator
+    tags:
+      - { name: data_fixtures }
+  eic_default_content.group_type_event_generator:
+    class: Drupal\eic_dummy_content\Generator\GroupTypeEventGenerator
+    tags:
+      - { name: data_fixtures }
+  eic_default_content.organisation_generator:
+    class: Drupal\eic_dummy_content\Generator\OrganisationGenerator
+    tags:
+      - { name: data_fixtures }
+  eic_default_content.story_generator:
+    class: Drupal\eic_dummy_content\Generator\StoryGenerator
+    tags:
+      - { name: data_fixtures }
+  eic_default_content.news_generator:
+    class: Drupal\eic_dummy_content\Generator\NewsGenerator
+    tags:
+      - { name: data_fixtures }

--- a/lib/modules/eic_default_content/modules/eic_dummy_content/src/Generator/GroupTypeEventGenerator.php
+++ b/lib/modules/eic_default_content/modules/eic_dummy_content/src/Generator/GroupTypeEventGenerator.php
@@ -1,8 +1,10 @@
 <?php
 
-namespace Drupal\eic_default_content\Generator;
+namespace Drupal\eic_dummy_content\Generator;
 
+use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\eic_content\Constants\DefaultContentModerationStates;
+use Drupal\eic_default_content\Generator\CoreGenerator;
 use Drupal\eic_groups\GroupsModerationHelper;
 use Drupal\group\Entity\Group;
 use Drupal\group\Entity\GroupContent;
@@ -10,11 +12,11 @@ use Drupal\group\Entity\GroupInterface;
 use Drupal\node\Entity\Node;
 
 /**
- * Class to generate groups using fixtures.
+ * Class to generate global events using fixtures.
  *
- * @package Drupal\eic_default_content\Generator
+ * @package Drupal\eic_dummy_content\Generator
  */
-class GroupGenerator extends CoreGenerator {
+class GroupTypeEventGenerator extends CoreGenerator {
 
   /**
    * Group flex saver service.
@@ -64,21 +66,73 @@ class GroupGenerator extends CoreGenerator {
     for ($i = 0; $i < 5; $i++) {
       $visibility = $i % 2 ? 'public' : 'private';
       $group_number = $i + 1;
+
+      switch ($this->faker->randomNumber(1, TRUE)) {
+        case 1:
+          // On going event.
+          $start_date = new DrupalDateTime('-2 days');
+          $end_date = new DrupalDateTime('+2 days');
+          break;
+
+        case 2:
+          // Future event.
+          $start_date = new DrupalDateTime('+2 days');
+          $end_date = new DrupalDateTime('+4 days');
+          break;
+
+        default:
+          // Past event.
+          $start_date = new DrupalDateTime('-4 days');
+          $end_date = new DrupalDateTime('-2 days');
+          break;
+
+      }
+
       $values = [
-        'label' => "Group #$group_number",
-        'type' => 'group',
+        'label' => "Global Event #$group_number",
+        'type' => 'event',
         'field_body' => $this->getFormattedText('full_html'),
+        'field_tag_line' => 'EIC event',
         'field_welcome_message' => $this->getFormattedText('full_html'),
         'status' => TRUE,
         'moderation_state' => GroupsModerationHelper::GROUP_PUBLISHED_STATE,
-        'field_hero' => $this->createMedia([
+        'field_header_visual' => $this->createMedia([
           'oe_media_image' => $this->getRandomImage(),
         ], 'image'),
-        'field_thumbnail' => $this->createMedia([
+        'field_image' => $this->createMedia([
           'oe_media_image' => $this->getRandomImage(),
         ], 'image'),
+        'field_documents' => [
+          $this->createMedia([
+            'field_body' => $this->getFormattedText('full_html'),
+            'field_media_file' => $this->getRandomImage(),
+            'field_language' => $this->getRandomEntities('taxonomy_term', ['vid' => 'languages'], 1),
+          ], 'eic_document'),
+        ],
+        'field_date_range' => [
+          'value'=> $start_date->format('Y-m-d\TH:i:s'),
+          'end_value' => $end_date->format('Y-m-d\TH:i:s'),
+        ],
+        'field_event_registration_date' => [
+          'value'=> $start_date->format('Y-m-d\TH:i:s'),
+          'end_value' => $end_date->format('Y-m-d\TH:i:s'),
+        ],
+        'field_organised_by' => 'EIC Admin',
+        'field_link' => 'https://myevent.site',
+        'field_website_url' => 'https://myevent.site',
+        'field_location_type' => $i % 2 ? 'on_site' : 'remote',
+        'field_location' => [
+          'country_code' => 'BE',
+          'address_line1' => 'Grand Place',
+          'locality' => 'Bruxelles',
+          'postal_code' => '1000',
+        ],
+        'field_vocab_event_type' => $this->getRandomEntities('group', ['type' => 'group'], 2),
+        'field_vocab_event_type' => $this->getRandomEntities('taxonomy_term', ['vid' => 'event_type'], 1),
         'field_vocab_topics' => $this->getRandomEntities('taxonomy_term', ['vid' => 'topics'], 1),
         'field_vocab_geo' => $this->getRandomEntities('taxonomy_term', ['vid' => 'geo'], 1),
+        'field_vocab_language' => $this->getRandomEntities('taxonomy_term', ['vid' => 'languages'], 1),
+        'field_funding_source' => $this->getRandomEntities('taxonomy_term', ['vid' => 'funding_source'], 1),
         'features' => $available_features,
         'uid' => 1,
       ];
@@ -93,13 +147,12 @@ class GroupGenerator extends CoreGenerator {
       $book->save();
 
       $this->createDiscussions($group);
-      $this->createGroupEvents($group);
       $this->createWikiPages($group);
     }
   }
 
   /**
-   * Creates a single discussion for the given group.
+   * Creates a single discussion for the given group event.
    *
    * @param \Drupal\group\Entity\GroupInterface $group
    *   The group entity.
@@ -136,54 +189,7 @@ class GroupGenerator extends CoreGenerator {
   }
 
   /**
-   * Creates a single group event (node) for the given group.
-   *
-   * @param \Drupal\group\Entity\GroupInterface $group
-   *   The group entity.
-   *
-   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
-   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
-   * @throws \Drupal\Core\Entity\EntityStorageException
-   */
-  private function createGroupEvents(GroupInterface $group) {
-    $content_type_id = $group
-      ->getGroupType()
-      ->getContentPlugin('group_node:event')
-      ->getContentTypeConfigId();
-
-    $node = Node::create([
-      'field_body' => $this->getFormattedText('full_html'),
-      'type' => 'event',
-      'title' => 'Event in ' . $group->label(),
-      'field_link' => 'https://myevent.site',
-      'field_organised_by' => 'Someone',
-      'field_vocab_event_type' => $this->getRandomEntities('taxonomy_term', ['vid' => 'event_type'], 1),
-      'field_vocab_topics' => $this->getRandomEntities('taxonomy_term', ['vid' => 'topics'], 3),
-      'field_vocab_geo' => $this->getRandomEntities('taxonomy_term', ['vid' => 'geo'], 2),
-      'status' => TRUE,
-      'uid' => 1,
-      'moderation_state' => DefaultContentModerationStates::PUBLISHED_STATE,
-    ]);
-
-    $node->save();
-    $group_content = GroupContent::create([
-      'type' => $content_type_id,
-      'gid' => $group->id(),
-      'entity_id' => $node->id(),
-    ]);
-    $group_content->save();
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function unLoad() {
-    $this->unloadEntities('group_permission');
-    $this->unloadEntities('group');
-  }
-
-  /**
-   * Creates multiple wiki pages for the given group.
+   * Creates multiple wiki pages for the given group event.
    *
    * @param \Drupal\group\Entity\GroupInterface $group
    *   The group entity.
@@ -228,6 +234,15 @@ class GroupGenerator extends CoreGenerator {
       ]);
       $group_content->save();
     }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function unLoad() {
+    $this->unloadEntities('group_permission');
+    $this->unloadEntities('group');
+    return;
   }
 
 }

--- a/lib/modules/eic_default_content/modules/eic_dummy_content/src/Generator/NewsGenerator.php
+++ b/lib/modules/eic_default_content/modules/eic_dummy_content/src/Generator/NewsGenerator.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Drupal\eic_default_content\Generator;
+namespace Drupal\eic_dummy_content\Generator;
 
+use Drupal\eic_default_content\Generator\CoreGenerator;
 use Drupal\eic_moderation\Constants\EICContentModeration;
 use Drupal\eic_private_content\PrivateContentConst;
 use Drupal\node\Entity\Node;
@@ -9,7 +10,7 @@ use Drupal\node\Entity\Node;
 /**
  * Class to generate news using fixtures.
  *
- * @package Drupal\eic_default_content\Generator
+ * @package Drupal\eic_dummy_content\Generator
  */
 class NewsGenerator extends CoreGenerator {
 

--- a/lib/modules/eic_default_content/modules/eic_dummy_content/src/Generator/OrganisationGenerator.php
+++ b/lib/modules/eic_default_content/modules/eic_dummy_content/src/Generator/OrganisationGenerator.php
@@ -1,9 +1,10 @@
 <?php
 
-namespace Drupal\eic_default_content\Generator;
+namespace Drupal\eic_dummy_content\Generator;
 
 use Drupal\Core\Url;
 use Drupal\eic_content\Constants\DefaultContentModerationStates;
+use Drupal\eic_default_content\Generator\CoreGenerator;
 use Drupal\eic_groups\GroupsModerationHelper;
 use Drupal\eic_moderation\Constants\EICContentModeration;
 use Drupal\group\Entity\Group;
@@ -14,7 +15,7 @@ use Drupal\node\Entity\Node;
 /**
  * Class to generate organisations using fixtures.
  *
- * @package Drupal\eic_default_content\Generator
+ * @package Drupal\eic_dummy_content\Generator
  */
 class OrganisationGenerator extends CoreGenerator {
 

--- a/lib/modules/eic_default_content/modules/eic_dummy_content/src/Generator/StoryGenerator.php
+++ b/lib/modules/eic_default_content/modules/eic_dummy_content/src/Generator/StoryGenerator.php
@@ -1,14 +1,15 @@
 <?php
 
-namespace Drupal\eic_default_content\Generator;
+namespace Drupal\eic_dummy_content\Generator;
 
 use Drupal\eic_moderation\Constants\EICContentModeration;
+use Drupal\eic_default_content\Generator\CoreGenerator;
 use Drupal\node\Entity\Node;
 
 /**
  * Class StoryGenerator
  *
- * @package Drupal\eic_default_content\Generator
+ * @package Drupal\eic_dummy_content\Generator
  */
 class StoryGenerator extends CoreGenerator {
 

--- a/lib/modules/eic_default_content/modules/eic_dummy_content/src/Generator/TaxonomyGenerator.php
+++ b/lib/modules/eic_default_content/modules/eic_dummy_content/src/Generator/TaxonomyGenerator.php
@@ -1,13 +1,14 @@
 <?php
 
-namespace Drupal\eic_default_content\Generator;
+namespace Drupal\eic_dummy_content\Generator;
 
+use Drupal\eic_default_content\Generator\CoreGenerator;
 use Drupal\taxonomy\Entity\Term;
 
 /**
  * Generates default content for taxonomy.
  *
- * @package Drupal\eic_default_content\Generator
+ * @package Drupal\eic_dummy_content\Generator
  */
 class TaxonomyGenerator extends CoreGenerator {
 

--- a/lib/modules/eic_default_content/modules/eic_dummy_content/src/Generator/UserGenerator.php
+++ b/lib/modules/eic_default_content/modules/eic_dummy_content/src/Generator/UserGenerator.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Drupal\eic_default_content\Generator;
+namespace Drupal\eic_dummy_content\Generator;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\eic_default_content\Generator\CoreGenerator;
 use Drupal\eic_topics\Constants\Topics;
 use Drupal\eic_user\ProfileConst;
 use Drupal\profile\Entity\Profile;
@@ -11,7 +12,7 @@ use Drupal\user\Entity\User;
 /**
  * Generates default users.
  *
- * @package Drupal\eic_default_content\Generator
+ * @package Drupal\eic_dummy_content\Generator
  */
 class UserGenerator extends CoreGenerator {
 

--- a/lib/modules/eic_flags/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_flags/src/Hooks/EntityOperations.php
@@ -8,7 +8,6 @@ use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountProxyInterface;
-use Drupal\Core\State\StateInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Url;
 use Drupal\eic_flags\FlaggedEntitiesListBuilder;
@@ -17,7 +16,6 @@ use Drupal\eic_flags\FlagType;
 use Drupal\eic_flags\RequestStatus;
 use Drupal\eic_flags\RequestTypes;
 use Drupal\eic_flags\Service\RequestHandlerCollector;
-use Drupal\eic_migrate\Commands\MigrateToolsOverrideCommands;
 use Drupal\eic_topics\Constants\Topics;
 use Drupal\flag\FlagCountManagerInterface;
 use Drupal\flag\FlagServiceInterface;
@@ -93,13 +91,6 @@ class EntityOperations implements ContainerInjectionInterface {
   private $flagHelper;
 
   /**
-   * The state cache.
-   *
-   * @var \Drupal\Core\State\StateInterface
-   */
-  private $state;
-
-  /**
    * EntityOperations constructor.
    *
    * @param \Drupal\eic_flags\Service\RequestHandlerCollector $collector
@@ -118,8 +109,6 @@ class EntityOperations implements ContainerInjectionInterface {
    *   The Flag service.
    * @param \Drupal\eic_flags\FlagHelper $eic_flag_helper
    *   The EIC Flag helper service.
-   * @param \Drupal\Core\State\StateInterface $state
-   *   The state cache.
    */
   public function __construct(
     RequestHandlerCollector $collector,
@@ -129,8 +118,7 @@ class EntityOperations implements ContainerInjectionInterface {
     AccountProxyInterface $account,
     FlagCountManagerInterface $flag_count_manager,
     FlagServiceInterface $flag_service,
-    FlagHelper $eic_flag_helper,
-    StateInterface $state
+    FlagHelper $eic_flag_helper
   ) {
     $this->collector = $collector;
     $this->moderationInformation = $moderation_information;
@@ -140,7 +128,6 @@ class EntityOperations implements ContainerInjectionInterface {
     $this->flagCountManager = $flag_count_manager;
     $this->flagService = $flag_service;
     $this->flagHelper = $eic_flag_helper;
-    $this->state = $state;
   }
 
   /**
@@ -155,8 +142,7 @@ class EntityOperations implements ContainerInjectionInterface {
       $container->get('current_user'),
       $container->get('flag.count'),
       $container->get('flag'),
-      $container->get('eic_flags.helper'),
-      $container->get('state')
+      $container->get('eic_flags.helper')
     );
   }
 
@@ -401,7 +387,7 @@ class EntityOperations implements ContainerInjectionInterface {
    */
   public function followEntityOnCreation(EntityInterface $entity) {
     // If we are running migrations, stop flagging entities.
-    if ($this->state->get(MigrateToolsOverrideCommands::STATE_MIGRATIONS_IS_RUNNING)) {
+    if (eic_migrate_is_migration_messages_running()) {
       return;
     }
 
@@ -468,7 +454,7 @@ class EntityOperations implements ContainerInjectionInterface {
    */
   public function followTopicsOnUserProfileUpdate(ProfileInterface $profile) {
     // If we are running migrations, stop flagging entities.
-    if ($this->state->get(MigrateToolsOverrideCommands::STATE_MIGRATIONS_IS_RUNNING)) {
+    if (eic_migrate_is_migration_messages_running()) {
       return;
     }
 

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/src/EventSubscriber/FlagEventSubscriber.php
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/src/EventSubscriber/FlagEventSubscriber.php
@@ -2,11 +2,9 @@
 
 namespace Drupal\eic_message_subscriptions\EventSubscriber;
 
-use Drupal\Core\State\StateInterface;
 use Drupal\eic_flags\FlagType;
 use Drupal\eic_message_subscriptions\Event\MessageSubscriptionEvent;
 use Drupal\eic_message_subscriptions\Event\MessageSubscriptionEvents;
-use Drupal\eic_migrate\Commands\MigrateToolsOverrideCommands;
 use Drupal\flag\Event\FlagEvents;
 use Drupal\flag\Event\FlaggingEvent;
 use Drupal\flag\FlagInterface;
@@ -26,26 +24,15 @@ class FlagEventSubscriber implements EventSubscriberInterface {
   protected $eventDispatcher;
 
   /**
-   * The state cache.
-   *
-   * @var \Drupal\Core\State\StateInterface
-   */
-  protected $state;
-
-  /**
    * FlagEventSubscriber constructor.
    *
    * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $event_dispatcher
    *   The event dispatcher service.
-   * @param \Drupal\Core\State\StateInterface $state
-   *   The state cache.
    */
   public function __construct(
-    EventDispatcherInterface $event_dispatcher,
-    StateInterface $state
+    EventDispatcherInterface $event_dispatcher
   ) {
     $this->eventDispatcher = $event_dispatcher;
-    $this->state = $state;
   }
 
   /**
@@ -112,7 +99,7 @@ class FlagEventSubscriber implements EventSubscriberInterface {
    *   TRUE if the flag can trigger message subscriptions.
    */
   public function isApplicable(FlagInterface $flag) {
-    if ($this->state->get(MigrateToolsOverrideCommands::STATE_MIGRATIONS_IS_RUNNING)) {
+    if (eic_migrate_is_migration_messages_running()) {
       FALSE;
     }
 

--- a/lib/modules/eic_messages/src/Service/MessageBus.php
+++ b/lib/modules/eic_messages/src/Service/MessageBus.php
@@ -3,10 +3,8 @@
 namespace Drupal\eic_messages\Service;
 
 use Drupal\Core\Logger\LoggerChannelTrait;
-use Drupal\Core\State\StateInterface;
 use Drupal\eic_messages\Handler\MessageHandlerInterface;
 use Drupal\eic_messages\Util\QueuedMessageChecker;
-use Drupal\eic_migrate\Commands\MigrateToolsOverrideCommands;
 use Drupal\message\Entity\Message;
 use Drupal\message\MessageInterface;
 use Exception;
@@ -35,20 +33,12 @@ class MessageBus implements MessageBusInterface {
   private $queuedMessageChecker;
 
   /**
-   * @var StateInterface
-   */
-  private $state;
-
-  /**
    * @param \Drupal\eic_messages\Util\QueuedMessageChecker $queued_message_checker
-   * @param StateInterface $state
    */
   public function __construct(
-    QueuedMessageChecker $queued_message_checker,
-    StateInterface $state
+    QueuedMessageChecker $queued_message_checker
   ) {
     $this->queuedMessageChecker = $queued_message_checker;
-    $this->state = $state;
   }
 
   /**
@@ -56,7 +46,7 @@ class MessageBus implements MessageBusInterface {
    */
   public function dispatch($message): void {
     // If we are running migrations, stop saving messages and sending notifications.
-    if ($this->state->get(MigrateToolsOverrideCommands::STATE_MIGRATIONS_IS_RUNNING)) {
+    if (eic_migrate_is_migration_running()) {
       return;
     }
 

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_taxonomy_term_c4m_vocab_tag.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_taxonomy_term_c4m_vocab_tag.yml
@@ -32,8 +32,5 @@ destination:
   plugin: 'entity:taxonomy_term'
   default_bundle: tags
 migration_dependencies:
-  required:
-    - upgrade_d7_node_complete_group
-    - upgrade_d7_node_complete_organisation
-    - upgrade_d7_node_complete_event_site
+  required: { }
   optional: { }

--- a/lib/modules/eic_migrate/eic_migrate.module
+++ b/lib/modules/eic_migrate/eic_migrate.module
@@ -19,7 +19,33 @@ function eic_migrate_entity_type_alter(array &$entity_types) {
  */
 function eic_migrate_mail_alter(&$message) {
   // If we are running migrations, prevent email sending.
-  if (\Drupal::service('state')->get(MigrateToolsOverrideCommands::STATE_MIGRATIONS_IS_RUNNING)) {
+  if (eic_migrate_is_migration_running()) {
     $message['send'] = FALSE;
   }
+}
+
+/**
+ * Determines if we are running the D7 migration.
+ *
+ * @return bool
+ *   TRUE if migration is running, FALSE otherwise.
+ */
+function eic_migrate_is_migration_running() {
+  if (\Drupal::service('state')->get(MigrateToolsOverrideCommands::STATE_MIGRATIONS_IS_RUNNING)) {
+    return TRUE;
+  }
+  return FALSE;
+}
+
+/**
+ * Determines if we are running the D7 message migration.
+ *
+ * @return bool
+ *   TRUE if migration is running, FALSE otherwise.
+ */
+function eic_migrate_is_migration_messages_running() {
+  if (\Drupal::service('state')->get(MigrateToolsOverrideCommands::STATE_MIGRATIONS_MESSAGES_IS_RUNNING)) {
+    return TRUE;
+  }
+  return FALSE;
 }

--- a/lib/modules/eic_migrate/src/Plugin/Validation/Constraint/MigrationRunningMessagesConstraintValidator.php
+++ b/lib/modules/eic_migrate/src/Plugin/Validation/Constraint/MigrationRunningMessagesConstraintValidator.php
@@ -2,10 +2,8 @@
 
 namespace Drupal\eic_migrate\Plugin\Validation\Constraint;
 
-use Drupal\eic_migrate\Commands\MigrateToolsOverrideCommands;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
-
 
 class MigrationRunningMessagesConstraintValidator extends ConstraintValidator {
 
@@ -13,26 +11,23 @@ class MigrationRunningMessagesConstraintValidator extends ConstraintValidator {
    * {@inheritdoc}
    */
   public function validate($entity, Constraint $constraint) {
-    $state = \Drupal::state();
-
     // Constraint only for Message.
     if ('message' !== $entity->getEntityTypeId()) {
       return;
     }
 
     // If no migrations running, just ignore that constraint.
-    if (!$state->get(MigrateToolsOverrideCommands::STATE_MIGRATIONS_IS_RUNNING)) {
+    if (!eic_migrate_is_migration_running()) {
       return;
     }
 
     // If Message migration is running, ignore that constraint.
-    if (
-      $state->get(MigrateToolsOverrideCommands::STATE_MIGRATIONS_MESSAGES_IS_RUNNING)
-    ) {
+    if (eic_migrate_is_migration_messages_running()) {
       return;
     }
 
-    // Add violation when migrations is running and entity tries to generate Message.
+    // Add violation when migrations is running and entity tries to generate
+    // Message.
     $this->context->buildViolation($constraint->migrationRunning)->addViolation();
   }
 


### PR DESCRIPTION
### Improvements

- Introduced a helper function to determine if migration is running
- Splitted default and dummy content into 2 separate modules

### Tests

- [x] Run `drush en eic_default_content`
- [x] Run `drush fixtures:reload all`
- [x] Make sure you have the overviews, menu items (main menu) and default blocks
- [x] Run `drush en eic_dummy_content`
- [x] Run `drush fixtures:reload all`
- [x] Make sure you have the default content + groups/stories/news/taxonomy/users