### PR TITLE
EICNET-2603: Add the MAnage invitations link to group dropdown.

### DIFF
--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
@@ -277,12 +277,26 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
       'url' => Url::fromRoute('view.group_pending_members.page_1', ['group' => $group->id()]),
     ];
 
+    // Adds pending invitations URL to the group operation links.
+    $group_operation_links['edit-invitations'] = [
+      'title' => $this->t('Manage invitations'),
+      'url' => Url::fromRoute('view.group_invitations.page_1', ['group' => $group->id()]),
+    ];
+
     // We extract only the group edit/delete/publish operation links into a new
     // array.
     $visible_group_operation_links = array_filter($group_operation_links, function ($item, $key) {
       return in_array(
         $key,
-        ['edit', 'delete', 'publish', 'request_block', 'edit-members', 'edit-membership-requests']
+        [
+          'edit',
+          'delete',
+          'publish',
+          'request_block',
+          'edit-members',
+          'edit-membership-requests',
+          'edit-invitations',
+        ]
       ) && $item['url']->access();
     }, ARRAY_FILTER_USE_BOTH);
 


### PR DESCRIPTION
### Tests

- [x] Run `drush cr`
- [x] As SA/GO/GA, go to a **Group** and make sure you get the "Manage invitations" link in the group dropdown
- [x] As SA/GO/GA, go to an **Event** and make sure you get the "Manage invitations" link in the group dropdown
- [x] As SA/GO/GA, go to an **Organisation** and make sure you get the "Manage invitations" link in the group dropdown