### PR TITLE
EICNET-191: Handle paragraphs field for Event GT.

### DIFF
--- a/config/sync/core.entity_form_display.group.event.default.yml
+++ b/config/sync/core.entity_form_display.group.event.default.yml
@@ -188,14 +188,15 @@ content:
     settings:
       title: Paragraph
       title_plural: Paragraphs
-      edit_mode: open
+      edit_mode: closed
       closed_mode: summary
       autocollapse: none
       closed_mode_threshold: 0
       add_mode: dropdown
       form_display_mode: default
-      default_paragraph_type: ''
+      default_paragraph_type: full_text_content
       features:
+        add_above: '0'
         collapse_edit_all: collapse_edit_all
         duplicate: duplicate
     third_party_settings: {  }

--- a/lib/modules/eic_events/eic_events.module
+++ b/lib/modules/eic_events/eic_events.module
@@ -5,8 +5,12 @@
  * Primary module hooks for EIC Events module.
  */
 
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\eic_events\Constants\Event;
+use Drupal\eic_events\Hooks\EntityOperations;
 use Drupal\eic_events\Hooks\FormOperations;
 
 /**
@@ -34,4 +38,17 @@ function eic_events_cron() {
 function eic_events_form_group_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   \Drupal::classResolver(FormOperations::class)
     ->formGroupFormAlter($form, $form_state, $form_id);
+}
+
+/**
+ * Implements hook_entity_field_access().
+ */
+function eic_events_entity_field_access(
+  $operation,
+  FieldDefinitionInterface $field_definition,
+  AccountInterface $account,
+  FieldItemListInterface $items = NULL
+) {
+  return \Drupal::classResolver(EntityOperations::class)
+    ->entityFieldAccess($operation, $field_definition, $account, $items);
 }

--- a/lib/modules/eic_events/src/Constants/Event.php
+++ b/lib/modules/eic_events/src/Constants/Event.php
@@ -47,7 +47,17 @@ final class Event {
   const GROUP_EVENT_TYPE_VOCABULARY_NAME = 'global_event_type';
 
   /**
+   * The legacy paragraphs field name.
+   *
+   * @var string
+   */
+  const LEGACY_PARAGRAPHS_FIELD = 'field_additional_content';
+
+  /**
+   * Returns the label for the event state.
+   *
    * @return array
+   *   An array with state as key with translated label as value.
    */
   public static function getStateLabelsMapping(): array {
     return [

--- a/lib/modules/eic_events/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_events/src/Hooks/EntityOperations.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Drupal\eic_events\Hooks;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\eic_events\Constants\Event;
+
+/**
+ * Class EntityOperations.
+ *
+ * Implementations for entity hooks.
+ */
+class EntityOperations {
+
+  use StringTranslationTrait;
+
+  /**
+   * Implements hook_entity_field_access().
+   */
+  public function entityFieldAccess(
+    $operation,
+    FieldDefinitionInterface $field_definition,
+    AccountInterface $account,
+    FieldItemListInterface $items = NULL
+  ) {
+    return $this->handleLegacyParagraphs($operation, $field_definition, $account, $items);
+  }
+
+  /**
+   * Determines access to legacy paragraphs.
+   */
+  protected function handleLegacyParagraphs(
+    $operation,
+    FieldDefinitionInterface $field_definition,
+    AccountInterface $account,
+    FieldItemListInterface $items = NULL
+  ) {
+    $access = AccessResult::neutral();
+
+    // We don't want users to add new paragraphs. Only the ones that were
+    // migrated for legacy reasons can be accessed.
+    if ($operation == 'edit' && $field_definition->getName() === Event::LEGACY_PARAGRAPHS_FIELD) {
+      // If there are no items,we deny access.
+      if ($items->isEmpty()) {
+        return AccessResult::forbidden();
+      }
+      else {
+        return AccessResult::allowed();
+      }
+    }
+
+    return $access;
+  }
+
+}

--- a/lib/modules/eic_events/src/Hooks/FormOperations.php
+++ b/lib/modules/eic_events/src/Hooks/FormOperations.php
@@ -49,6 +49,7 @@ class FormOperations implements ContainerInjectionInterface {
    */
   public function formGroupFormAlter(&$form, FormStateInterface $form_state, $form_id) {
     $this->handleEventTypeField($form, $form_state, $form_id);
+    $this->handleLegacyParagraphs($form, $form_state, $form_id);
   }
 
   /**
@@ -89,6 +90,30 @@ class FormOperations implements ContainerInjectionInterface {
           && !in_array($term->id(), $form['field_vocab_event_type']['widget']['#default_value'])) {
         unset($form['field_vocab_event_type']['widget']['#options'][$term->id()]);
       }
+    }
+  }
+
+  /**
+   * Handles the field_vocab_event_type of the form.
+   *
+   * @param array $form
+   *   The form array.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state object.
+   * @param string $form_id
+   *   The form ID.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  protected function handleLegacyParagraphs(array &$form, FormStateInterface $form_state, string $form_id) {
+    if (!isset($form[Event::LEGACY_PARAGRAPHS_FIELD])) {
+      return;
+    }
+
+    // We don't want users to create new paragraphs.
+    if (isset($form[Event::LEGACY_PARAGRAPHS_FIELD]['widget']['add_more'])) {
+      unset($form[Event::LEGACY_PARAGRAPHS_FIELD]['widget']['add_more']);
     }
   }
 


### PR DESCRIPTION
### Tests

- [x] Create a new Event GT
- [x] Make sure there is no field **Additional content** field with paragraphs
- [x] Edit the event and make sure the field is not there
- [x] Edit the migrated event `/events/eic-innovators-summit/edit`
- [x] Make sure the field is there and you can edit/move/delete paragraphs
- [x] Make sure you cannot create new paragraphs