### PR TITLE
EICNET-2541: Shared event in organisation is not shown

### DIFF
--- a/lib/modules/eic_groups/modules/eic_share_content/src/Controller/ShareContentController.php
+++ b/lib/modules/eic_groups/modules/eic_share_content/src/Controller/ShareContentController.php
@@ -125,7 +125,7 @@ class ShareContentController extends ControllerBase {
     $groups = $this->shareManager->getShareableTargetGroupsForUser($this->currentUser, $group, $node);
     $formatted_groups = [];
     foreach ($groups as $group) {
-      $formatted_groups[$group->bundle()][] = [
+      $formatted_groups[$group->getGroupType()->label()][] = [
         'id' => $group->id(),
         'label' => $group->label(),
       ];


### PR DESCRIPTION
### Improvements

- Do not allow users to share draft content;
- Fix issue where group content could be shared multiple times;;
- Fix coding standards.

### Test

- [x] As SA/SCM, go to a public group. Make sure group feature "Events" is enabled for the group.
- [x] Create a new draft event
- [x] Try to share with another group and make sure no groups are listed. This is because the event is in draft state.
- [x] Publish the event
- [x] Try to share with another group and make sure you have group or organisations to share with.
- [x] Try to share the event with the same group/organisation twice and make sure you get an error message "**This content is already shared with this group**"