### PR TITLE
Feature/eicnet 1323 fix last comment timestamp

### DIFF
--- a/config/sync/core.entity_form_display.node.discussion.default.yml
+++ b/config/sync/core.entity_form_display.node.discussion.default.yml
@@ -188,10 +188,10 @@ content:
     settings:
       title: Paragraph
       title_plural: Paragraphs
-      edit_mode: open
+      edit_mode: closed
       add_mode: dropdown
       form_display_mode: default
-      default_paragraph_type: ''
+      default_paragraph_type: _none
     third_party_settings: {  }
   field_related_documents:
     type: entity_reference_autocomplete

--- a/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorDiscussion.php
+++ b/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorDiscussion.php
@@ -81,15 +81,10 @@ class ProcessorDiscussion extends DocumentProcessor {
       ->range(0, 1)
       ->execute();
 
-    $total_comments = $this->entityTypeManager->getStorage('comment')
-      ->getQuery()
-      ->condition('entity_id', $nid)
-      ->count()
-      ->execute();
-
     $discussion = $this->entityTypeManager->getStorage('node')->load($nid);
     $likes = 0;
     $follows = 0;
+    $total_comments = $discussion->field_comments->comment_count;
 
     if ($discussion instanceof NodeInterface) {
       $statistics = $this->statisticsHelper->getEntityStatistics($discussion);
@@ -105,6 +100,9 @@ class ProcessorDiscussion extends DocumentProcessor {
 
     if (!$results) {
       $document->addField('ss_discussion_last_comment_text', '');
+      // Since last comment from the comments field always set a timestamp even
+      // when there are no comments, we set it to 0 here.
+      $document->setField('its_last_comment_timestamp', 0);
       return;
     }
 


### PR DESCRIPTION
### Improvements

- Collapsed the Contributors paragraph by default to avoid having required fields

### Tests

- [ ] Create Discussion A in a group
- [ ] Comment it
- [ ] Create Discussion B in the same group
- [ ] Go to `groups/<group-name>/discussions`
- [ ] Sort by last commented
- [ ] Make sure Discussion B is displayed after Discussion A