### PR TITLE
EICNET-2423: Wrong User picture in tagged-comment email

### DIFF
--- a/config/sync/core.entity_view_display.message.notify_user_tagged_on_comment.mail_body.yml
+++ b/config/sync/core.entity_view_display.message.notify_user_tagged_on_comment.mail_body.yml
@@ -1,6 +1,6 @@
 uuid: 82e92d36-95a2-4837-8f74-e2cefb2fa796
 langcode: en
-status: false
+status: true
 dependencies:
   config:
     - core.entity_view_mode.message.mail_body
@@ -15,6 +15,8 @@ bundle: notify_user_tagged_on_comment
 mode: mail_body
 content:
   partial_1:
+    settings: {  }
+    third_party_settings: {  }
     weight: 0
     region: content
 hidden:

--- a/config/sync/core.entity_view_display.message.notify_user_tagged_on_comment.mail_subject.yml
+++ b/config/sync/core.entity_view_display.message.notify_user_tagged_on_comment.mail_subject.yml
@@ -1,6 +1,6 @@
 uuid: 47d2ec9e-93a2-4ea5-b5cd-91b420aa4ddb
 langcode: en
-status: false
+status: true
 dependencies:
   config:
     - core.entity_view_mode.message.mail_subject

--- a/lib/themes/eic_community/templates/content/comment--notification-teaser.html.twig
+++ b/lib/themes/eic_community/templates/content/comment--notification-teaser.html.twig
@@ -47,11 +47,7 @@
                                                             <tbody>
                                                               <tr>
                                                                 <td style="width:48px;">
-<<<<<<< HEAD
-                                                                  <img src="{{ comment.author.image.src }}" style="object-fit: cover; border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" height="48" width="48">
-=======
                                                                   <img height="auto" src="{{ comment.author.image.src }}" style="border-radius:60px; border:0;display:block;outline:none;text-decoration:none;height:auto;width:48px;font-size:13px;" width="48">
->>>>>>> 79f86890a29f2f717fcbf38d5645226300ed8589
                                                                 </td>
                                                               </tr>
                                                             </tbody>
@@ -74,7 +70,7 @@
                                               <tr>
                                                 <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
                                                   <div style="font-family:Arial;font-size:14px;line-height:1.4;text-align:left;color:#707070;">
-                                                    {{ comment.comment }}
+                                                    {{ comment.comment|raw }}
                                                     {% if comment.tagged_users is defined %}
                                                       <br><br>With:
                                                       {% for user in comment.tagged_users %}


### PR DESCRIPTION
### Fixes 

- Fix email template for user tagged on comment notifications.

### Test

- [ ] Go to a discussion detail
- [ ] Add a comment and apply some styles (bold, underline, italic and a link) and tag multiple users
- [ ] Run cron
- [ ] Make sure all the tagged users get an email and make sure the user image has the correct dimensions as the comment text is shown as html and not as plain text