### PR TITLE
[EICNET-1743]chore: Include group & group_content within message purge settings

### DIFF
--- a/config/sync/message.settings.yml
+++ b/config/sync/message.settings.yml
@@ -2,6 +2,8 @@ _core:
   default_config_hash: _QhkR_LYNacHU4oQybqcZgNge_q1SbQghAjqVBoognE
 delete_on_entity_delete:
   comment: comment
+  group: group
+  group_content: group_content
   node: node
   taxonomy_term: taxonomy_term
   user: user


### PR DESCRIPTION
## To Test

- [x] Create a group & a discussion 
- [x] Delete the group
- [x] Run the cron
- [x] Check that no message should remain within the db targeting the deleted group