### PR TITLE
EICNET-390: Allow video medias in News and Stories documents

### DIFF
--- a/config/sync/field.field.node.news.field_document_media.yml
+++ b/config/sync/field.field.node.news.field_document_media.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.storage.node.field_document_media
     - media.type.eic_document
+    - media.type.video
     - node.type.news
 id: node.news.field_document_media
 field_name: field_document_media
@@ -21,8 +22,10 @@ settings:
   handler_settings:
     target_bundles:
       eic_document: eic_document
+      video: video
     sort:
       field: _none
+      direction: ASC
     auto_create: false
-    auto_create_bundle: ''
+    auto_create_bundle: eic_document
 field_type: entity_reference

--- a/config/sync/field.field.node.story.field_document_media.yml
+++ b/config/sync/field.field.node.story.field_document_media.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.storage.node.field_document_media
     - media.type.eic_document
+    - media.type.video
     - node.type.story
 _core:
   default_config_hash: WDGdsizDGZA0EpSve7quhAGjPd7B8K3vqsRGb-YDptc
@@ -23,8 +24,10 @@ settings:
   handler_settings:
     target_bundles:
       eic_document: eic_document
+      video: video
     sort:
       field: _none
+      direction: ASC
     auto_create: false
-    auto_create_bundle: ''
+    auto_create_bundle: eic_document
 field_type: entity_reference

--- a/lib/themes/eic_community/includes/preprocess/content/node--news--story.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--news--story.inc
@@ -172,14 +172,22 @@ function _eic_community_story_image_field(&$variables) {
  */
 function _eic_community_story_document_field(&$variables) {
   $node = $variables['node'];
+  /** @var \Drupal\media\MediaInterface[] $medias */
   $medias = $node->get('field_document_media')->referencedEntities();
 
   foreach ($medias as $media) {
-    $file = File::load($media->field_media_file->target_id);
+    switch ($media->bundle()) {
+      case 'video':
+        $file = File::load($media->field_media_video_file->target_id);
+        break;
+
+      default:
+        $file = File::load($media->field_media_file->target_id);
+        break;
+    }
+
     $download_url = MediaHelper::formatMediaDownloadLink($media)->toString();
-
     $file_type = strstr($file->get('filemime')->getString(), '/', TRUE);
-
     $variables['downloads'][] = [
       'title' => $media->getName(),
       'language' => $media->language()->getName(),


### PR DESCRIPTION
### Improvements

- Allow video medias to be uploaded into field documents in News and Story CTypes.

### Test

- [x] As SA/SCM, create a story and a news and make sure you can upload video files in "Documents" field