### PR TITLE
[EICNET-2589] fix: add space above discussion title

### DIFF
--- a/lib/themes/eic_community/sass/compositions/_discussion-thread.scss
+++ b/lib/themes/eic_community/sass/compositions/_discussion-thread.scss
@@ -55,7 +55,8 @@
   }
 
   &__title {
-    margin-top: 0;
+    margin-bottom:  $ecl-spacing-2-xs;
+    margin-top: $ecl-spacing-xs;
     @include ecl-responsive-font('label');
   }
 


### PR DESCRIPTION
# How to test

- [ ] Go to a group page
- [ ] Check a discussion title
- [ ] It should be like on the design