### PR TITLE
EICNET-2556: As a user I can create empty comments (Improvements)

### DIFF
--- a/lib/modules/eic_groups/src/Controller/DiscussionController.php
+++ b/lib/modules/eic_groups/src/Controller/DiscussionController.php
@@ -142,6 +142,12 @@ class DiscussionController extends ControllerBase {
     $tagged_users = $content['taggedUsers'] ?? NULL;
     $parent_id = $content['parentId'];
 
+    // User cannot post empty comments and therefore we return bad request
+    // response.
+    if (!$text) {
+      return new JsonResponse('You cannot post empty comments', Response::HTTP_BAD_REQUEST);
+    }
+
     if ($node = Node::load($discussion_id)) {
       Cache::invalidateTags($node->getCacheTags());
     }

--- a/lib/themes/eic_community/react/components/Block/CommentsDiscussion/Partials/Answer.js
+++ b/lib/themes/eic_community/react/components/Block/CommentsDiscussion/Partials/Answer.js
@@ -73,6 +73,7 @@ class Answer extends React.Component {
                   flagComment={this.props.flagComment}
                   updateComment={this.props.updateComment}
                   deleteComment={this.props.deleteComment}
+                  addNotification={this.props.addNotification}
                   comment={child}
                 />
               </header>

--- a/lib/themes/eic_community/react/components/Block/CommentsDiscussion/Partials/CollapseActions.js
+++ b/lib/themes/eic_community/react/components/Block/CommentsDiscussion/Partials/CollapseActions.js
@@ -73,7 +73,7 @@ class CollapseActions extends React.Component {
             {(hasPermission('edit_all_comments') || (hasPermission('edit_own_comments') && this.state.isOwnerComment)) &&
             <div className="ecl-collapsible-options__item">
               <PopupForm title={getTranslation('action_edit_comment')} actionComment={this.props.updateComment}
-                         parentId={this.props.parentId} showTextArea={true} comment={this.props.comment}/>
+                         parentId={this.props.parentId} showTextArea={true} comment={this.props.comment} addNotification={this.props.addNotification}/>
             </div>
             }
 

--- a/lib/themes/eic_community/react/components/Block/CommentsDiscussion/Partials/Popup.js
+++ b/lib/themes/eic_community/react/components/Block/CommentsDiscussion/Partials/Popup.js
@@ -28,6 +28,15 @@ class PopupForm extends React.Component {
   }
 
   submit(e, closeFunction) {
+    e.preventDefault();
+    let textToValidate = this.state.text;
+    // Strip html to correctly check length.
+    textToValidate = textToValidate.replace(/(<([^>]+)>)/gi, "");
+    if (textToValidate.length <= 0) {
+      this.props.addNotification('Comment field is required.', 'danger');
+      return;
+    }
+
     closeFunction();
     this.props.actionComment(
       e,

--- a/lib/themes/eic_community/react/components/Block/CommentsDiscussion/Partials/TopAnswer.js
+++ b/lib/themes/eic_community/react/components/Block/CommentsDiscussion/Partials/TopAnswer.js
@@ -60,6 +60,7 @@ class TopAnswer extends React.Component {
                 flagComment={this.props.flagComment}
                 makeRequest={this.props.makeRequest}
                 updateComment={this.props.updateComment}
+                addNotification={this.props.addNotification}
                 comment={this.props.comment}
               />
             </header>


### PR DESCRIPTION
### Improvements

- Validate empty comment on comment edit form.

### Test

- [x] As DA, go to a discussion with comments
- [x] Try to edit a comment
- [x] Make sure you cannot submit if the comment is empty