### PR TITLE
[EICNET-2539] fix: set error text in red

### DIFF
--- a/lib/themes/eic_community/sass/components/_messages.scss
+++ b/lib/themes/eic_community/sass/components/_messages.scss
@@ -1,0 +1,5 @@
+.messages {
+  &--error {
+    color: $ecl-color-red;
+  }
+}

--- a/lib/themes/eic_community/sass/eic_community.screen.scss
+++ b/lib/themes/eic_community/sass/eic_community.screen.scss
@@ -132,6 +132,7 @@
 @import "./components/investment";
 @import "./components/link";
 @import "./components/media-container";
+@import "./components/messages";
 @import "./components/meta-list";
 @import "./components/modal";
 @import "./components/navigation-list";


### PR DESCRIPTION
# How to test

1. As a TU, go to a group
2. Click on Add Content
3. Click on Add Discussion, Document, Event, Gallery, Video (not Wiki)
4. Fill in the required fields of the main page (not the required fields of the tabs)
5. Click on Save
6. Check that "Field is required" is in red
