### PR TITLE
EICNET-1710: Handle empty address parameters in the sidebar detail event

### DIFF
--- a/lib/modules/eic_groups/src/EICGroupsHelper.php
+++ b/lib/modules/eic_groups/src/EICGroupsHelper.php
@@ -988,18 +988,33 @@ class EICGroupsHelper implements EICGroupsHelperInterface {
    */
   public static function formatAddress($address) {
     $countries_map = CountryManager::getStandardList();
-    $location_formatted = $address[FieldHelper::getPropertyName(AddressField::ADDRESS_LINE1)]
+    $location_values = [];
+    $location_values[] = $address[FieldHelper::getPropertyName(AddressField::ADDRESS_LINE1)]
       . ' ' .
-      $address[FieldHelper::getPropertyName(AddressField::ADDRESS_LINE2)] . '<br />';
-    $location_formatted .= $address[FieldHelper::getPropertyName(AddressField::POSTAL_CODE)]
+      $address[FieldHelper::getPropertyName(AddressField::ADDRESS_LINE2)];
+    $location_values[] = $address[FieldHelper::getPropertyName(AddressField::POSTAL_CODE)]
       . ' ' .
-      $address[FieldHelper::getPropertyName(AddressField::LOCALITY)] . '<br />';
-    $location_formatted .= array_key_exists(
-      $address['country_code'],
-      $countries_map
-    ) ?
+      $address[FieldHelper::getPropertyName(AddressField::LOCALITY)];
+    $location_values[] = array_key_exists(
+        $address['country_code'],
+        $countries_map
+      ) ?
       $countries_map[$address['country_code']] :
       '';
+
+    $location_formatted = '';
+    foreach ($location_values as $key => $value) {
+      $location_formatted .= $value;
+      if (
+        isset($location_values[$key + 1]) &&
+        !empty(trim($location_formatted)) &&
+        !empty(trim($location_values[$key + 1]))
+      ) {
+        if (!empty(trim($location_values[$key + 1]))) {
+          $location_formatted .= '<br />';
+        }
+      }
+    }
 
     return $location_formatted;
   }


### PR DESCRIPTION
### Improvements

- Handle empty address properties from event location address in the sidebar.

### Test

- [ ] Change address of a global event: try to leave the street address as empty and add only the postal code and the City
- [ ] Go to the event detail page and make sure there is no empty space before the postal code + city

Before:
![image](https://user-images.githubusercontent.com/9576940/175978571-dc047230-a309-4442-b8ef-2ed15c6be1aa.png)

- [ ] Edit the event again and leave the postal code and city as empty and add only the street address
- [ ] Go to the event detail page and make sure there is no empty space between the street address and the country name

Before:
![image](https://user-images.githubusercontent.com/9576940/175978629-d1243ff2-ae43-44d5-a1d0-bb413fd866f3.png)