### PR TITLE
EICNET-2066: 

### DIFF
--- a/lib/modules/eic_groups/src/Access/HighlightGroupContentAccessCheck.php
+++ b/lib/modules/eic_groups/src/Access/HighlightGroupContentAccessCheck.php
@@ -4,14 +4,12 @@ namespace Drupal\eic_groups\Access;
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Routing\Access\AccessInterface;
-use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountProxy;
 use Drupal\group\Entity\GroupInterface;
 use Drupal\node\NodeInterface;
-use Drupal\user\Entity\User;
 
 /**
- * Class HighlightGroupContentAccessCheck
+ * Provides an access checker for highlighting group content.
  *
  * @package Drupal\eic_groups\Access
  */
@@ -29,11 +27,17 @@ class HighlightGroupContentAccessCheck implements AccessInterface {
   ];
 
   /**
+   * Constructs a new HighlightGroupContentAccessCheck object.
+   *
    * @param \Drupal\Core\Session\AccountProxy $account
+   *   The current user account.
    * @param \Drupal\group\Entity\GroupInterface|null $group
+   *   The group entity.
    * @param \Drupal\node\NodeInterface|null $node
+   *   The group content node.
    *
    * @return \Drupal\Core\Access\AccessResultInterface
+   *   The access result.
    */
   public function access(
     AccountProxy $account,
@@ -46,7 +50,9 @@ class HighlightGroupContentAccessCheck implements AccessInterface {
 
     $account = $account->getAccount();
     if (!$group->hasPermission('highlight group content', $account)) {
-      return AccessResult::forbidden('highlight group content permission is required');
+      return AccessResult::forbidden('highlight group content permission is required')
+        ->addCacheableDependency($group)
+        ->addCacheableDependency($account);
     }
 
     $group_content = $group->getContentEntities(NULL, [
@@ -55,10 +61,14 @@ class HighlightGroupContentAccessCheck implements AccessInterface {
     ]);
 
     if (empty($group_content)) {
-      return AccessResult::forbidden('Invalid group content argument');
+      return AccessResult::forbidden('Invalid group content argument')
+        ->addCacheableDependency($group)
+        ->addCacheableDependency($account);
     }
 
-    return AccessResult::allowed();
+    return AccessResult::allowed()
+      ->addCacheableDependency($group)
+      ->addCacheableDependency($account);
   }
 
 }

--- a/lib/modules/eic_recommend_content/eic_recommend_content.services.yml
+++ b/lib/modules/eic_recommend_content/eic_recommend_content.services.yml
@@ -1,7 +1,7 @@
 services:
   eic_recommend_content.access_check.recommend_content:
     class: Drupal\eic_recommend_content\Access\RecommendContentAccessCheck
-    arguments: ['@oec_group_flex.helper', '@entity_type.manager', '@eic_recommend_content.manager']
+    arguments: ['@oec_group_flex.helper', '@entity_type.manager', '@eic_recommend_content.manager', '@eic_groups.helper']
     tags:
       - { name: access_check, applies_to: _eic_recommend_content_access_check }
   eic_recommend_content.manager:

--- a/lib/modules/eic_recommend_content/src/Access/RecommendContentAccessCheck.php
+++ b/lib/modules/eic_recommend_content/src/Access/RecommendContentAccessCheck.php
@@ -7,6 +7,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Routing\Access\AccessInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\eic_content\Constants\DefaultContentModerationStates;
+use Drupal\eic_groups\EICGroupsHelper;
 use Drupal\eic_recommend_content\Services\RecommendContentManager;
 use Drupal\eic_user\UserHelper;
 use Drupal\oec_group_flex\OECGroupFlexHelper;
@@ -43,6 +44,13 @@ class RecommendContentAccessCheck implements AccessInterface {
   protected $recommendContentManager;
 
   /**
+   * The EIC Groups helper service.
+   *
+   * @var \Drupal\eic_groups\EICGroupsHelper
+   */
+  protected $eicGroupsHelper;
+
+  /**
    * Constructs a new RecommendGroupAccessCheck object.
    *
    * @param \Drupal\oec_group_flex\OECGroupFlexHelper $oec_group_flex_helper
@@ -51,15 +59,19 @@ class RecommendContentAccessCheck implements AccessInterface {
    *   The Entity type manager.
    * @param \Drupal\eic_recommend_content\Services\RecommendContentManager $recommend_content_manager
    *   The EIC Recommend content manager.
+   * @param \Drupal\eic_groups\EICGroupsHelper $eic_groups_helper
+   *   The EIC Groups helper service.
    */
   public function __construct(
     OECGroupFlexHelper $oec_group_flex_helper,
     EntityTypeManagerInterface $entity_type_manager,
-    RecommendContentManager $recommend_content_manager
+    RecommendContentManager $recommend_content_manager,
+    EICGroupsHelper $eic_groups_helper
   ) {
     $this->oecGroupFlexHelper = $oec_group_flex_helper;
     $this->entityTypeManager = $entity_type_manager;
     $this->recommendContentManager = $recommend_content_manager;
+    $this->eicGroupsHelper = $eic_groups_helper;
   }
 
   /**
@@ -120,9 +132,22 @@ class RecommendContentAccessCheck implements AccessInterface {
     }
 
     $moderation_state = $entity->get('moderation_state')->value;
+    // Wether or not the current entity is a group content.
+    $is_group_content = FALSE;
 
     switch ($moderation_state) {
       case DefaultContentModerationStates::PUBLISHED_STATE:
+        // If the entity belongs to a group and the group is not published, we
+        // deny access to recommend it.
+        if ($group = $this->eicGroupsHelper->getOwnerGroupByEntity($entity)) {
+          $is_group_content = TRUE;
+          if ($group->get('moderation_state')->value !== $moderation_state) {
+            $access->addCacheableDependency($account)
+              ->addCacheableDependency($entity);
+            break;
+          }
+        }
+
         // Power users can always recommend published content.
         if (UserHelper::isPowerUser($account)) {
           $access = AccessResult::allowed()
@@ -143,6 +168,10 @@ class RecommendContentAccessCheck implements AccessInterface {
           ->addCacheableDependency($entity);
         break;
 
+    }
+
+    if ($is_group_content && $group) {
+      $access->addCacheableDependency($group);
     }
 
     return $access;


### PR DESCRIPTION
### Fixes

- Fix caching issue with highlight flag not shown when a GM becomes an Admin;
- Disable content recommendation when group is not published;
- fix coding standards.

### Test

- [ ] As GO/GA, go to a public group with discussions
- [ ] Make sure the you can recommend discussions
- [ ] Make sure you can highlight discussions. Also make sure GM cannot highlight a discussion.
- [ ] Make sure you can request group archival or group deletion from the group management dropdown
- [ ] As SA/SCM, archive the group
- [ ] As GO/GA/GM, make sure you cannot recommend any content in the group
- [ ] As GO/GA, make sure you can still highlight content in group. Also make sure GM cannot highlight any content.
- [ ] As GO/GA/GM, make sure you cannot request group archival (because the group is already archived
- [ ] As GO/GA, make sure you can still request group deletion from the group management dropdown. GM should not be able to request group deletion when the group is archived.