### PR TITLE
EICNET-2605: TU sees Delete profile button but access to page is not authorized

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/users/user.inc
+++ b/lib/themes/eic_community/includes/preprocess/users/user.inc
@@ -245,8 +245,7 @@ function _get_render_block_search_overview(string $source): array {
   $access_result = $plugin_block->access(\Drupal::currentUser());
   if (is_object($access_result) && $access_result->isForbidden() || is_bool($access_result) && !$access_result) {
     return [];
-  }
-  else {
+  } else {
     return $plugin_block->build();
   }
 }

--- a/lib/themes/eic_community/includes/preprocess/users/user.inc
+++ b/lib/themes/eic_community/includes/preprocess/users/user.inc
@@ -227,6 +227,7 @@ function eic_community_preprocess_user(array &$variables) {
  *   The source class in string.
  *
  * @return array
+ *   The search overview block renderable array.
  */
 function _get_render_block_search_overview(string $source): array {
   $block_manager = \Drupal::service('plugin.manager.block');
@@ -244,7 +245,8 @@ function _get_render_block_search_overview(string $source): array {
   $access_result = $plugin_block->access(\Drupal::currentUser());
   if (is_object($access_result) && $access_result->isForbidden() || is_bool($access_result) && !$access_result) {
     return [];
-  } else {
+  }
+  else {
     return $plugin_block->build();
   }
 }
@@ -657,6 +659,11 @@ function _eic_community_get_user_operation_links(UserInterface $account, Profile
 
   $processed_user_operation_links = [];
   foreach ($user_operation_links as $key => $user_operation_link) {
+    // Check access to the URL.
+    if (!$user_operation_link['url']->access()) {
+      continue;
+    }
+
     switch ($key) {
       // Override operation link titles.
       case 'edit':
@@ -683,6 +690,11 @@ function _eic_community_get_user_operation_links(UserInterface $account, Profile
     $member_profile_operation_links = \Drupal::entityTypeManager()->getListBuilder($member_profile->getEntityTypeId())
       ->getOperations($member_profile);
     foreach ($member_profile_operation_links as $key => $member_profile_operation_link) {
+      // Check access to the URL.
+      if (!$member_profile_operation_link['url']->access()) {
+        continue;
+      }
+
       // Override operation link titles.
       switch ($key) {
         case 'edit':


### PR DESCRIPTION
### Fixes

- Show only operation links the user has access to in user profile page.

### To be discussed

- Concerning account deletion, we should discuss this because it will impact all the content in the platform. We need to decide what to do with the content when a user tries to delete his/her account. Should the content be deleted or should we change the author to someone else? What if the user is the owner of a group?

### Test

- [ ] As TU, go to your profile page
- [ ] Click on "Manage profile" dropdown and make sure there is no "Delete" link to the delete the profile