### PR TITLE
EICNET-2458: Fix empty avatar state in the latest activity stream.

### DIFF
--- a/lib/modules/eic_groups/templates/eic-group-last-activities-members.html.twig
+++ b/lib/modules/eic_groups/templates/eic-group-last-activities-members.html.twig
@@ -66,9 +66,18 @@
                                   {% else %}
                                     <div class="ecl-author__media-wrapper">
                                   {% endif %}
-                                    <figure class="ecl-media-container ecl-author__media"><img
-                                        alt="Avatar image of {{ member.full_name }}" class="ecl-media-container__media"
-                                        src="{{ member.picture }}"></figure>
+                                    <figure class="ecl-media-container ecl-author__media">
+                                      {% if member.picture %}
+                                        <img
+                                          alt="Avatar image of {{ member.full_name }}" class="ecl-media-container__media"
+                                          src="{{ member.picture }}">
+                                      {% else %}
+                                        <svg class="ecl-icon ecl-icon--xs ecl-author-action__icon" focusable="false"
+                                          aria-hidden="true">
+                                          <use xlink:href="/themes/custom/eic_community/dist/images/sprite/custom/sprites/custom.svg#custom--user"></use>
+                                        </svg>
+                                      {% endif %}
+                                    </figure>
                                   {% if member.url %}
                                     </a>
                                   {% else %}

--- a/lib/modules/eic_search/src/Plugin/Block/ActivityStreamBlock.php
+++ b/lib/modules/eic_search/src/Plugin/Block/ActivityStreamBlock.php
@@ -5,6 +5,7 @@ namespace Drupal\eic_search\Plugin\Block;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Block\Annotation\Block;
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Datetime\DateFormatter;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\File\FileUrlGeneratorInterface;
@@ -211,10 +212,27 @@ class ActivityStreamBlock extends BlockBase implements ContainerFactoryPluginInt
       'node_statistics_url' => Url::fromRoute('eic_statistics.get_node_statistics')->toString(),
     ];
 
+    $cache = [
+      'contexts' => [
+        'url.path',
+        'url.query_args',
+      ],
+    ];
+
+    // Send members data and cache tags.
+    $members = [];
+    if ($show_members) {
+      $members = $this->getMembersData($group);
+      $cache['tags'] = [];
+      foreach ($members as $member) {
+        $cache['tags'] = Cache::mergeTags($member['cache_tags'], $member['cache_tags']);
+      }
+    }
+
     return $build += [
       '#theme' => 'eic_group_last_activities_members',
-      '#cache' => ['contexts' => ['url.path', 'url.query_args']],
-      '#members' => $show_members ? $this->getMembersData($group) : [],
+      '#cache' => $cache,
+      '#members' => $members,
       '#url' => Url::fromRoute('eic_search.solr_search', [], $url_options)->toString(),
       '#translations' => [
         'no_results_title' => $this->t('We haven’t found any search results', [], ['context' => 'eic_group']),
@@ -310,6 +328,8 @@ class ActivityStreamBlock extends BlockBase implements ContainerFactoryPluginInt
         'picture' => $file_url,
         'url' => $user_profile_url,
         'organisations' => $organisations,
+        'uid' => $user->id(),
+        'cache_tags' => $user->getCacheTags(),
       ];
     }, $members);
   }


### PR DESCRIPTION
### Improvements

- Fix empty avatar state in the latest activity stream.

### Test

- [ ] View the latest activity stream of a group
- [ ] Make sure the empty avatar picture is shown for members without a picture in the sidebar.

![image](https://user-images.githubusercontent.com/9576940/173572201-111e17fd-b2d9-4a94-aeea-4873ea800489.png) 