### PR TITLE
EICNET-2004: Group creation status banners - published (Fixes)

### DIFF
--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupOverviewMessageBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupOverviewMessageBlock.php
@@ -149,9 +149,8 @@ class EICGroupOverviewMessageBlock extends BlockBase implements ContainerFactory
           '#group' => $group,
           '#edit_link' => $group->toUrl('edit-form')->toString(),
           '#delete_link' => $group->toUrl('delete-form')->toString(),
-          '#invite_link' => Url::fromRoute('entity.group_content.add_form', [
+          '#invite_link' => Url::fromRoute('ginvite.invitation.bulk', [
             'group' => $group->id(),
-            'plugin_id' => 'group_invitation',
           ])->toString(),
           '#has_content' => $has_group_content,
           '#has_member' => count($group->getMembers()) > 1 ? TRUE : FALSE,

--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupOverviewMessageBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupOverviewMessageBlock.php
@@ -154,10 +154,7 @@ class EICGroupOverviewMessageBlock extends BlockBase implements ContainerFactory
             'plugin_id' => 'group_invitation',
           ])->toString(),
           '#has_content' => $has_group_content,
-          '#has_member' => !empty($group->getMembers([
-            EICGroupsHelper::GROUP_ADMINISTRATOR_ROLE,
-            EICGroupsHelper::GROUP_MEMBER_ROLE,
-          ])),
+          '#has_member' => count($group->getMembers()) > 1 ? TRUE : FALSE,
           '#actions' => $content_operations,
           '#help_link' => Url::fromRoute('contact.site_page')->toString(),
         ];


### PR DESCRIPTION
### Fixes

- Show banner for inviting group members until the GO invites a new user.

### Test

- [x] As SA/SCM, create a new group a publish it
- [x] Make sure you see the banner to invite new users to the group
- [x] Invite a user
- [x] Log in with the invited user to accept the invitation
- [x] As SA/SCM, go back to the group and make sure the banner disappeared