### PR TITLE
EICNET-2423: Fix comment notification template

### DIFF
--- a/lib/themes/eic_community/templates/content/comment--notification-teaser.html.twig
+++ b/lib/themes/eic_community/templates/content/comment--notification-teaser.html.twig
@@ -74,9 +74,7 @@
 																										{% if comment.tagged_users is defined %}
 																											<br><br>With:
 																											{% for user in comment.tagged_users %}
-																												<a style="font-weight: bold; text-decoration: none; color: #004494" href="{{ user.path }}" target="_blank">{{ user.name }}</a>
-																												{% if loop.last == false %},
-																												{% endif %}
+																												<a style="font-weight: bold; text-decoration: none; color: #004494" href="{{ user.path }}" target="_blank">{{ user.name }}</a>{% if loop.last == false %}, {% endif %}
 																											{% endfor %}
 																										{% endif %}
 																									</div>


### PR DESCRIPTION
### Fixes

- Remove `<br>` tag between each tagged user in email notification

### Test

- [x] Go to a discussion detail
- [x] Add a comment and apply some styles (bold, underline, italic and a link) and tag multiple users
- [x] Run cron
- [ ] Make sure all the tagged users get an email and make sure the user image has the correct dimensions + the comment text is shown as html and not as plain text + make sure there is no `<br>` tag between each tagged user.