### PR TITLE
EICNET-2228: As TU I cannot reply on certain comments

### DIFF
--- a/lib/modules/eic_groups/src/Controller/DiscussionController.php
+++ b/lib/modules/eic_groups/src/Controller/DiscussionController.php
@@ -623,8 +623,8 @@ class DiscussionController extends ControllerBase {
       'edited_time' => $edited_time ?
         $this->t('Edited on @time', ['@time' => $edited_time ?: $created_time], ['context' => 'eic_groups']) :
         NULL,
-      'is_soft_delete' => $soft_deleted,
-      'is_archived' => $archived,
+      'is_soft_delete' => $soft_deleted ?? 0,
+      'is_archived' => $archived ?? 0,
       'created_time' => $this->t(
         'Created on @time',
         ['@time' => $created_time],


### PR DESCRIPTION
### Fixes

- Fix default value for commet.is_soft_delete and comment is_archived values sent to react.

### Test

- [ ] Import DB from QA
- [ ] Go to `/groups/edegem-v2/discussions/discussion-test-comments`
- [ ] Check if some of the old comments can still be replied

Before:

- ![image](https://user-images.githubusercontent.com/9576940/174643058-66901014-ce72-4fa8-9f0a-3f730e6fc529.png)

After::

- ![image](https://user-images.githubusercontent.com/9576940/174642987-6a776fb6-ac01-4f53-ae8b-7be09d4f7e85.png)