### PR TITLE
EICNET-2598: Groups without an image in /groups should show the default empty image

### DIFF
--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/GroupResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/GroupResultItem.js
@@ -23,6 +23,10 @@ class GroupResultItem extends React.Component {
         ? 'ecl-teaser-overview__item ecl-teaser-overview__item--organisation'
         : 'ecl-teaser-overview__item';
     const itemUrl = url(this.props.result.ss_url);
+    const has_teaser_image = (
+      this.props.result.ss_group_teaser_formatted_image !== undefined &&
+      this.props.result.ss_group_teaser_formatted_image !== ''
+    );
 
     let tags = [
       {
@@ -54,14 +58,14 @@ class GroupResultItem extends React.Component {
         <div className="ecl-teaser ecl-teaser--group  ecl-teaser--as-card ecl-teaser--as-card-grey">
           <a href={itemUrl}>
             <figure className="ecl-teaser__image-wrapper">
-              {this.props.result.ss_group_teaser_formatted_image !== undefined && (
+              {has_teaser_image && (
                 <img
                   className="ecl-teaser__image"
                   src={this.props.result.ss_group_teaser_formatted_image}
                   alt={this.props.result.tm_global_title}
                 />
               )}
-              {this.props.result.ss_group_teaser_formatted_image === undefined && (
+              {!has_teaser_image && (
                 <div
                   className="ecl-teaser__image-fallback-wrapper"
                   dangerouslySetInnerHTML={{


### PR DESCRIPTION
### Fixes

Fix group and organisation teasers without an image in react component.

### Test

- [x] Go to `/groups` and make sure groups without an image show the default empty image. Make sure the same happens in `/organisations`