### PR TITLE
EICNET-2332: Add alt text to field video.

### DIFF
--- a/config/sync/field.field.node.news.field_video.yml
+++ b/config/sync/field.field.node.news.field_video.yml
@@ -12,7 +12,7 @@ field_name: field_video
 entity_type: node
 bundle: news
 label: Video
-description: ''
+description: "<p>You can upload a video or link a remote video from : Youtube, Dailymotion, Vimeo.</p>\r\n<p>Important note: the video you are uploading will be processed by our video conversion system. This means that for a short period of time, the video will not be accessible. An info message \"Your video is being processed, come back later.\" will be displayed in the front-office instead.</p>"
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.node.story.field_video.yml
+++ b/config/sync/field.field.node.story.field_video.yml
@@ -14,7 +14,7 @@ field_name: field_video
 entity_type: node
 bundle: story
 label: Video
-description: ''
+description: "<p>You can upload a video or link a remote video from : Youtube, Dailymotion, Vimeo.</p>\r\n<p>Important note: the video you are uploading will be processed by our video conversion system. This means that for a short period of time, the video will not be accessible. An info message \"Your video is being processed, come back later.\" will be displayed in the front-office instead.</p>"
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.node.video.field_video_media.yml
+++ b/config/sync/field.field.node.video.field_video_media.yml
@@ -12,7 +12,7 @@ field_name: field_video_media
 entity_type: node
 bundle: video
 label: Video
-description: '<p>You can upload a video or link a remote video from : youtube, daylimotion, vimeo.</p>'
+description: "<p>You can upload a video or link a remote video from : Youtube, Dailymotion, Vimeo.</p>\r\n<p>Important note: the video you are uploading will be processed by our video conversion system. This means that for a short period of time, the video will not be accessible. An info message \"Your video is being processed, come back later.\" will be displayed in the front-office instead.</p>"
 required: true
 translatable: false
 default_value: {  }


### PR DESCRIPTION
### Improvements

- Add alt text to field video in News, Story and Video.

### Test

- [x] As TU, try to create a News, Story and a Video
- [x] Make sure the video field has an alt text according to the ticket https://citnet.tech.ec.europa.eu/CITnet/jira/browse/EICNET-2332