### PR TITLE
EICNET-1335: Hide highlight icon for trusted users if content is not highlighted

### DIFF
--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Library/Partials/HighlightLink.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/Library/Partials/HighlightLink.js
@@ -33,7 +33,7 @@ class HighlightLink extends React.Component {
 
     const tooltipContent = this.state.isHighlighted ? this.props.translation.unHighlight : this.props.translation.highlight
 
-    return (<div className={`ecl-highlight ${this.state.isHighlighted && 'ecl-highlight--is-highlighted'}`}>
+    return <div className={`ecl-highlight ${this.state.isHighlighted && 'ecl-highlight--is-highlighted'}`}>
       {this.overviewSettings.is_power_user || this.overviewSettings.is_group_owner || this.overviewSettings.is_group_admin ? (
         <>
           <ReactTooltip backgroundColor={'#004494'} type="info" effect="solid" className='ecl-highlight__tooltip' />
@@ -43,12 +43,12 @@ class HighlightLink extends React.Component {
           </a>
         </>
       ) : (
-        <div className={'ecl-highlight__item'}>
+        this.state.isHighlighted && <div className={'ecl-highlight__item'}>
           <div dangerouslySetInnerHTML={{__html: svg('highlight', 'ecl-icon ecl-icon--m ecl-highlight__icon')}} />
           <span className="ecl-highlight__label">Highlight</span>
         </div>
       )}
-    </div>);
+    </div>;
   }
 }
 


### PR DESCRIPTION
### Improvements

- Hide highlight icon for trusted users if content is not highlighted.

### Test

- [x] As TU (member or non-member), go to the discussions overview of a group
- [x] Make sure the highlighted icon (yellow black icon) is shown for highlighted discussions only. Non highlighted discussions shouldn't have any icon
- [x] As SA/SCM/GO/GA, make sure the highlighted icon is shown for both highlighted (yellow black icon) and non highlighted discussions (white blue icon).