### PR TITLE
EICNET-2612: Fix issue in BookTokens class that is thrown when re-generating URL aliases

### DIFF
--- a/lib/modules/eic_content/modules/eic_content_book/src/Hooks/BookTokens.php
+++ b/lib/modules/eic_content/modules/eic_content_book/src/Hooks/BookTokens.php
@@ -100,7 +100,7 @@ class BookTokens implements ContainerInjectionInterface {
             break;
           }
 
-          if (!$node->book['nid'] || $node->book['pid'] <= 0) {
+          if (!$node->book || !$node->book['nid'] || $node->book['pid'] <= 0) {
             break;
           }
 


### PR DESCRIPTION
### Fixes

- Fix issue with BookTokens when generating path alias.

### Tests

- [x] Import DB from QA
- [x] Clear all logs from `/admin/reports/dblog`
- [x] As DA, go to `/admin/config/search/path/delete_bulk` check the option "All aliases" and "Only delete automatically generated aliases" and click delete aliases now
- [x] Go to `/admin/config/search/path/update_bulk`
- [x] Select "Group", "Group content" and "Content" and click Update
- [x] Go drupal logs `/admin/reports/dblog` and make sure there is no notice: `Notice: Trying to access array offset on value of type null in Drupal\eic_content_book\Hooks\BookTokens->tokens() `