### PR TITLE
EICNET-2562: Prevent legacy paragraphs to be silently populated.

### DIFF
--- a/config/sync/core.entity_form_display.group.event.default.yml
+++ b/config/sync/core.entity_form_display.group.event.default.yml
@@ -194,11 +194,11 @@ content:
       closed_mode_threshold: 0
       add_mode: dropdown
       form_display_mode: default
-      default_paragraph_type: full_text_content
+      default_paragraph_type: _none
       features:
         add_above: '0'
         collapse_edit_all: collapse_edit_all
-        duplicate: duplicate
+        duplicate: '0'
     third_party_settings: {  }
   field_body:
     type: text_textarea


### PR DESCRIPTION
### Tests

- [x] Create a global event
- [x] Edit it and make sure you can submit without error message saying the that the paragraph body field is required
- [x] You can also check the entity in devel and make sure that the `field_additional_content` is not populated