### PR TITLE
EICNET-2285: Rebuild group permission resets Joining method

### DIFF
--- a/lib/modules/eic_admin/src/Form/UpdateAllGroupPermissionsForm.php
+++ b/lib/modules/eic_admin/src/Form/UpdateAllGroupPermissionsForm.php
@@ -3,15 +3,23 @@
 namespace Drupal\eic_admin\Form;
 
 use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Component\Plugin\Exception\PluginException;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\eic_content\Plugin\Field\FieldWidget\EntityTreeWidget;
+use Drupal\eic_groups\Constants\GroupJoiningMethodType;
+use Drupal\eic_user\UserHelper;
 use Drupal\group\Entity\Group;
 use Drupal\group\Entity\GroupInterface;
 use Drupal\group\Entity\GroupType;
+use Drupal\group\GroupRoleSynchronizer;
+use Drupal\group_flex\GroupFlexGroupSaver;
 use Drupal\group_permissions\GroupPermissionsManagerInterface;
+use Drupal\oec_group_features\GroupFeatureHelper;
+use Drupal\oec_group_features\GroupFeaturePluginManager;
+use Drupal\oec_group_flex\OECGroupFlexHelper;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class UpdateAllGroupPermissionsForm extends FormBase {
@@ -38,6 +46,41 @@ class UpdateAllGroupPermissionsForm extends FormBase {
   private TimeInterface $datetime;
 
   /**
+   * The Group flex saver service.
+   *
+   * @var \Drupal\group_flex\GroupFlexGroupSaver
+   */
+  protected $groupFlexSaver;
+
+  /**
+   * The OEC group flex helper service.
+   *
+   * @var \Drupal\oec_group_flex\OECGroupFlexHelper
+   */
+  protected $oecGroupFlexHelper;
+
+  /**
+   * The group role synchronizer.
+   *
+   * @var \Drupal\group\GroupRoleSynchronizer
+   */
+  protected $groupRoleSynchronizer;
+
+  /**
+   * The OEC group feature helper service.
+   *
+   * @var \Drupal\oec_group_features\GroupFeatureHelper
+   */
+  protected $groupFeatureHelper;
+
+  /**
+   * The Group feature plugin manager.
+   *
+   * @var \Drupal\oec_group_features\GroupFeaturePluginManager
+   */
+  protected $groupFeaturePluginManager;
+
+  /**
    * UpdateAllGroupPermissionsForm constructor.
    *
    * @param EntityTypeManagerInterface $em
@@ -46,15 +89,35 @@ class UpdateAllGroupPermissionsForm extends FormBase {
    *   The group permission manager.
    * @param TimeInterface $datetime
    *   The datetime time service.
+   * @param \Drupal\group_flex\GroupFlexGroupSaver $group_flex_saver
+   *   The Group flex saver service.
+   * @param \Drupal\oec_group_flex\OECGroupFlexHelper $group_flex_saver
+   *   The OEC group flex helper service.
+   * @param \Drupal\group\GroupRoleSynchronizer $groupRoleSynchronizer
+   *   The group role synchronizer.
+   * @param \Drupal\oec_group_features\GroupFeatureHelper $oec_group_features_helper
+   *   The OEC group feature helper service.
+   * @param \Drupal\oec_group_features\GroupFeaturePluginManager $group_feature_plugin_manager
+   *   The Group feature plugin manager.
    */
   public function __construct(
     EntityTypeManagerInterface $em,
     GroupPermissionsManagerInterface $permissions_manager,
-    TimeInterface $datetime
+    TimeInterface $datetime,
+    GroupFlexGroupSaver $group_flex_saver,
+    OECGroupFlexHelper $oec_group_flex_helper,
+    GroupRoleSynchronizer $group_role_synchronizer,
+    GroupFeatureHelper $oec_group_features_helper,
+    GroupFeaturePluginManager $group_feature_plugin_manager
   ) {
     $this->em = $em;
     $this->permissionsManager = $permissions_manager;
     $this->datetime = $datetime;
+    $this->groupFlexSaver = $group_flex_saver;
+    $this->oecGroupFlexHelper = $oec_group_flex_helper;
+    $this->groupRoleSynchronizer = $group_role_synchronizer;
+    $this->groupFeatureHelper = $oec_group_features_helper;
+    $this->groupFeaturePluginManager = $group_feature_plugin_manager;
   }
 
   /**
@@ -64,7 +127,12 @@ class UpdateAllGroupPermissionsForm extends FormBase {
     return new static(
       $container->get('entity_type.manager'),
       $container->get('group_permission.group_permissions_manager'),
-      $container->get('datetime.time')
+      $container->get('datetime.time'),
+      $container->get('group_flex.group_saver'),
+      $container->get('oec_group_flex.helper'),
+      $container->get('group_role.synchronizer'),
+      $container->get('oec_group_features.helper'),
+      $container->get('plugin.manager.group_feature')
     );
   }
 
@@ -160,11 +228,32 @@ class UpdateAllGroupPermissionsForm extends FormBase {
         continue;
       }
 
+      $tuGroupRoleId = $this->groupRoleSynchronizer->getGroupRoleId($group_type->id(), UserHelper::ROLE_TRUSTED_USER);
+
+      // Default joining method.
+      $group_joining_method = [
+        GroupJoiningMethodType::GROUP_JOINING_METHOD_TU_OPEN => GroupJoiningMethodType::GROUP_JOINING_METHOD_TU_OPEN
+      ];
+
       $permissions = $groupPermissions->getPermissions();
       foreach ($type_roles as $type_role) {
+        // Sets joining method depending on the permissions for Trusted users.
+        if ($type_role->id() === $tuGroupRoleId) {
+          if (in_array('join group', $permissions[$tuGroupRoleId])) {
+            $group_joining_method = [
+              GroupJoiningMethodType::GROUP_JOINING_METHOD_TU_OPEN => GroupJoiningMethodType::GROUP_JOINING_METHOD_TU_OPEN
+            ];
+          }
+          elseif (in_array('request group membership', $permissions[$tuGroupRoleId])) {
+            $group_joining_method = [
+              GroupJoiningMethodType::GROUP_JOINING_METHOD_TU_MEMBERSHIP_REQUEST => GroupJoiningMethodType::GROUP_JOINING_METHOD_TU_MEMBERSHIP_REQUEST
+            ];
+          }
+        }
         $permissions[$type_role->id()] = $type_role->getPermissions();
       }
 
+      // Updates permissions based on the group type permissions.
       $groupPermissions->setPermissions($permissions);
 
       $violations = $groupPermissions->validate();
@@ -184,6 +273,48 @@ class UpdateAllGroupPermissionsForm extends FormBase {
       $groupPermissions->setRevisionCreationTime($this->datetime->getRequestTime());
       $groupPermissions->setRevisionLogMessage('Group features enabled/disabled.');
       $groupPermissions->save();
+
+      $group_visibility = $this->oecGroupFlexHelper->getGroupVisibilitySettings($group);
+      // Saves group visibility.
+      $this->groupFlexSaver->saveGroupVisibility(
+        $group,
+        $group_visibility['plugin_id'],
+        !empty($group_visibility['settings']) ? $group_visibility['settings'] : []
+      );
+
+      // Saves group joining methods.
+      $this->groupFlexSaver->saveGroupJoiningMethods(
+        $group,
+        $group_joining_method
+      );
+
+      // Get all available features for this group type.
+      $available_features = [];
+      foreach ($this->groupFeatureHelper->getGroupTypeAvailableFeatures($group->getGroupType()->id()) as $plugin_id => $label) {
+        try {
+          $available_features[$plugin_id] = $this->groupFeaturePluginManager->createInstance($plugin_id);
+        }
+        catch (PluginException $e) {
+          $logger = $this->getLogger('oec_group_features');
+          $logger->error($e->getMessage());
+        }
+      }
+
+      // Get group enabled features.
+      $enabled_features = [];
+      foreach ($group->get(GroupFeatureHelper::FEATURES_FIELD_NAME)->getValue() as $feature) {
+        $enabled_features[$feature['value']] = $feature['value'];
+      }
+
+      // Enable features that are selected for this group.
+      foreach (array_intersect_key($available_features, $enabled_features) as $feature_key => $enabled_feature) {
+        $available_features[$feature_key]->enable($group);
+      }
+
+      // Disable features that are not selected for this group.
+      foreach (array_diff_key($available_features, $enabled_features) as $feature_key => $disabled_feature) {
+        $available_features[$feature_key]->disable($group);
+      }
 
       $this->messenger()->addMessage(
         $this->t(

--- a/lib/modules/eic_admin/src/Form/UpdateAllGroupPermissionsForm.php
+++ b/lib/modules/eic_admin/src/Form/UpdateAllGroupPermissionsForm.php
@@ -145,7 +145,7 @@ class UpdateAllGroupPermissionsForm extends FormBase {
       $container->get('group_role.synchronizer'),
       $container->get('oec_group_features.helper'),
       $container->get('plugin.manager.group_feature'),
-      $container->get('group_flex.group_saver')
+      $container->get('group_flex.group_type')
     );
   }
 


### PR DESCRIPTION
### Fixes

- Save group joining methods + visibility + group feature permissions when executing group permissions rebuild process.

### Test

- [x] Go to `/groups/rebuild-permissions` and rebuild permissions for a group
- [x] Make sure the group visibility + joining methods + group features are kept