### PR TITLE
EICNET-2564: Pending membership requests link is not shown in the group management dropdown

### DIFF
--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
@@ -91,7 +91,7 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
   /**
    * The solr search manager service.
    *
-   * @var SolrSearchManager
+   * @var \Drupal\eic_search\Service\SolrSearchManager
    */
   protected $solrSearchManager;
 
@@ -121,7 +121,7 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
    *   The flag service.
    * @param \Drupal\eic_group_statistics\GroupStatisticsHelperInterface $group_statistics_helper
    *   The group statistics helper service.
-   * @param SolrSearchManager $solr_search_manager
+   * @param \Drupal\eic_search\Service\SolrSearchManager $solr_search_manager
    *   The solr search manager service.
    */
   public function __construct(
@@ -271,12 +271,18 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
       ];
     }
 
+    // Adds pending membership requests URL to the group operation links.
+    $group_operation_links['edit-membership-requests'] = [
+      'title' => $this->t('Membership requests'),
+      'url' => Url::fromRoute('view.group_pending_members.page_1', ['group' => $group->id()]),
+    ];
+
     // We extract only the group edit/delete/publish operation links into a new
     // array.
     $visible_group_operation_links = array_filter($group_operation_links, function ($item, $key) {
       return in_array(
         $key,
-        ['edit', 'delete', 'publish', 'request_block', 'edit-members']
+        ['edit', 'delete', 'publish', 'request_block', 'edit-members', 'edit-membership-requests']
       ) && $item['url']->access();
     }, ARRAY_FILTER_USE_BOTH);
 


### PR DESCRIPTION
### Improvements

- Show pending membership requests link in group management dropdown.

### Test

- [x] As TU (GO), go to a public group with joining methods set to "Open"
- [x] Make sure you cannot see the link "Membership requests" in the group management dropdown
- [x] Edit the group and change the joining method to "Request"
- [x] Make sure you can see the link "Membership requests" in the group management dropdown