### PR TITLE
EICNET-2435: Migrate Flags (Fix regressions)

### DIFF
--- a/lib/modules/eic_flags/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_flags/src/Hooks/EntityOperations.php
@@ -387,7 +387,7 @@ class EntityOperations implements ContainerInjectionInterface {
    */
   public function followEntityOnCreation(EntityInterface $entity) {
     // If we are running migrations, stop flagging entities.
-    if (eic_migrate_is_migration_messages_running()) {
+    if (eic_migrate_is_migration_running()) {
       return;
     }
 
@@ -454,7 +454,7 @@ class EntityOperations implements ContainerInjectionInterface {
    */
   public function followTopicsOnUserProfileUpdate(ProfileInterface $profile) {
     // If we are running migrations, stop flagging entities.
-    if (eic_migrate_is_migration_messages_running()) {
+    if (eic_migrate_is_migration_running()) {
       return;
     }
 

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/src/EventSubscriber/FlagEventSubscriber.php
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/src/EventSubscriber/FlagEventSubscriber.php
@@ -99,7 +99,7 @@ class FlagEventSubscriber implements EventSubscriberInterface {
    *   TRUE if the flag can trigger message subscriptions.
    */
   public function isApplicable(FlagInterface $flag) {
-    if (eic_migrate_is_migration_messages_running()) {
+    if (eic_migrate_is_migration_running()) {
       FALSE;
     }
 


### PR DESCRIPTION
### Improvements

- Fix regression in eic_flags module to prevent entities from being followed during migrations.

### Test

Rollback migrations:

- [ ] drush mr upgrade_d7_flag_follow_group
- [ ] drush mr upgrade_d7_user_membership
- [ ] drush mr upgrade_d7_node_complete_event_site
- [ ] drush mr upgrade_d7_node_complete_group

Migrate groups/events and follow group flags:

- [ ] drush mim upgrade_d7_node_complete_group
- [ ] drush mim upgrade_d7_node_complete_event_site
- [ ] drush mim upgrade_d7_user_membership
- [ ] drush mim upgrade_d7_flag_follow_group

### Compare

Group:

- D7 -> https://eic.accp.eismea.eu/community7/eic-procurers-day-with-ruag-ag-private-group
- D9 -> `/groups/eic-procurers-day-ruag-ag-private-group`

Make sure the group has 11 followers

Event:

- D7 -> https://eic.accp.eismea.eu/community7/eic-ghg-co-creation-peer-to-peer---2nd-cohort
- D9 -> `/events/eic-ghg-co-creation-peer-peer-2nd-cohort`

Make sure the event has 6 followers