### PR TITLE
EICNET-900: Recommend content (improvements)

### DIFF
--- a/lib/modules/eic_recommend_content/eic_recommend_content.routing.yml
+++ b/lib/modules/eic_recommend_content/eic_recommend_content.routing.yml
@@ -3,7 +3,7 @@ eic_recommend_content.recommend:
   methods: [ POST ]
   defaults:
     _controller: 'Drupal\eic_recommend_content\Controller\RecommendContentController::recommend'
-    _title: 'Recommend group'
+    _title: 'Recommend'
   requirements:
     _eic_recommend_content_access_check: 'TRUE'
     entity_type: '[a-z0-9_]+'

--- a/lib/modules/eic_recommend_content/src/Services/RecommendContentManager.php
+++ b/lib/modules/eic_recommend_content/src/Services/RecommendContentManager.php
@@ -148,14 +148,6 @@ class RecommendContentManager {
       $flag_counter[$flag->id()] = 0;
     }
 
-    $link_label = $this->t(
-      'Recommend @entity_type (@count)',
-      [
-        '@entity_type' => $entity->getEntityTypeId(),
-        '@count' => $flag_counter[$flag->id()],
-      ]
-    );
-
     $user_url = Url::fromRoute('eic_search.solr_search', [
       'datasource' => json_encode(['user']),
       'source_class' => UserRecommendSourceType::class,
@@ -177,7 +169,6 @@ class RecommendContentManager {
           $get_users_url_parameters['current_group'] = $group->id();
           $can_recommend_external_users = $this->canRecommendExternalUsers($group);
         }
-        $link_label = $this->t('Recommend content (@count)', ['@count' => $flag_counter[$flag->id()]]);
         break;
 
       case 'group':
@@ -191,7 +182,7 @@ class RecommendContentManager {
 
     }
 
-    return $endpoint_url ? [
+    return ($endpoint_url && $can_recommend) ? [
       '#theme' => 'eic_recommend_content_link',
       '#entity_type' => $entity->getEntityTypeId(),
       '#entity_id' => $entity->id(),
@@ -199,7 +190,7 @@ class RecommendContentManager {
       '#can_recommend' => $can_recommend,
       '#can_recommend_external_users' => $can_recommend_external_users,
       '#translations' => [
-        'link_label' => $link_label,
+        'link_label' => $this->t('Recommend'),
         'modal_title' => $this->t('Recommend this content'),
         'modal_description' => $can_recommend_external_users ?
           $this->t('Select exisiting members or people outside of the platform you wish to recommend this content to. Those will be presented to you as long as they have the permission to view the content you want to share.') :

--- a/lib/modules/eic_recommend_content/templates/eic-recommend-content-link.html.twig
+++ b/lib/modules/eic_recommend_content/templates/eic-recommend-content-link.html.twig
@@ -6,7 +6,7 @@
   data-can-recommend="{{ can_recommend }}"
   data-can-recommend-external-users="{{ can_recommend_external_users }}"
   data-endpoint="{{ endpoint }}"
-  data-label={{translations.link_label}}
+  data-label="{{ translations.link_label }}"
   data-tree-widget-settings="{{ tree_settings | json_encode }}"
   data-tree-widget-translations="{{ tree_translations | json_encode }}"
   data-modal-title="{{ translations.modal_title }}"

--- a/lib/themes/eic_community/includes/preprocess/blocks/block--eic-group-header-block.inc
+++ b/lib/themes/eic_community/includes/preprocess/blocks/block--eic-group-header-block.inc
@@ -5,6 +5,7 @@
  * Contains implementation for hook_preprocess_block() for eic_group_header.
  */
 
+use Drupal\Core\Link;
 use Drupal\Core\Url;
 use Drupal\eic_community\ValueObject\ImageValueObject;
 use Drupal\eic_groups\Constants\GroupVisibilityType;
@@ -12,6 +13,7 @@ use Drupal\eic_groups\GroupsModerationHelper;
 use Drupal\eic_overviews\GlobalOverviewPages;
 use Drupal\eic_search\SearchHelper;
 use Drupal\oec_group_flex\GroupVisibilityRecordInterface;
+use Drupal\taxonomy\Entity\Term;
 
 /**
  * Implements hook_preprocess_eic_group_header_block().
@@ -193,6 +195,12 @@ function eic_community_preprocess_eic_group_header_block(array &$variables) {
       }
     }
 
+    // We set the recommend flag in the 2nd position.
+    if ($name === 'recommend_content') {
+      $flags[1] = $flag;
+      continue;
+    }
+
     $flags[] = $flag;
   }
 
@@ -249,9 +257,10 @@ function eic_community_preprocess_eic_group_header_block(array &$variables) {
         'id' => strtolower($visibility),
       ];
       break;
+
     case 'organisation':
       $types = $group->get('field_organisation_type')->referencedEntities();
-      $tags = array_map(function (\Drupal\taxonomy\Entity\Term $type) {
+      $tags = array_map(function (Term $type) {
         $filters = [
           'sm_group_organisation_type_string' => $type->label(),
         ];
@@ -261,7 +270,7 @@ function eic_community_preprocess_eic_group_header_block(array &$variables) {
         ];
 
         $overview_page = GlobalOverviewPages::getGlobalOverviewPageLink(GlobalOverviewPages::ORGANISATIONS);
-        $url = $overview_page instanceof \Drupal\Core\Link ? $overview_page->getUrl() : NULL;
+        $url = $overview_page instanceof Link ? $overview_page->getUrl() : NULL;
         $url = $url instanceof Url ? $url->setOptions($query_options) : NULL;
 
         return [
@@ -271,6 +280,7 @@ function eic_community_preprocess_eic_group_header_block(array &$variables) {
         ];
       }, $types);
       break;
+
   }
 
   if ($group->get('moderation_state')->value !== GroupsModerationHelper::GROUP_PUBLISHED_STATE) {
@@ -280,9 +290,11 @@ function eic_community_preprocess_eic_group_header_block(array &$variables) {
       case GroupsModerationHelper::GROUP_BLOCKED_STATE:
         $id = 'private';
         break;
+
       case GroupsModerationHelper::GROUP_PENDING_STATE:
         $id = 'restricted';
         break;
+
     }
 
     $tags[] = [

--- a/lib/themes/eic_community/includes/preprocess/content/node--discussion.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--discussion.inc
@@ -5,6 +5,7 @@
  * Prepares variables for node discussion templates.
  */
 
+use Drupal\Component\Utility\Xss;
 use Drupal\eic_groups\Constants\GroupVisibilityType;
 use Drupal\eic_groups\GroupsModerationHelper;
 use Drupal\group\Entity\GroupInterface;
@@ -72,8 +73,9 @@ function _preprocess_discussion_full(&$variables, $discussion_type, $node) {
     return ['content' => $item];
   }, $flags);
 
+  // Show recommend content flag in the 2nd place.
   if (isset($variables['elements']['recommend_content'])) {
-    $flags['recommend_content'] = $variables['elements']['recommend_content'];
+    array_splice($flags, 2, 0, [$variables['elements']['recommend_content']]);
   }
 
   $group = \Drupal::service('eic_groups.helper')->getGroupFromRoute();
@@ -110,7 +112,7 @@ function _preprocess_discussion_full(&$variables, $discussion_type, $node) {
  */
 function _preprocess_discussion_teaser(&$variables, $discussion_type, $node) {
   $teaser = _eic_community_prepare_node_teaser_array($node);
-  $teaser['description'] = \Drupal\Component\Utility\Xss::filter($node->get('field_body')->value);
+  $teaser['description'] = Xss::filter($node->get('field_body')->value);
   $teaser['type'] = $discussion_type;
 
   // Remove unwanted items.

--- a/lib/themes/eic_community/includes/preprocess/content/node--document.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--document.inc
@@ -101,7 +101,7 @@ function eic_community_preprocess_node__document(array &$variables) {
           'name' => in_array($file_type,
             ['video', 'image']) ? $file_type : 'document_' . _eic_community_get_file_type_icon_name(
               pathinfo($file->getFilename(), PATHINFO_EXTENSION)
-            ),
+          ),
         ],
       ];
 
@@ -166,8 +166,9 @@ function eic_community_preprocess_node__document(array &$variables) {
         ];
       }
 
+      // Show recommend content flag in the 2nd place.
       if (isset($variables['elements']['recommend_content'])) {
-        $variables['editorial_actions']['items'][]['content'] = $variables['elements']['recommend_content']['content'];
+        array_splice($variables['editorial_actions']['items'], 2, 0, [['content' => $variables['elements']['recommend_content']['content']]]);
       }
 
       $group = \Drupal::service('eic_groups.helper')->getGroupFromRoute();

--- a/lib/themes/eic_community/includes/preprocess/content/node--news--story.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--news--story.inc
@@ -126,10 +126,6 @@ function _eic_community_preprocess_node_news_story(array &$variables) {
     // Sidebar elements.
     _eic_community_display_flags($variables);
 
-    if (isset($variables['elements']['recommend_content'])) {
-      $variables['editorial_actions']['items'][]['content'] = $variables['elements']['recommend_content']['content'];
-    }
-
     $group = \Drupal::service('eic_groups.helper')->getGroupFromRoute();
     if (!$group && $node->hasField(PrivateContentConst::FIELD_NAME)
       && !$node->get(PrivateContentConst::FIELD_NAME)->value) {
@@ -226,8 +222,9 @@ function _eic_community_display_flags(&$variables) {
     ];
   }
 
+  // Show recommend content flag in the 2nd place.
   if (isset($variables['elements']['recommend_content'])) {
-    $variables['editorial_actions']['items'][]['content'] = $variables['elements']['recommend_content']['content'];
+    array_splice($variables['editorial_actions']['items'], 2, 0, [['content' => $variables['elements']['recommend_content']['content']]]);
   }
 }
 


### PR DESCRIPTION
### Improvements

- Show recommend flag in the 2nd place for groups and content
- Hide recommend flag when user cannot recommend entity
- Fix issue where recommend flag was shown twice in News and Stories
- Fix issue with recommend flag link text was not printed correctly.

### Test

- [ ] As TU, go to a News or a Story content type and make sure the "Recommend" flag is not shown twice and positioned at the 2nd place in the sidebar flags
- [ ] Go to a public group, and make sure the "Recommend" flag is positioned at the 2nd place in the group header
- [ ] Go to any content of a public group (discussion, document, video, gallery, etc.), and make sure the "Recommend" flag is positioned at the 2nd place in the sidebar
- [ ] As DA, go to `/admin/config/regional/translate`, search for "Recommend" and make sure you can translate the "Recommend" text that is used for the flag label