### PR TITLE
EICNET-1318: Make field field_document_type not required in galleries.

### DIFF
--- a/config/sync/field.field.node.gallery.field_document_type.yml
+++ b/config/sync/field.field.node.gallery.field_document_type.yml
@@ -12,7 +12,7 @@ entity_type: node
 bundle: gallery
 label: 'Document type'
 description: ''
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''


### PR DESCRIPTION
This was already reviewed here: https://github.com/EIC-EA/EIC-community-D8/pull/1662 and accidentally reverted here: https://github.com/EIC-EA/EIC-community-D8/pull/1669/files