### PR TITLE
EICNET-226: Migrate "image" media type (Add default alt text)

### DIFF
--- a/config/sync/migrate_plus.migration.upgrade_d7_file_image_to_media.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_file_image_to_media.yml
@@ -42,8 +42,13 @@ process:
       method: row
   oe_media_image/alt:
     -
-      plugin: get
-      source: field_file_image_alt_text_value
+      plugin: callback
+      source:
+        - filename
+        - field_file_image_alt_text_value
+      callable:
+        - \Drupal\eic_migrate\Constants\Misc
+        - getImageAltText
   oe_media_image/title:
     -
       plugin: get

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_file_image_to_media.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_file_image_to_media.yml
@@ -37,8 +37,13 @@ process:
     - plugin: skip_on_empty
       method: row
   oe_media_image/alt:
-    - plugin: get
-      source: field_file_image_alt_text_value
+    - plugin: callback
+      source:
+        - filename
+        - field_file_image_alt_text_value
+      callable:
+        - \Drupal\eic_migrate\Constants\Misc
+        - getImageAltText
   oe_media_image/title:
     - plugin: get
       source: field_file_image_title_text_value


### PR DESCRIPTION
### Fixes

- Fix migration of alt texts for file images to media migration.

### Test

- [x] Run `drush mim upgrade_d7_file_image_to_media --update`
- [x] Go to `/media/3352/edit` and make sure it has an alt text (the same text as the media name)