### PR TITLE
EICNET-1443: Path redirect migration (improvements)

### DIFF
--- a/config/sync/migrate_plus.migration.upgrade_d7_group_old_path_redirect.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_group_old_path_redirect.yml
@@ -36,6 +36,8 @@ process:
       source: group_id
       migration:
         - upgrade_d7_node_complete_group
+        - upgrade_d7_node_complete_event_site
+        - upgrade_d7_node_complete_organisation
     -
       plugin: node_complete_node_lookup
     -
@@ -76,4 +78,6 @@ destination:
 migration_dependencies:
   required:
     - upgrade_d7_node_complete_group
+    - upgrade_d7_node_complete_event_site
+    - upgrade_d7_node_complete_organisation
   optional: {  }

--- a/config/sync/migrate_plus.migration.upgrade_d7_group_path_redirect.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_group_path_redirect.yml
@@ -36,6 +36,8 @@ process:
       source: group_id
       migration:
         - upgrade_d7_node_complete_group
+        - upgrade_d7_node_complete_event_site
+        - upgrade_d7_node_complete_organisation
     -
       plugin: node_complete_node_lookup
     -
@@ -76,4 +78,6 @@ destination:
 migration_dependencies:
   required:
     - upgrade_d7_node_complete_group
+    - upgrade_d7_node_complete_event_site
+    - upgrade_d7_node_complete_organisation
   optional: {  }

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_group_old_path_redirect.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_group_old_path_redirect.yml
@@ -35,6 +35,8 @@ process:
       source: group_id
       migration:
         - upgrade_d7_node_complete_group
+        - upgrade_d7_node_complete_event_site
+        - upgrade_d7_node_complete_organisation
     -
       plugin: node_complete_node_lookup
     -
@@ -75,4 +77,6 @@ destination:
 migration_dependencies:
   required:
     - upgrade_d7_node_complete_group
+    - upgrade_d7_node_complete_event_site
+    - upgrade_d7_node_complete_organisation
   optional: {  }

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_group_path_redirect.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_group_path_redirect.yml
@@ -31,6 +31,8 @@ process:
       source: group_id
       migration:
         - upgrade_d7_node_complete_group
+        - upgrade_d7_node_complete_event_site
+        - upgrade_d7_node_complete_organisation
     - plugin: node_complete_node_lookup
     - plugin: skip_on_empty
       method: row
@@ -63,4 +65,6 @@ destination:
 migration_dependencies:
   required:
     - upgrade_d7_node_complete_group
+    - upgrade_d7_node_complete_event_site
+    - upgrade_d7_node_complete_organisation
   optional: {  }


### PR DESCRIPTION
### Features

- Include events and organisations in group path redirect migrations.

### Tests

Migrate group redirects:

- [ ] Run `drush mim upgrade_d7_group_path_redirect --update`
- [ ] Run `drush mim upgrade_d7_group_old_path_redirect --update`
- [ ] Try to go to `/eic-ghg-co-creation-peer-to-peer---2nd-cohort` and make sure you get redirected to `/events/eic-ghg-co-creation-peer-peer-2nd-cohort `