### PR TITLE
EICNET-1320: Node 'Story' migration (improvements phase 3)

### DIFF
--- a/lib/modules/eic_migrate/src/EventSubscriber/PostMigrationSubscriber.php
+++ b/lib/modules/eic_migrate/src/EventSubscriber/PostMigrationSubscriber.php
@@ -176,6 +176,8 @@ class PostMigrationSubscriber implements EventSubscriberInterface {
 
         // Load the migrated group.
         if ($group = $this->entityTypeManager->getStorage('group')->load($gid)) {
+          // We enable syncing to avoid creating new revisions.
+          $group->setSyncing(TRUE);
           $this->setGroupVisibility($group, $event);
           $this->setGroupJoiningMethod($group, $event);
           $this->setGroupFeatures($group, $event);
@@ -442,7 +444,7 @@ class PostMigrationSubscriber implements EventSubscriberInterface {
     // Set the values for each row.
     foreach ($node_values as $parent_id => $items) {
       if ($group = $this->entityTypeManager->getStorage('group')->loadRevision($parent_id)) {
-        $this->updateEntityReferenceValue($group, 'field_related_groups', $items);
+        $this->updateEntityReferenceValue($group, 'field_related_groups', $items, FALSE);
       }
     }
   }
@@ -489,7 +491,7 @@ class PostMigrationSubscriber implements EventSubscriberInterface {
     // Set the values for each row.
     foreach ($node_values as $parent_nid => $items) {
       if ($node = $this->entityTypeManager->getStorage('node')->loadRevision($parent_nid)) {
-        $this->updateEntityReferenceValue($node, 'field_related_stories', $items);
+        $this->updateEntityReferenceValue($node, 'field_related_stories', $items, FALSE);
       }
     }
   }
@@ -528,16 +530,11 @@ class PostMigrationSubscriber implements EventSubscriberInterface {
         $result['parent_language'],
       ];
       $migrated_row = $migration->getIdMap()->getRowBySource($source_ids);
-      $parent_migrated_row = $migration->getIdMap()->getRowBySource($parent_source_ids);
       $parent_migrated_row = $this->migrateLookup->lookup(
         [
           'upgrade_d7_node_complete_article',
         ],
-        [
-          $result['entity_id'],
-          $result['parent_vid'],
-          $result['parent_language'],
-        ]
+        $parent_source_ids
       );
 
       if (empty($migrated_row) || empty($parent_migrated_row)) {
@@ -551,7 +548,7 @@ class PostMigrationSubscriber implements EventSubscriberInterface {
     // Set the values for each row.
     foreach ($node_values as $parent_id => $items) {
       if ($node = $this->entityTypeManager->getStorage('node')->loadRevision($parent_id)) {
-        $this->updateEntityReferenceValue($node, 'field_related_groups', $items);
+        $this->updateEntityReferenceValue($node, 'field_related_groups', $items, FALSE);
       }
       $related_story_node_ids[$node->id()] = $node->id();
     }


### PR DESCRIPTION
### Fixes

- Enable entity syncronization when saving group visibility + joining methods + features during migration;
- Don't preserve relationships when updating field_related_stories and field_related_groups to avoid duplicated references.

### Test

- [x] Run `drush mr upgrade_d7_node_complete_group`
- [x] Run `drush mim upgrade_d7_node_complete_group`
- [x] Go to -> /stories/open-call-introduce-new-digital-solutions-pharma-supply-chain/edit and make sure the fields related stories and related groups were correctly migrated. Compare it with D7 https://eic.accp.eismea.eu/community7/articles/open-call-introduce-new-digital-solutions-pharma-supply-chain.
- [x] Go to -> /groups/ict4water-actor-awareness-water-digital/edit and make sure the field related groups was correctly migrated. Compare it with D7 https://eic.accp.eismea.eu/community7/ict4water---actor-awareness-water-digital-aw-/node/10912/edit