### PR TITLE
EICNET-1318: Make field_document_type optional for galleries.

### DIFF
--- a/config/sync/field.field.node.gallery.field_document_type.yml
+++ b/config/sync/field.field.node.gallery.field_document_type.yml
@@ -12,7 +12,7 @@ entity_type: node
 bundle: gallery
 label: 'Document type'
 description: ''
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''


### PR DESCRIPTION
### Improvements

- Just made the document type field optional