### PR TITLE
EICNET-1438: Fix issue that breaks activity stream list after loading more results

### DIFF
--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/ActivityStreamResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/ActivityStreamResultItem.js
@@ -19,7 +19,7 @@ class ActivityStreamResultItem extends React.Component {
 
   getStatistics() {
     const endpoint = window.drupalSettings?.node_statistics_url;
-    if (!endpoint) {
+    if (!endpoint || this.props.result.ss_type == undefined) {
       return null;
     }
 
@@ -91,7 +91,7 @@ class ActivityStreamResultItem extends React.Component {
     const fullname = `${this.props.result.ss_author_first_name} ${this.props.result.ss_author_last_name}`;
     const message = `${this.props.result.tm_X3b_en_field_share_message && this.props.result.tm_X3b_en_field_share_message.length > 0 ? this.props.result.tm_X3b_en_field_share_message.shift() : ''}`;
 
-    if (!this.props.result || !this.props.result.ss_type || this.state.loading) {
+    if (!this.props.result || !this.props.result.ss_type || this.props.result.ss_type == undefined || this.state.loading) {
       return <></>;
     }
 


### PR DESCRIPTION
### Fixes

- Fix react activity stream result component when activity stream result type is undefined.

### Test

- [x] Import DB from DEV environment
- [x] Re-index solr
- [x] Go to `/groups/testing-playground/latest-activity` and click on load more until you load all the items
- [x] Make sure the list doesn't break