### PR TITLE
EICNET-2613: Recommend content - Putting an enter inside comment field does not show up in the email

### DIFF
--- a/lib/modules/eic_recommend_content/src/Services/RecommendContentManager.php
+++ b/lib/modules/eic_recommend_content/src/Services/RecommendContentManager.php
@@ -28,6 +28,11 @@ class RecommendContentManager {
   use StringTranslationTrait;
 
   /**
+   * Array of allowed HTML tags to send on the recommendation email.
+   */
+  const RECOMMEND_ALLOWED_HTML_TAGS = ['a', 'em', 'u', 's', 'p', 'br', 'strong'];
+
+  /**
    * The entity type manager.
    *
    * @var \Drupal\Core\Entity\EntityTypeManagerInterface
@@ -290,7 +295,7 @@ class RecommendContentManager {
       'global' => $flag->isGlobal(),
       'field_recommend_emails' => implode(',', $user_emails),
       'field_recommend_message' => [
-        'value' => Markup::create(Xss::filter($message)),
+        'value' => Markup::create(Xss::filter($message, self::RECOMMEND_ALLOWED_HTML_TAGS)),
         'format' => 'basic_text',
       ],
     ]);


### PR DESCRIPTION
### Fixes

- Fix issue with allowed html tags that go in the recommendation email (`<br>` was being stripped out).

### Test

- [x] As SA/SCM, try to recommend a group
- [x] Add some text in the recommendation message field (make sure you add some enters in the text)
- [x] Confirm the recommendation
- [x] Run cron
- [x] Make sure the users received a notification and also make sure the enters were not stripped out from the recommendation message that goes in the email