### PR TITLE
EICNET-191: Allow HTML in full_text_content paragaph body.

### DIFF
--- a/config/sync/core.entity_view_display.paragraph.full_text_content.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.full_text_content.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.paragraph.full_text_content.field_title
     - paragraphs.paragraphs_type.full_text_content
   module:
+    - text
     - typed_link
 id: paragraph.full_text_content.default
 targetEntityType: paragraph
@@ -15,7 +16,7 @@ bundle: full_text_content
 mode: default
 content:
   field_body:
-    type: basic_string
+    type: text_default
     label: hidden
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/field.field.paragraph.full_text_content.field_body.yml
+++ b/config/sync/field.field.paragraph.full_text_content.field_body.yml
@@ -5,6 +5,8 @@ dependencies:
   config:
     - field.storage.paragraph.field_body
     - paragraphs.paragraphs_type.full_text_content
+  module:
+    - text
 id: paragraph.full_text_content.field_body
 field_name: field_body
 entity_type: paragraph
@@ -16,4 +18,4 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }
-field_type: string_long
+field_type: text_long

--- a/lib/themes/eic_community/includes/preprocess/events.inc
+++ b/lib/themes/eic_community/includes/preprocess/events.inc
@@ -41,8 +41,7 @@ function _eic_community_render_event_detail_page(array &$variables, EntityInterf
   _eic_community_display_topics($variables);
 
   // We show flags only for node, group already have it in the group header.
-  if (!$entity instanceof GroupInterface)
-  {
+  if (!$entity instanceof GroupInterface) {
     _eic_community_display_flags($variables);
   }
 
@@ -66,6 +65,16 @@ function _eic_community_render_event_detail_page(array &$variables, EntityInterf
     $existing_tags = $variables['#cache']['tags'] ?? [];
     $variables['#cache']['tags'] = array_merge($existing_tags, $group->getCacheTags());
   }
+
+  // Append paragraphs to the body. These paragraphs are legacy content coming
+  // from the migration.
+  $full_body = $entity->field_body->value;
+  if ($entity->getEntityTypeId() == 'group' && $entity->hasField('field_additional_content')) {
+    $view_builder = \Drupal::entityTypeManager()->getViewBuilder($entity_type);
+    $additional_content = $view_builder->viewField($entity->field_additional_content);
+    $full_body .= \Drupal::service('renderer')->render($additional_content);
+  }
+  $variables['full_body'] = $full_body;
 
   if ($entity->bundle() !== 'event') {
     return;

--- a/lib/themes/eic_community/includes/preprocess/paragraphs/paragraph--full-text-content.inc
+++ b/lib/themes/eic_community/includes/preprocess/paragraphs/paragraph--full-text-content.inc
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @file
+ * Prepares variables for paragraph full text content template.
+ */
+
+/**
+ * Implements hook_preprocess_paragraph() for full_text_content paragraph.
+ */
+function eic_community_preprocess_paragraph__full_text_content(array &$variables) {
+  /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
+  $paragraph = $variables['paragraph'];
+
+  switch ($paragraph->getParentEntity()->getEntityTypeId()) {
+    case 'group':
+      $container_classes = '';
+      break;
+
+    default:
+      $container_classes = 'ecl-container';
+      break;
+  }
+  $variables['container_classes'] = $container_classes;
+}

--- a/lib/themes/eic_community/patterns/compositions/text-block.html.twig
+++ b/lib/themes/eic_community/patterns/compositions/text-block.html.twig
@@ -1,7 +1,7 @@
 {% set title_element = title_element|default('h2') %}
 
 <div class="ecl-text-block {{ extra_classes }}">
-  <div class="ecl-container">
+  <div class="{{ container_classes }}">
     <div class="ecl-text-block__wrapper">
       <section class="ecl-text-block__content">
         {% if title is not empty %}

--- a/lib/themes/eic_community/templates/group/group--event--full.html.twig
+++ b/lib/themes/eic_community/templates/group/group--event--full.html.twig
@@ -2,7 +2,7 @@
   {% embed "@theme/patterns/compositions/editorial-article.html.twig" with editorial_article|default({}) %}
     {% block content %}
       {% include "@theme/patterns/components/event.html.twig" with {
-        body: group.field_body.value|raw
+        body: full_body
       } %}
       {% include "@theme/patterns/components/filelist.html.twig" with file_list|default({}) %}
     {% endblock %}

--- a/lib/themes/eic_community/templates/paragraphs/paragraph--full-text-content.html.twig
+++ b/lib/themes/eic_community/templates/paragraphs/paragraph--full-text-content.html.twig
@@ -25,4 +25,5 @@
     call_to_action: _call_to_action,
   }],
   extra_classes: 'ecl-section-wrapper',
+  container_classes: container_classes,
 }) only %}


### PR DESCRIPTION
### Tests

- [x] Go to `/events/eic-innovators-summit/edit`
- [x] Check that you have 3 paragraps with an HTML body
- [x] Go to `/events/eic-innovators-summit`
- [x] Check that the paragraphs are displayed after the body