### PR TITLE
EICNET-2294: Fix wrong destiniation field name.

### DIFF
--- a/config/sync/migrate_plus.migration.upgrade_d7_node_complete_event.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_node_complete_event.yml
@@ -73,14 +73,14 @@ process:
       map:
         - draft
         - published
-  field_body/0/format:
+  body/0/format:
     -
       plugin: callback
       source: c4m_body/0/format
       callable:
         - \Drupal\eic_migrate\Constants\Misc
         - getTextFormat
-  field_body/0/value:
+  body/0/value:
     -
       plugin: eic_html_sanitizer
       source: c4m_body/0/value

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_event.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_event.yml
@@ -65,13 +65,13 @@ process:
       map:
         0: draft
         1: published
-  field_body/0/format:
+  body/0/format:
     - plugin: callback
       source: c4m_body/0/format
       callable:
         - '\Drupal\eic_migrate\Constants\Misc'
         - getTextFormat
-  field_body/0/value:
+  body/0/value:
     - plugin: eic_html_sanitizer
       source: c4m_body/0/value
     - plugin: eic_media_wysiwyg_filter


### PR DESCRIPTION
### Fixes

- Event CT is using body field unlike the other CTs, as a quick fix I fixed the destination field

### Tests

- [x] Run `drush mr upgrade_d7_node_complete_event`
- [x] Run `drush mim upgrade_d7_node_complete_event`
- [x] Go to `/events/eic-forum-wg-eic-prizes-alumni-network-kick-meeting/edit`
- [x] Make sure you have the body (Description) field with value (in this case it's a big table)