### PR TITLE
EICNET-2539: No validation error message shown when required fields in inactive tabs are empty

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4311,6 +4311,9 @@
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
                     }
+                },
+                "patches_applied": {
+                    "HTML5 Validation Prevents Submission in Tabs": "https://www.drupal.org/files/issues/2021-07-22/2969051-37.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -10357,16 +10360,6 @@
             "homepage": "http://github.com/myclabs/php-enum",
             "keywords": [
                 "enum"
-            ],
-            "funding": [
-                {
-                    "url": "https://github.com/mnapoli",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/myclabs/php-enum",
-                    "type": "tidelift"
-                }
             ],
             "time": "2021-07-05T08:18:36+00:00"
         },

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -29,6 +29,9 @@
     "drupal/entity_usage": {
       "3168418 - Batch update error when there are no entities to load": "https://www.drupal.org/files/issues/2021-12-07/batch-update-error-3168418-16.patch"
     },
+    "drupal/field_group": {
+      "HTML5 Validation Prevents Submission in Tabs": "https://www.drupal.org/files/issues/2021-07-22/2969051-37.patch"
+    },
     "drupal/ginvite": {
       "3209902 - More graceful handling of missing plugin": "https://www.drupal.org/files/issues/2022-03-30/ginvite-fix__invite_route_permission-3209902-5.patch"
     },

--- a/config/sync/core.entity_form_display.group.organisation.default.yml
+++ b/config/sync/core.entity_form_display.group.organisation.default.yml
@@ -254,10 +254,10 @@ content:
     settings:
       title: Paragraph
       title_plural: Paragraphs
-      edit_mode: open
+      edit_mode: closed
       add_mode: dropdown
       form_display_mode: default
-      default_paragraph_type: ''
+      default_paragraph_type: _none
     third_party_settings: {  }
   field_needs:
     type: entity_reference_paragraphs
@@ -266,10 +266,10 @@ content:
     settings:
       title: Paragraph
       title_plural: Paragraphs
-      edit_mode: open
+      edit_mode: closed
       add_mode: dropdown
       form_display_mode: default
-      default_paragraph_type: ''
+      default_paragraph_type: _none
     third_party_settings: {  }
   field_offers:
     type: entity_reference_paragraphs
@@ -278,10 +278,10 @@ content:
     settings:
       title: Paragraph
       title_plural: Paragraphs
-      edit_mode: open
+      edit_mode: closed
       add_mode: dropdown
       form_display_mode: default
-      default_paragraph_type: ''
+      default_paragraph_type: _none
     third_party_settings: {  }
   field_organisation_employees:
     type: number

--- a/config/sync/core.entity_form_display.node.gallery.default.yml
+++ b/config/sync/core.entity_form_display.node.gallery.default.yml
@@ -193,10 +193,10 @@ content:
     settings:
       title: Paragraph
       title_plural: Paragraphs
-      edit_mode: open
+      edit_mode: closed
       add_mode: dropdown
       form_display_mode: default
-      default_paragraph_type: ''
+      default_paragraph_type: _none
     third_party_settings: {  }
   field_send_notification:
     weight: 3

--- a/config/sync/core.entity_form_display.node.news.default.yml
+++ b/config/sync/core.entity_form_display.node.news.default.yml
@@ -245,10 +245,10 @@ content:
     settings:
       title: Paragraph
       title_plural: Paragraphs
-      edit_mode: open
+      edit_mode: closed
       add_mode: dropdown
       form_display_mode: default
-      default_paragraph_type: ''
+      default_paragraph_type: _none
     third_party_settings: {  }
   field_post_activity:
     weight: 5

--- a/config/sync/core.entity_form_display.node.story.default.yml
+++ b/config/sync/core.entity_form_display.node.story.default.yml
@@ -296,7 +296,7 @@ content:
     settings:
       title: Paragraph
       title_plural: Paragraphs
-      edit_mode: open
+      edit_mode: closed
       add_mode: dropdown
       form_display_mode: default
       default_paragraph_type: _none

--- a/config/sync/core.entity_form_display.node.video.default.yml
+++ b/config/sync/core.entity_form_display.node.video.default.yml
@@ -188,10 +188,10 @@ content:
     settings:
       title: Paragraph
       title_plural: Paragraphs
-      edit_mode: open
+      edit_mode: closed
       add_mode: dropdown
       form_display_mode: default
-      default_paragraph_type: ''
+      default_paragraph_type: _none
     third_party_settings: {  }
   field_send_notification:
     weight: 4

--- a/lib/modules/eic_content/eic_content.module
+++ b/lib/modules/eic_content/eic_content.module
@@ -11,7 +11,6 @@
 
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\eic_content\Hooks\EntityOperations;
 use Drupal\eic_content\Hooks\EntityOperationsContributor;
@@ -119,12 +118,4 @@ function eic_content_metatags_attachments_alter(array &$metatag_attachments) {
     ],
     'og_image_0',
   ];
-}
-
-/**
- * Implements hook_form_alter().
- */
-function eic_content_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  // Disable html5 form validation.
-  $form['#attributes']['novalidate'] = 'novalidate';
 }

--- a/lib/modules/eic_content/eic_content.module
+++ b/lib/modules/eic_content/eic_content.module
@@ -11,6 +11,7 @@
 
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\eic_content\Hooks\EntityOperations;
 use Drupal\eic_content\Hooks\EntityOperationsContributor;
@@ -118,4 +119,12 @@ function eic_content_metatags_attachments_alter(array &$metatag_attachments) {
     ],
     'og_image_0',
   ];
+}
+
+/**
+ * Implements hook_form_alter().
+ */
+function eic_content_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // Disable html5 form validation.
+  $form['#attributes']['novalidate'] = 'novalidate';
 }

--- a/lib/themes/eic_community/react/components/Field/EntityTree/entrypoint.js
+++ b/lib/themes/eic_community/react/components/Field/EntityTree/entrypoint.js
@@ -29,6 +29,7 @@ for (let element of elements) {
       group={element.dataset.groupId}
       searchSpecificUsers={parseInt(element.dataset.searchSpecificUsers)}
       canCreateTag={parseInt(element.dataset.canCreateTag)}
+      hasError={Boolean(parseInt(element.dataset.hasError))}
     />,
     newElement
   );

--- a/lib/themes/eic_community/react/components/Field/EntityTree/index.js
+++ b/lib/themes/eic_community/react/components/Field/EntityTree/index.js
@@ -30,18 +30,18 @@ class EntityTree extends React.Component {
     this.addChip = this.addChip.bind(this);
     this.removeChip = this.removeChip.bind(this);
     // Uncomment line bellow if we use html5 form validation.
-    // this.submitForm = this.submitForm.bind(this)
+    this.submitForm = this.submitForm.bind(this)
     this.firstEl = React.createRef();
   }
 
   componentDidMount() {
-    // document.addEventListener('click', this.submitForm)
+    document.addEventListener('click', this.submitForm)
     this.search();
   }
 
   componentWillUnmount() {
     // Uncomment line bellow if we use html5 form validation.
-    // document.removeEventListener('click', this.submitForm)
+    document.removeEventListener('click', this.submitForm)
   }
 
   submitForm(e) {

--- a/lib/themes/eic_community/react/components/Field/EntityTree/index.js
+++ b/lib/themes/eic_community/react/components/Field/EntityTree/index.js
@@ -21,7 +21,7 @@ class EntityTree extends React.Component {
       isLoadingMore: false,
       page: 0,
       length: this.props.length,
-      hasError: false,
+      hasError: this.props.hasError,
     }
 
     this.search = this.search.bind(this);
@@ -29,17 +29,19 @@ class EntityTree extends React.Component {
     this.searchUsers = this.searchUsers.bind(this);
     this.addChip = this.addChip.bind(this);
     this.removeChip = this.removeChip.bind(this);
-    this.submitForm = this.submitForm.bind(this)
+    // Uncomment line bellow if we use html5 form validation.
+    // this.submitForm = this.submitForm.bind(this)
     this.firstEl = React.createRef();
   }
 
   componentDidMount() {
-    document.addEventListener('click', this.submitForm)
+    // document.addEventListener('click', this.submitForm)
     this.search();
   }
 
   componentWillUnmount() {
-    document.removeEventListener('click', this.submitForm)
+    // Uncomment line bellow if we use html5 form validation.
+    // document.removeEventListener('click', this.submitForm)
   }
 
   submitForm(e) {

--- a/lib/themes/eic_community/react/components/Field/EntityTree/index.js
+++ b/lib/themes/eic_community/react/components/Field/EntityTree/index.js
@@ -29,7 +29,6 @@ class EntityTree extends React.Component {
     this.searchUsers = this.searchUsers.bind(this);
     this.addChip = this.addChip.bind(this);
     this.removeChip = this.removeChip.bind(this);
-    // Uncomment line bellow if we use html5 form validation.
     this.submitForm = this.submitForm.bind(this)
     this.firstEl = React.createRef();
   }
@@ -40,7 +39,6 @@ class EntityTree extends React.Component {
   }
 
   componentWillUnmount() {
-    // Uncomment line bellow if we use html5 form validation.
     document.removeEventListener('click', this.submitForm)
   }
 


### PR DESCRIPTION
### Improvements

- Remove html5 validation from all forms;
- Show required field label on entity tree widget react component after user submits the form.

### Test

- [x] As TU (GM), try to add a discussion in a group
- [x] Leave the Topics and Regions & Countries fields empty
- [x] Click on save
- [x] the field group "Topics, countries & tags" is automatically focused and you see a required label on both Topics and Regions & Countries fields:

![image](https://user-images.githubusercontent.com/9576940/176676183-c490ea3c-7e10-4d8a-9d2a-50652f311b7d.png)

- [x] Try to create a gallery, story and a video and make sure the field "Contributors" is closed by default
- [x] Try to create a News and make sure the field "Paragraphs" is closed by default