### PR TITLE
[EICNET-2558] feat: add Quill link formatter

### DIFF
--- a/lib/themes/eic_community/react/components/Block/CommentsDiscussion/Partials/components/WysiswigEditor.js
+++ b/lib/themes/eic_community/react/components/Block/CommentsDiscussion/Partials/components/WysiswigEditor.js
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactQuill from 'react-quill';
 import 'react-quill/dist/quill.snow.css'
+import Quill from 'quill'
 
 class WysiswigEditor extends React.Component {
   constructor(props) {
@@ -13,8 +14,21 @@ class WysiswigEditor extends React.Component {
         ['bold', 'italic', 'underline','strike'],
         ['link'],
         ['clean']
-      ],
+      ]
     }
+
+    var Link = Quill.import('formats/link');
+    var builtInFunc = Link.sanitize;
+    Link.sanitize = function customSanitizeLinkInput(linkValueInput) {
+        let val = linkValueInput;
+    
+        // do nothing, since this implies user's already using a custom protocol
+        if (val.indexOf("http://") !== 0 && val.indexOf("https://") !== 0) {
+          val = "https://" + val;
+        }
+
+        return builtInFunc.call(this, val); // retain the built-in logic
+    };
   }
 
   render() {


### PR DESCRIPTION
# How to test:

- [ ] Go to discussion
- [ ] Click on the widget link on the wysiwyg
- [ ] Enter a url without a protocol like `www.google.be`
- [ ] Enter and submit the comment
- [ ] Click on the link, you should be redirected to google.
