### PR TITLE
EICNET-2597: Whenever a user accepts his last invitation, he still sees the warning message that an invitation is awaiting his feedback

### DIFF
--- a/lib/modules/eic_groups/eic_groups.services.yml
+++ b/lib/modules/eic_groups/eic_groups.services.yml
@@ -73,3 +73,9 @@ services:
     decoration_priority: 1
     public: true
     arguments: ['@eic_groups.pathauto.generator.decorator.inner', '@current_route_match', '@config.factory', '@module_handler', '@token', '@pathauto.alias_cleaner', '@pathauto.alias_storage_helper', '@pathauto.alias_uniquifier', '@pathauto.verbose_messenger', '@string_translation', '@token.entity_mapper', '@entity_type.manager', '@plugin.manager.alias_type']
+  eic_groups.ginvite_event_subscriber.decorator:
+    class: Drupal\eic_groups\EventSubscriber\GinviteSubscriber
+    decorates: ginvite_event_subscriber
+    decoration_priority: 1
+    public: true
+    arguments: ['@eic_groups.ginvite_event_subscriber.decorator.inner', '@ginvite.invitation_loader', '@current_user', '@messenger', '@logger.factory']

--- a/lib/modules/eic_groups/src/EventSubscriber/GinviteSubscriber.php
+++ b/lib/modules/eic_groups/src/EventSubscriber/GinviteSubscriber.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Drupal\eic_groups\EventSubscriber;
+
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Url;
+use Drupal\ginvite\GroupInvitationLoader;
+use Drupal\ginvite\EventSubscriber\GinviteSubscriber as GinviteSubscriberBase;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+
+/**
+ * Decorates Ginvite module event subscriber.
+ *
+ * @package Drupal\eic_groups\EventSubscriber
+ */
+class GinviteSubscriber extends GinviteSubscriberBase {
+
+  /**
+   * The group invite event subscriber.
+   *
+   * @var \Drupal\ginvite\EventSubscriber\GinviteSubscriber
+   */
+  protected $ginviteSubscriber;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(
+    GinviteSubscriberBase $ginvite_subscriber_inner_service,
+    GroupInvitationLoader $invitation_loader,
+    AccountInterface $current_user,
+    MessengerInterface $messenger,
+    LoggerChannelFactoryInterface $logger_factory
+  ) {
+    parent::__construct($invitation_loader, $current_user, $messenger, $logger_factory);
+    $this->ginviteSubscriber = $ginvite_subscriber_inner_service;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function notifyAboutPendingInvitations(GetResponseEvent $event) {
+    // Exclude routes where this info is redundant or will generate a
+    // misleading extra message on the next request.
+    $route_exclusions = [
+      'view.my_invitations.page_1',
+      'ginvite.invitation.accept',
+      'ginvite.invitation.decline',
+      'image.style_private',
+    ];
+    $route = $event->getRequest()->get('_route');
+
+    // @todo Doing this should already improve some performance however, we
+    // should create a function to query the invitations and limit the results
+    // to 1. This will avoid querying the whole table when we just want to know
+    // if the user has at least 1 pending invitation.
+    if (
+      !empty($route) &&
+      !in_array($route, $route_exclusions) &&
+      $this->groupInvitationLoader->loadByUser()
+    ) {
+      $destination = Url::fromRoute('view.my_invitations.page_1', ['user' => $this->currentUser->id()])->toString();
+      $replace = ['@url' => $destination];
+      $message = $this->t('You have pending group invitations. <a href="@url">Visit your profile</a> to see them.', $replace);
+      $this->messenger->addMessage($message, 'warning', FALSE);
+    }
+  }
+
+  /**
+   * Magic method to return any method call inside the inner service.
+   */
+  public function __call($method, $args) {
+    return call_user_func_array(
+      [$this->ginviteSubscriber, $method],
+      $args
+    );
+  }
+
+}

--- a/lib/modules/eic_groups/src/EventSubscriber/GinviteSubscriber.php
+++ b/lib/modules/eic_groups/src/EventSubscriber/GinviteSubscriber.php
@@ -55,7 +55,11 @@ class GinviteSubscriber extends GinviteSubscriberBase {
     // @todo Doing this should already improve some performance however, we
     // should create a function to query the invitations and limit the results
     // to 1. This will avoid querying the whole table when we just want to know
-    // if the user has at least 1 pending invitation.
+    // if the user has at least 1 pending invitation. Also, it would probably
+    // worth to create a separated block to show the information about pending
+    // invitations, to avoid strange behavior such as opening a new tab and
+    // navigate through the platform before clicking on accept invitation in
+    // the original tab.
     if (
       !empty($route) &&
       !in_array($route, $route_exclusions) &&


### PR DESCRIPTION
### Improvements

- Decorate group invite event subscriber so that it avoids showing the invitations message on certain routes;
- Small improvements in code for better performance.

### Test

- [x] As SA/SCM, invite a user (with no invitations) to a group
- [x] Login as the user and make sure you have the pending invitations message in the banner
- [x] Go to the invitations page and accept the invitation
- [x] When you get redirected back to the invitations page you should only see the Success message