### PR TITLE
EICNET-2563: Comment in discussions overview teaser in not rendered as html

### DIFF
--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Discussion/Comment.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Discussion/Comment.js
@@ -50,10 +50,7 @@ const Comment = (props) => {
           </header>
 
           <div className="ecl-comment__main">
-            <div className="ecl-editable-wrapper">
-              {props.comment.text}
-            </div>
-
+            <div className="ecl-editable-wrapper" dangerouslySetInnerHTML={{__html: props.comment.text}} />
           </div>
 
           <footer className="ecl-comment__footer">


### PR DESCRIPTION
### Improvements

- Render discussion comment as html in discussions overview teaser.

### Test

- [x] As TU, go to a group discussions overview
- [x] Make sure the comment body on each discussion teaser is rendered as html instead of plain text