### PR TITLE
EICNET-2609: Options to "Send notification" and "Post message in activity stream" should be enabled by default

### DIFF
--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Hooks/FormOperations.php
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Hooks/FormOperations.php
@@ -151,10 +151,23 @@ class FormOperations implements ContainerInjectionInterface {
       $form_state->set('entity_is_published', $entity->isPublished());
       $form_state->set('previous_state', $entity->get('moderation_state')->value);
 
+      $is_new_content = $entity->isNew();
+      // Check if the current node is the default revision and is in draft
+      // state. If that's the case, it means there is no published or archived
+      // version and therefore the "Send notification" checkbox should be
+      // checked by default.
+      if (
+        !$is_new_content &&
+        $entity->revision_default->value &&
+        $entity->get('moderation_state')->value === DefaultContentModerationStates::DRAFT_STATE
+      ) {
+        $is_new_content = TRUE;
+      }
+
       $form['field_send_notification'] = [
         '#title' => $this->t('Send notification'),
         '#type' => 'checkbox',
-        '#default_value' => $entity->isNew() && !in_array($entity->bundle(), $field_disable_by_default_types),
+        '#default_value' => $is_new_content && !in_array($entity->bundle(), $field_disable_by_default_types),
       ];
       $form['actions']['submit']['#submit'][] = [
         $this,

--- a/lib/modules/eic_messages/src/Hooks/FormOperations.php
+++ b/lib/modules/eic_messages/src/Hooks/FormOperations.php
@@ -140,6 +140,18 @@ class FormOperations implements ContainerInjectionInterface {
     if ($is_group_content && $form_state->get('form_display')
       ->getComponent('field_post_activity')) {
 
+      // Check if the current node is the default revision and is in draft
+      // state. If that's the case, it means there is no published or archived
+      // version and therefore the post activity checkbox should be checked by
+      // default.
+      if (
+        !$is_new_content &&
+        $entity->revision_default->value &&
+        $entity->get('moderation_state')->value === DefaultContentModerationStates::DRAFT_STATE
+      ) {
+        $is_new_content = TRUE;
+      }
+
       // We show the field_post_activity if the node has an Activity message
       // template.
       if (ActivityStreamMessageTemplates::hasTemplate($node)) {


### PR DESCRIPTION
### Improvements

- Check options "Send notification" and "Post message in the activity stream" by default until there is a published revision.

### Test

- [ ] As TU, try to create a new draft discussion in a group and make sure the options "Send notification" and "Post message in the activity stream" are checked by default
- [ ] Edit the draft and make sure the options are still checked by default
- [ ] Change the discussion state to published and save it
- [ ] Edit the discussion again and make sure the options are now disabled by default because we have a published version already