### PR TITLE
EICNET-2204: Group teaser archived status

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/groups/event.inc
+++ b/lib/themes/eic_community/includes/preprocess/groups/event.inc
@@ -75,7 +75,7 @@ function eic_community_preprocess_group__event(&$variables) {
         }
 
         // Get group state.
-        $item['group_state'] = _eic_groups_get_moderation_state_tag($group);
+        $teaser['group_state'] = _eic_groups_get_moderation_state_tag($group);
 
         $teaser['type'] = [$teaser['type']];
       }

--- a/lib/themes/eic_community/includes/preprocess/groups/event.inc
+++ b/lib/themes/eic_community/includes/preprocess/groups/event.inc
@@ -74,6 +74,9 @@ function eic_community_preprocess_group__event(&$variables) {
           $teaser['type']['label'] .= " & {$value}";
         }
 
+        // Get group state.
+        $item['group_state'] = _eic_groups_get_moderation_state_tag($group);
+
         $teaser['type'] = [$teaser['type']];
       }
 

--- a/lib/themes/eic_community/includes/preprocess/groups/group.inc
+++ b/lib/themes/eic_community/includes/preprocess/groups/group.inc
@@ -75,7 +75,10 @@ function eic_community_preprocess_group__group(array &$variables) {
       }
 
       // Get group visibility.
-      if ($group_visibility_label = \Drupal::service('oec_group_flex.helper')->getGroupVisibilityTagLabel($group)) {
+      if (
+        \Drupal::currentUser()->isAuthenticated() &&
+        $group_visibility_label = \Drupal::service('oec_group_flex.helper')->getGroupVisibilityTagLabel($group)
+      ) {
         $item['type']['label'] = $group_visibility_label;
         $item['type']['extra_classes'] = 'ecl-tag--is-' . strtolower($group_visibility_label);
       }
@@ -437,10 +440,6 @@ function _preprocess_group_tags(GroupInterface $group) {
  *   The group moderation state tag.
  */
 function _eic_groups_get_moderation_state_tag(GroupInterface $group) {
-  if (\Drupal::currentUser()->isAnonymous()) {
-    return [];
-  }
-
   $moderation_state = $group->get('moderation_state')->value;
   $tag = [];
   if ($moderation_state !== GroupsModerationHelper::GROUP_PUBLISHED_STATE) {

--- a/lib/themes/eic_community/includes/preprocess/groups/group.inc
+++ b/lib/themes/eic_community/includes/preprocess/groups/group.inc
@@ -10,6 +10,7 @@ use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Render\Markup;
 use Drupal\eic_community\ValueObject\ImageValueObject;
 use Drupal\eic_groups\EICGroupsHelper;
+use Drupal\eic_groups\GroupsModerationHelper;
 use Drupal\eic_media\MediaHelper;
 use Drupal\file\Entity\File;
 use Drupal\group\Entity\GroupInterface;
@@ -81,6 +82,9 @@ function eic_community_preprocess_group__group(array &$variables) {
 
       // Get group tags.
       $item['tags'] = _preprocess_group_tags($group);
+
+      // Get group state.
+      $item['group_state'] = _eic_groups_get_moderation_state_tag($group);
 
       // Get group last activity.
       // @todo Get the real last activity.
@@ -421,4 +425,44 @@ function _preprocess_group_tags(GroupInterface $group) {
     }
   }
   return $tags;
+}
+
+/**
+ * Gets group moderation state tag.
+ *
+ * @param \Drupal\group\Entity\GroupInterface $group
+ *   The group entity.
+ *
+ * @return array
+ *   The group moderation state tag.
+ */
+function _eic_groups_get_moderation_state_tag(GroupInterface $group) {
+  if (\Drupal::currentUser()->isAnonymous()) {
+    return [];
+  }
+
+  $moderation_state = $group->get('moderation_state')->value;
+  $tag = [];
+  if ($moderation_state !== GroupsModerationHelper::GROUP_PUBLISHED_STATE) {
+    $moderation_id = 'public';
+
+    switch ($moderation_id) {
+      case 'draft':
+      case 'blocked':
+        $moderation_id = 'private';
+        break;
+
+      case 'pending':
+        $moderation_id = 'restricted';
+        break;
+
+    }
+
+    $tag = [
+      'label' => ucfirst($moderation_state),
+      'extra_classes' => "ecl-tag--is-$moderation_id",
+    ];
+  }
+
+  return $tag;
 }

--- a/lib/themes/eic_community/includes/preprocess/groups/organisation.inc
+++ b/lib/themes/eic_community/includes/preprocess/groups/organisation.inc
@@ -640,6 +640,9 @@ function _eic_community_render_organisation_teaser(&$variables, GroupInterface $
     ];
   }
 
+  // Get group state.
+  $teaser['group_state'] = _eic_groups_get_moderation_state_tag($group);
+
   // Get organisation statistics.
   $organisation_statistics = \Drupal::service('eic_group_statistics.helper')->loadGroupStatistics($group);
   $teaser['stats'] = [

--- a/lib/themes/eic_community/patterns/compositions/event/event.teaser.html.twig
+++ b/lib/themes/eic_community/patterns/compositions/event/event.teaser.html.twig
@@ -1,158 +1,169 @@
 {% set title_element = title_element|default('h2') %}
 
 <div class="ecl-teaser ecl-teaser--event {{ highlight.is_active ? 'ecl-teaser--is-highlighted' }} {{ extra_classes }}">
-  <div class="ecl-teaser__main">
-    {% if image is not empty %}
-      <figure class="ecl-teaser__image-wrapper">
-        <img class="ecl-teaser__image" src="{{ image.src }}" alt="{{ image.alt }}" />
-      </figure>
-    {% endif %}
-    <div class="ecl-teaser__main-wrapper">
-      <div class="ecl-teaser__content-wrapper">
-        <div class="ecl-teaser__content">
-          {% if tags is not empty %}
-            <div class="ecl-teaser__tags-wrapper">
-              <div class="ecl-teaser__tags">
-                {% for tag in tags %}
-                  <div class="ecl-teaser__tag">
-                    {% include '@ecl-twig/ec-component-tag/ecl-tag.html.twig' with {
+	<div class="ecl-teaser__main">
+		{% if image is not empty %}
+			<figure class="ecl-teaser__image-wrapper">
+				<img class="ecl-teaser__image" src="{{ image.src }}" alt="{{ image.alt }}"/>
+			</figure>
+		{% endif %}
+		<div class="ecl-teaser__main-wrapper">
+			<div class="ecl-teaser__content-wrapper">
+				<div class="ecl-teaser__content">
+					{% if tags is not empty || group_state is not empty %}
+						<div class="ecl-teaser__tags-wrapper">
+							<div class="ecl-teaser__tags">
+								{% for tag in tags %}
+									<div class="ecl-teaser__tag">
+										{% include '@ecl-twig/ec-component-tag/ecl-tag.html.twig' with {
                       tag: tag|merge({
                         type: tag.path ? 'link' : 'display',
                       })
                     } only %}
-                  </div>
-                {% endfor %}
-              </div>
-            </div>
-          {% endif %}
-
-        <{{ title_element }} class="ecl-teaser__title">
-          {% if path is not empty %}
-            <a href="{{ path }}">
-              {% if title_before %}
-                <span class="ecl-teaser__title-before">{{ title_before }}</span>
-              {% endif %}
-
-              <span class="ecl-teaser__title-overflow"><span>{{ title }}</span></span>
-
-              {% if title_after %}
-                <span class="ecl-teaser__title-after">{{ title_after }}</span>
-              {% endif %}
-            </a>
-          {% else %}
-            {% if title_before %}
-              <span class="ecl-teaser__title-before">{{ title_before }}</span>
-            {% endif %}
-
-            <span class="ecl-teaser__title-overflow"><span>{{ title }}</span></span>
-
-            {% if title_after %}
-              <span class="ecl-teaser__title-after">{{ title_after }}</span>
-            {% endif %}
-          {% endif %}
-        </{{ title_element }}>
-
-          {# {% if stats is not empty or type is not empty %}
-            <div class="ecl-teaser__meta-fields">
-              {% if type is not empty %}
-                {% include "@theme/patterns/components/content-type-indicator.html.twig" with type|default({})|merge({
-                  extra_classes: 'ecl-teaser__type',
-                  icon_file_path: icon_file_path,
-                }) only %}
-              {% endif %}
-
-              {% if stats is not empty %}
-                <div class="ecl-teaser__stats">
-                  {% for stat in stats %}
-                    <div class="ecl-teaser__stat">
-                      {% if stat.icon is not empty and icon_file_path %}
-                        {% include '@ecl-twig/ec-component-icon/ecl-icon.html.twig' with {
-                          icon: {
-                            size: 'xs',
-                            path: icon_file_path,
-                            type: stat.icon.type,
-                            name: stat.icon.name,
-                          },
-                          extra_classes: 'ecl-teaser__stat-icon',
-                        } only %}
-                      {% endif %}
-                      <span class="ecl-teaser__stat-label">{{ stat.label }}</span>
-                      <span class="ecl-teaser__stat-value">{{ stat.value }}</span>
-                    </div>
-                  {% endfor %}
-                </div>
-              {% endif %}
-            </div>
-          {% endif %} #}
-
-          {# <div class="ecl-teaser__meta-footer"> #}
-            {# {% if actions is not empty %}
-              <div class="ecl-teaser__actions">
-                {% for action in actions %}
-                  <div class="ecl-teaser__action">
-                    {% set _icon = {} %}
-
-                    {% if icon_file_path and action.icon %}
-                      {% set _icon = action.icon|default({})|merge({
-                        path: icon_file_path,
-                        size: 'm',
-                      }) %}
-                    {% endif %}
-
-                    {% include '@ecl-twig/ec-component-link/ecl-link.html.twig' with {
-                      icon: _icon,
-                      extra_classes: 'ecl-link--button ecl-link--button-primary',
-                      link: {
-                        path: action.path,
-                        label: action.label,
-                        icon_position: 'before',
-                        type: 'standalone',
-                      },
+										{% include "@ecl-twig/ec-component-tag/ecl-tag.html.twig" with {
+                      tag: group_state|merge({
+                        type: 'display',
+                      }),
+                      extra_classes: group_state.extra_classes,
                     } only %}
-                  </div>
-                {% endfor %}
-              </div>
-            {% endif %}
+									</div>
+								{% endfor %}
+							</div>
+						</div>
+					{% endif %}
 
-            {% if timestamp %}
-              <div class="ecl-teaser__meta-column">
-                {% include "@theme/patterns/components/timestamp.html.twig" with timestamp|default({})|merge({
-                  icon_file_path: icon_file_path,
-                  extra_classes: 'ecl-teaser__timestamp',
-                }) only %}
-              </div>
-            {% endif %} #}
-          {# </div> #}
-        </div>
-        {% if date is not empty %}
-          <div class="ecl-teaser__content-aside">
-{#            {% include '@ecl-twig/ec-component-date-block/ecl-date-block.html.twig' with date|default({}) only %}#}
-              {% include '@theme/patterns/components/date.custom.html.twig' with date|default({}) only %}
-          </div>
-        {% endif %}
-      </div>
+					<{{title_element}} class="ecl-teaser__title">
+						{% if path is not empty %}
+							<a href="{{ path }}">
+								{% if title_before %}
+									<span class="ecl-teaser__title-before">{{ title_before }}</span>
+								{% endif %}
 
-      <div class="ecl-teaser__meta-footer">
-        <div class="ecl-teaser__meta-column">
-          {% if type is not empty %}
-            {% if type is not iterable %}
-              {% set type = [type] %}
-            {% endif %}
-            {% for typeRow in type %}
-              {% include "@theme/patterns/components/content-type-indicator.html.twig" with typeRow|default({})|merge({
+								<span class="ecl-teaser__title-overflow">
+									<span>{{ title }}</span>
+								</span>
+
+								{% if title_after %}
+									<span class="ecl-teaser__title-after">{{ title_after }}</span>
+								{% endif %}
+							</a>
+						{% else %}
+							{% if title_before %}
+								<span class="ecl-teaser__title-before">{{ title_before }}</span>
+							{% endif %}
+
+							<span class="ecl-teaser__title-overflow">
+								<span>{{ title }}</span>
+							</span>
+
+							{% if title_after %}
+								<span class="ecl-teaser__title-after">{{ title_after }}</span>
+							{% endif %}
+						{% endif %}
+					</{{title_element}}>
+
+					{# {% if stats is not empty or type is not empty %}
+					            <div class="ecl-teaser__meta-fields">
+					              {% if type is not empty %}
+					                {% include "@theme/patterns/components/content-type-indicator.html.twig" with type|default({})|merge({
+					                  extra_classes: 'ecl-teaser__type',
+					                  icon_file_path: icon_file_path,
+					                }) only %}
+					              {% endif %}
+					
+					              {% if stats is not empty %}
+					                <div class="ecl-teaser__stats">
+					                  {% for stat in stats %}
+					                    <div class="ecl-teaser__stat">
+					                      {% if stat.icon is not empty and icon_file_path %}
+					                        {% include '@ecl-twig/ec-component-icon/ecl-icon.html.twig' with {
+					                          icon: {
+					                            size: 'xs',
+					                            path: icon_file_path,
+					                            type: stat.icon.type,
+					                            name: stat.icon.name,
+					                          },
+					                          extra_classes: 'ecl-teaser__stat-icon',
+					                        } only %}
+					                      {% endif %}
+					                      <span class="ecl-teaser__stat-label">{{ stat.label }}</span>
+					                      <span class="ecl-teaser__stat-value">{{ stat.value }}</span>
+					                    </div>
+					                  {% endfor %}
+					                </div>
+					              {% endif %}
+					            </div>
+					          {% endif %} #}
+
+				{# <div class="ecl-teaser__meta-footer"> #}
+					{# {% if actions is not empty %}
+					              <div class="ecl-teaser__actions">
+					                {% for action in actions %}
+					                  <div class="ecl-teaser__action">
+					                    {% set _icon = {} %}
+					
+					                    {% if icon_file_path and action.icon %}
+					                      {% set _icon = action.icon|default({})|merge({
+					                        path: icon_file_path,
+					                        size: 'm',
+					                      }) %}
+					                    {% endif %}
+					
+					                    {% include '@ecl-twig/ec-component-link/ecl-link.html.twig' with {
+					                      icon: _icon,
+					                      extra_classes: 'ecl-link--button ecl-link--button-primary',
+					                      link: {
+					                        path: action.path,
+					                        label: action.label,
+					                        icon_position: 'before',
+					                        type: 'standalone',
+					                      },
+					                    } only %}
+					                  </div>
+					                {% endfor %}
+					              </div>
+					            {% endif %}
+					
+					            {% if timestamp %}
+					              <div class="ecl-teaser__meta-column">
+					                {% include "@theme/patterns/components/timestamp.html.twig" with timestamp|default({})|merge({
+					                  icon_file_path: icon_file_path,
+					                  extra_classes: 'ecl-teaser__timestamp',
+					                }) only %}
+					              </div>
+					            {% endif %} #}
+					{# </div> #}
+				</div>
+				{% if date is not empty %}
+					<div
+						class="ecl-teaser__content-aside">
+						{#            {% include '@ecl-twig/ec-component-date-block/ecl-date-block.html.twig' with date|default({}) only %}#}
+						{% include '@theme/patterns/components/date.custom.html.twig' with date|default({}) only %}
+					</div>
+				{% endif %}
+			</div>
+
+			<div class="ecl-teaser__meta-footer">
+				<div class="ecl-teaser__meta-column">
+					{% if type is not empty %}
+						{% if type is not iterable %}
+							{% set type = [type] %}
+						{% endif %}
+						{% for typeRow in type %}
+							{% include "@theme/patterns/components/content-type-indicator.html.twig" with typeRow|default({})|merge({
                 extra_classes: 'ecl-teaser__type ' ~ typeRow.extra_classes,
                 icon_file_path: icon_file_path,
               }) only %}
-            {% endfor %}
-          {% endif %}
+						{% endfor %}
+					{% endif %}
 
-          {% if stats is not empty %}
-            <div class="ecl-teaser__stats-wrapper">
-              <div class="ecl-teaser__stats">
-                {% for stat in stats %}
-                  <div class="ecl-teaser__stat">
-                    {% if stat.icon is not empty and icon_file_path %}
-                      {% include '@ecl-twig/ec-component-icon/ecl-icon.html.twig' with {
+					{% if stats is not empty %}
+						<div class="ecl-teaser__stats-wrapper">
+							<div class="ecl-teaser__stats">
+								{% for stat in stats %}
+									<div class="ecl-teaser__stat">
+										{% if stat.icon is not empty and icon_file_path %}
+											{% include '@ecl-twig/ec-component-icon/ecl-icon.html.twig' with {
                         icon: {
                           size: 'xs',
                           path: icon_file_path,
@@ -161,48 +172,48 @@
                         },
                         extra_classes: 'ecl-teaser__stat-icon',
                       } only %}
-                    {% endif %}
-                    <span class="ecl-teaser__stat-label">{{ stat.label }}</span>
-                    <span class="ecl-teaser__stat-value">{{ stat.value }}</span>
-                  </div>
-                {% endfor %}
-              </div>
-            </div>
-          {% endif %}
+										{% endif %}
+										<span class="ecl-teaser__stat-label">{{ stat.label }}</span>
+										<span class="ecl-teaser__stat-value">{{ stat.value }}</span>
+									</div>
+								{% endfor %}
+							</div>
+						</div>
+					{% endif %}
 
-          {% if members %}
-            {% include "@theme/patterns/components/author-collection.html.twig" with {
+					{% if members %}
+						{% include "@theme/patterns/components/author-collection.html.twig" with {
               extra_classes: 'ecl-teaser__author-collection',
               length: members.value,
             } %}
-          {% endif %}
-        </div>
-      </div>
-    </div>
-  </div>
-  {% if timestamp or actions %}
-    <div class="ecl-teaser__footer">
-      {% if timestamp %}
-        {% include "@theme/patterns/components/timestamp.html.twig" with timestamp|default({})|merge({
+					{% endif %}
+				</div>
+			</div>
+		</div>
+	</div>
+	{% if timestamp or actions %}
+		<div class="ecl-teaser__footer">
+			{% if timestamp %}
+				{% include "@theme/patterns/components/timestamp.html.twig" with timestamp|default({})|merge({
           icon_file_path: icon_file_path,
           extra_classes: 'ecl-teaser__timestamp',
         }) only %}
-      {% endif %}
+			{% endif %}
 
-      {% if actions is not empty %}
-        <div class="ecl-teaser__actions">
-          {% for action in actions %}
-            <div class="ecl-teaser__action">
-              {% set _icon = {} %}
+			{% if actions is not empty %}
+				<div class="ecl-teaser__actions">
+					{% for action in actions %}
+						<div class="ecl-teaser__action">
+							{% set _icon = {} %}
 
-              {% if icon_file_path and action.icon %}
-                {% set _icon = action.icon|default({})|merge({
+							{% if icon_file_path and action.icon %}
+								{% set _icon = action.icon|default({})|merge({
                   path: icon_file_path,
                   size: 'm',
                 }) %}
-              {% endif %}
+							{% endif %}
 
-              {% include '@ecl-twig/ec-component-link/ecl-link.html.twig' with {
+							{% include '@ecl-twig/ec-component-link/ecl-link.html.twig' with {
                 icon: _icon,
                 extra_classes: 'ecl-link--button ecl-link--button-primary',
                 link: {
@@ -212,10 +223,10 @@
                   type: 'standalone',
                 },
               } only %}
-            </div>
-          {% endfor %}
-        </div>
-      {% endif %}
-    </div>
-  {% endif %}
+						</div>
+					{% endfor %}
+				</div>
+			{% endif %}
+		</div>
+	{% endif %}
 </div>

--- a/lib/themes/eic_community/patterns/compositions/event/event.teaser.html.twig
+++ b/lib/themes/eic_community/patterns/compositions/event/event.teaser.html.twig
@@ -10,7 +10,7 @@
 		<div class="ecl-teaser__main-wrapper">
 			<div class="ecl-teaser__content-wrapper">
 				<div class="ecl-teaser__content">
-					{% if tags is not empty || group_state is not empty %}
+					{% if tags is not empty or group_state is not empty %}
 						<div class="ecl-teaser__tags-wrapper">
 							<div class="ecl-teaser__tags">
 								{% for tag in tags %}
@@ -20,14 +20,18 @@
                         type: tag.path ? 'link' : 'display',
                       })
                     } only %}
-										{% include "@ecl-twig/ec-component-tag/ecl-tag.html.twig" with {
-                      tag: group_state|merge({
-                        type: 'display',
-                      }),
-                      extra_classes: group_state.extra_classes,
-                    } only %}
 									</div>
 								{% endfor %}
+								{% if group_state is not empty %}
+									<div class="ecl-teaser__tag">
+										{% include "@ecl-twig/ec-component-tag/ecl-tag.html.twig" with {
+											tag: group_state|merge({
+												type: 'display',
+											}),
+											extra_classes: group_state.extra_classes,
+										} only %}
+									</div>
+								{% endif %}
 							</div>
 						</div>
 					{% endif %}
@@ -70,7 +74,7 @@
 					                  icon_file_path: icon_file_path,
 					                }) only %}
 					              {% endif %}
-					
+
 					              {% if stats is not empty %}
 					                <div class="ecl-teaser__stats">
 					                  {% for stat in stats %}
@@ -101,14 +105,14 @@
 					                {% for action in actions %}
 					                  <div class="ecl-teaser__action">
 					                    {% set _icon = {} %}
-					
+
 					                    {% if icon_file_path and action.icon %}
 					                      {% set _icon = action.icon|default({})|merge({
 					                        path: icon_file_path,
 					                        size: 'm',
 					                      }) %}
 					                    {% endif %}
-					
+
 					                    {% include '@ecl-twig/ec-component-link/ecl-link.html.twig' with {
 					                      icon: _icon,
 					                      extra_classes: 'ecl-link--button ecl-link--button-primary',
@@ -123,7 +127,7 @@
 					                {% endfor %}
 					              </div>
 					            {% endif %}
-					
+
 					            {% if timestamp %}
 					              <div class="ecl-teaser__meta-column">
 					                {% include "@theme/patterns/components/timestamp.html.twig" with timestamp|default({})|merge({

--- a/lib/themes/eic_community/patterns/compositions/group/group.teaser.html.twig
+++ b/lib/themes/eic_community/patterns/compositions/group/group.teaser.html.twig
@@ -26,20 +26,26 @@
 		</a>
 	{% endif %}
 	<div class="ecl-teaser__main-wrapper">
-		{% if type is not empty || group_state is not empty %}
+		{% if type is not empty or group_state is not empty %}
 			<div class="ecl-teaser__meta-header">
-				{% include "@ecl-twig/ec-component-tag/ecl-tag.html.twig" with {
-          tag: type|merge({
-            type: type.path ? 'link' : 'display',
-          }),
-          extra_classes: type.extra_classes,
-        } only %}
-				{% include "@ecl-twig/ec-component-tag/ecl-tag.html.twig" with {
-          tag: group_state|merge({
-            type: 'display',
-          }),
-          extra_classes: group_state.extra_classes,
-        } only %}
+				<div class="ecl-teaser__tag">
+					{% include "@ecl-twig/ec-component-tag/ecl-tag.html.twig" with {
+						tag: type|merge({
+							type: type.path ? 'link' : 'display',
+						}),
+						extra_classes: type.extra_classes,
+					} only %}
+				</div>
+				{% if group_state is not empty %}
+					<div class="ecl-teaser__tag">
+						{% include "@ecl-twig/ec-component-tag/ecl-tag.html.twig" with {
+							tag: group_state|merge({
+								type: 'display',
+							}),
+							extra_classes: group_state.extra_classes,
+						} only %}
+					</div>
+				{% endif %}
 			</div>
 		{% endif %}
 		<div class="ecl-teaser__content-wrapper">

--- a/lib/themes/eic_community/patterns/compositions/group/group.teaser.html.twig
+++ b/lib/themes/eic_community/patterns/compositions/group/group.teaser.html.twig
@@ -28,14 +28,16 @@
 	<div class="ecl-teaser__main-wrapper">
 		{% if type is not empty or group_state is not empty %}
 			<div class="ecl-teaser__meta-header">
-				<div class="ecl-teaser__tag">
-					{% include "@ecl-twig/ec-component-tag/ecl-tag.html.twig" with {
-						tag: type|merge({
-							type: type.path ? 'link' : 'display',
-						}),
-						extra_classes: type.extra_classes,
-					} only %}
-				</div>
+				{% if type is not empty %}
+					<div class="ecl-teaser__tag">
+						{% include "@ecl-twig/ec-component-tag/ecl-tag.html.twig" with {
+							tag: type|merge({
+								type: type.path ? 'link' : 'display',
+							}),
+							extra_classes: type.extra_classes,
+						} only %}
+					</div>
+				{% endif %}
 				{% if group_state is not empty %}
 					<div class="ecl-teaser__tag">
 						{% include "@ecl-twig/ec-component-tag/ecl-tag.html.twig" with {

--- a/lib/themes/eic_community/patterns/compositions/group/group.teaser.html.twig
+++ b/lib/themes/eic_community/patterns/compositions/group/group.teaser.html.twig
@@ -1,16 +1,16 @@
 {% set title_element = title_element|default('h2') %}
 
 <div class="ecl-teaser ecl-teaser--group {{ highlight.is_active ? 'ecl-teaser--is-highlighted' }} {{ extra_classes }}">
-  {% if path is not empty %}
-    <a href="{{ path }}">
-  {% endif %}
-    <figure class="ecl-teaser__image-wrapper">
-      {% if image is not empty %}
-        <img class="ecl-teaser__image" src="{{ image.src }}" alt="{{ image.alt }}" />
-      {% else %}
-        {% if icon_file_path %}
-          <div class="ecl-teaser__image-fallback-wrapper">
-            {% include '@ecl-twig/ec-component-icon/ecl-icon.html.twig' with {
+	{% if path is not empty %}
+		<a href="{{ path }}">
+		{% endif %}
+		<figure class="ecl-teaser__image-wrapper">
+			{% if image is not empty %}
+				<img class="ecl-teaser__image" src="{{ image.src }}" alt="{{ image.alt }}"/>
+			{% else %}
+				{% if icon_file_path %}
+					<div class="ecl-teaser__image-fallback-wrapper">
+						{% include '@ecl-twig/ec-component-icon/ecl-icon.html.twig' with {
               icon: {
                 size: '3xl',
                 path: icon_file_path,
@@ -18,76 +18,86 @@
                 name: 'group_circle',
               },
             } only %}
-          </div>
-        {% endif %}
-      {% endif %}
-    </figure>
-  {% if path is not empty %}
-    </a>
-  {% endif %}
-  <div class="ecl-teaser__main-wrapper">
-    {% if type is not empty %}
-      <div class="ecl-teaser__meta-header">
-        {% include "@ecl-twig/ec-component-tag/ecl-tag.html.twig" with {
+					</div>
+				{% endif %}
+			{% endif %}
+		</figure>
+		{% if path is not empty %}
+		</a>
+	{% endif %}
+	<div class="ecl-teaser__main-wrapper">
+		{% if type is not empty || group_state is not empty %}
+			<div class="ecl-teaser__meta-header">
+				{% include "@ecl-twig/ec-component-tag/ecl-tag.html.twig" with {
           tag: type|merge({
             type: type.path ? 'link' : 'display',
           }),
           extra_classes: type.extra_classes,
         } only %}
-      </div>
-    {% endif %}
-    <div class="ecl-teaser__content-wrapper">
-      <div class="ecl-teaser__content">
-        <{{ title_element }} class="ecl-teaser__title">
-          {% if path is not empty %}
-            <a href="{{ path }}">
-              {% if title_before %}
-                <span class="ecl-teaser__title-before">{{ title_before }}</span>
-              {% endif %}
+				{% include "@ecl-twig/ec-component-tag/ecl-tag.html.twig" with {
+          tag: group_state|merge({
+            type: 'display',
+          }),
+          extra_classes: group_state.extra_classes,
+        } only %}
+			</div>
+		{% endif %}
+		<div class="ecl-teaser__content-wrapper">
+			<div class="ecl-teaser__content">
+				<{{title_element}} class="ecl-teaser__title">
+					{% if path is not empty %}
+						<a href="{{ path }}">
+							{% if title_before %}
+								<span class="ecl-teaser__title-before">{{ title_before }}</span>
+							{% endif %}
 
-              <span class="ecl-teaser__title-overflow"><span>{{ title }}</span></span>
+							<span class="ecl-teaser__title-overflow">
+								<span>{{ title }}</span>
+							</span>
 
-              {% if title_after %}
-                <span class="ecl-teaser__title-after">{{ title_after }}</span>
-              {% endif %}
-            </a>
-          {% else %}
-            {% if title_before %}
-              <span class="ecl-teaser__title-before">{{ title_before }}</span>
-            {% endif %}
+							{% if title_after %}
+								<span class="ecl-teaser__title-after">{{ title_after }}</span>
+							{% endif %}
+						</a>
+					{% else %}
+						{% if title_before %}
+							<span class="ecl-teaser__title-before">{{ title_before }}</span>
+						{% endif %}
 
-            <span class="ecl-teaser__title-overflow"><span>{{ title }}</span></span>
+						<span class="ecl-teaser__title-overflow">
+							<span>{{ title }}</span>
+						</span>
 
-            {% if title_after %}
-              <span class="ecl-teaser__title-after">{{ title_after }}</span>
-            {% endif %}
-          {% endif %}
-        </{{ title_element }}>
+						{% if title_after %}
+							<span class="ecl-teaser__title-after">{{ title_after }}</span>
+						{% endif %}
+					{% endif %}
+				</{{title_element}}>
 
-        {% if owner is not empty %}
-          {% include "@theme/patterns/components/author.html.twig" with owner|default({})|merge({
+				{% if owner is not empty %}
+					{% include "@theme/patterns/components/author.html.twig" with owner|default({})|merge({
             extra_classes: 'ecl-teaser__meta',
             size: 'tiny',
             author: owner.name,
             image: owner.image,
             icon_file_path: icon_file_path,
           }) only %}
-        {% endif %}
+				{% endif %}
 
-        {% if timestamp is not empty %}
-          {% include "@theme/patterns/components/timestamp.html.twig" with timestamp|default({})|merge({
+				{% if timestamp is not empty %}
+					{% include "@theme/patterns/components/timestamp.html.twig" with timestamp|default({})|merge({
             icon_file_path: icon_file_path
           }) only %}
-        {% endif %}
-      </div>
-    </div>
-    {% if stats is not empty %}
-      <div class="ecl-teaser__meta-footer">
-        <div class="ecl-teaser__stats">
-          {% for stat in stats %}
-            <div class="ecl-teaser__stat">
-              {% if stat.icon is not empty and icon_file_path %}
-                {% include '@ecl-twig/ec-component-icon/ecl-icon.html.twig' with {
+				{% endif %}
+			</div>
+		</div>
+		{% if stats is not empty %}
+			<div class="ecl-teaser__meta-footer">
+				<div class="ecl-teaser__stats">
+					{% for stat in stats %}
+						<div class="ecl-teaser__stat">
+							{% if stat.icon is not empty and icon_file_path %}
+								{% include '@ecl-twig/ec-component-icon/ecl-icon.html.twig' with {
                   icon: {
                     size: 'xs',
                     path: icon_file_path,
@@ -96,13 +106,13 @@
                   },
                   extra_classes: 'ecl-teaser__stat-icon',
                 } only %}
-              {% endif %}
-              <span class="ecl-teaser__stat-label">{{ stat.label }}</span>
-              <span class="ecl-teaser__stat-value">{{ stat.value }}</span>
-            </div>
-          {% endfor %}
-        </div>
-      </div>
-    {% endif %}
-  </div>
+							{% endif %}
+							<span class="ecl-teaser__stat-label">{{ stat.label }}</span>
+							<span class="ecl-teaser__stat-value">{{ stat.value }}</span>
+						</div>
+					{% endfor %}
+				</div>
+			</div>
+		{% endif %}
+	</div>
 </div>

--- a/lib/themes/eic_community/patterns/compositions/organisation/organisation.teaser.html.twig
+++ b/lib/themes/eic_community/patterns/compositions/organisation/organisation.teaser.html.twig
@@ -1,61 +1,75 @@
 {% set title_element = title_element|default('h2') %}
 
 <div class="ecl-teaser ecl-teaser--organisation {{ highlight.is_active ? 'ecl-teaser--is-highlighted' }} {{ extra_classes }}">
-  {% if image is not empty %}
-  <a href="{{ path }}">
-    <figure class="ecl-teaser__image-wrapper">
-      <img class="ecl-teaser__image" src="{{ image.src }}" alt="{{ image.alt }}" />
-    </figure>
-  </a>
-  {% endif %}
-  <div class="ecl-teaser__main-wrapper">
-    {% if tags is not empty %}
-      <div class="ecl-teaser__meta-header">
-        <div class="ecl-teaser__tags">
-          {% for tag in tags %}
-            <div class="ecl-teaser__tag">
-              {% include "@ecl-twig/ec-component-tag/ecl-tag.html.twig" with {
+	{% if image is not empty %}
+		<a href="{{ path }}">
+			<figure class="ecl-teaser__image-wrapper">
+				<img class="ecl-teaser__image" src="{{ image.src }}" alt="{{ image.alt }}"/>
+			</figure>
+		</a>
+	{% endif %}
+	<div class="ecl-teaser__main-wrapper">
+		{% if tags is not empty || group_state is not empty %}
+			<div class="ecl-teaser__meta-header">
+				<div class="ecl-teaser__tags">
+					{% for tag in tags %}
+						<div class="ecl-teaser__tag">
+							{% include "@ecl-twig/ec-component-tag/ecl-tag.html.twig" with {
                 tag: tag|merge({
                   type: tag.path ? "link" : "display"
                 })
               } only %}
-            </div>
-          {% endfor %}
-        </div>
-      </div>
-    {% endif %}
-    <div class="ecl-teaser__content-wrapper">
-      <div class="ecl-teaser__content">
-        <{{ title_element }} class="ecl-teaser__title">
-          {% if path is not empty %}
-            <a href="{{ path }}">
-              {% if title_before %}
-                <span class="ecl-teaser__title-before">{{ title_before }}</span>
-              {% endif %}
+						</div>
+					{% endfor %}
+					{% if group_state is not empty %}
+						<div class="ecl-teaser__tag">
+							{% include "@ecl-twig/ec-component-tag/ecl-tag.html.twig" with {
+              tag: group_state|merge({
+                type: 'display',
+              }),
+              extra_classes: group_state.extra_classes,
+            } only %}
+						</div>
+					{% endif %}
+				</div>
+			</div>
+		{% endif %}
+		<div class="ecl-teaser__content-wrapper">
+			<div class="ecl-teaser__content">
+				<{{title_element}} class="ecl-teaser__title">
+					{% if path is not empty %}
+						<a href="{{ path }}">
+							{% if title_before %}
+								<span class="ecl-teaser__title-before">{{ title_before }}</span>
+							{% endif %}
 
-              <span class="ecl-teaser__title-overflow"><span>{{ title }}</span></span>
+							<span class="ecl-teaser__title-overflow">
+								<span>{{ title }}</span>
+							</span>
 
-              {% if title_after %}
-                <span class="ecl-teaser__title-after">{{ title_after }}</span>
-              {% endif %}
-            </a>
-          {% else %}
-            {% if title_before %}
-              <span class="ecl-teaser__title-before">{{ title_before }}</span>
-            {% endif %}
+							{% if title_after %}
+								<span class="ecl-teaser__title-after">{{ title_after }}</span>
+							{% endif %}
+						</a>
+					{% else %}
+						{% if title_before %}
+							<span class="ecl-teaser__title-before">{{ title_before }}</span>
+						{% endif %}
 
-            <span class="ecl-teaser__title-overflow"><span>{{ title }}</span></span>
+						<span class="ecl-teaser__title-overflow">
+							<span>{{ title }}</span>
+						</span>
 
 
-            {% if title_after %}
-              <span class="ecl-teaser__title-after">{{ title_after }}</span>
-            {% endif %}
-          {% endif %}
-        </{{ title_element }}>
-        {% if location is not empty %}
-          <address class="ecl-teaser__description">
-            {% if icon_file_path %}
-              {% include "@ecl-twig/ec-component-icon/ecl-icon.html.twig" with {
+						{% if title_after %}
+							<span class="ecl-teaser__title-after">{{ title_after }}</span>
+						{% endif %}
+					{% endif %}
+				</{{title_element}}>
+				{% if location is not empty %}
+					<address class="ecl-teaser__description">
+						{% if icon_file_path %}
+							{% include "@ecl-twig/ec-component-icon/ecl-icon.html.twig" with {
                 icon: {
                   size: 'xs',
                   path: icon_file_path,
@@ -63,15 +77,15 @@
                   type: location.icon.type|default('custom'),
                 }
               } only %}
-            {% endif %}
-            {{ location.label }}
-          </address>
-        {% endif %}
+						{% endif %}
+						{{ location.label }}
+					</address>
+				{% endif %}
 
-        {% if size is not empty %}
-          <p class="ecl-teaser__description">
-            {% if icon_file_path %}
-              {% include "@ecl-twig/ec-component-icon/ecl-icon.html.twig" with {
+				{% if size is not empty %}
+					<p class="ecl-teaser__description">
+						{% if icon_file_path %}
+							{% include "@ecl-twig/ec-component-icon/ecl-icon.html.twig" with {
                 icon: {
                   size: 'xs',
                   path: icon_file_path,
@@ -79,19 +93,19 @@
                   type: size.icon.type|default('custom'),
                 }
               } only %}
-            {% endif %}
-            {{ size.label }}
-          </p>
-        {% endif %}
-      </div>
-    </div>
-    {% if stats is not empty %}
-      <div class="ecl-teaser__meta-footer">
-        <div class="ecl-teaser__stats">
-          {% for stat in stats %}
-            <div class="ecl-teaser__stat">
-              {% if stat.icon is not empty and icon_file_path %}
-                {% include '@ecl-twig/ec-component-icon/ecl-icon.html.twig' with {
+						{% endif %}
+						{{ size.label }}
+					</p>
+				{% endif %}
+			</div>
+		</div>
+		{% if stats is not empty %}
+			<div class="ecl-teaser__meta-footer">
+				<div class="ecl-teaser__stats">
+					{% for stat in stats %}
+						<div class="ecl-teaser__stat">
+							{% if stat.icon is not empty and icon_file_path %}
+								{% include '@ecl-twig/ec-component-icon/ecl-icon.html.twig' with {
                   icon: {
                     size: 'xs',
                     path: icon_file_path,
@@ -100,13 +114,13 @@
                   },
                   extra_classes: 'ecl-teaser__stat-icon',
                 } only %}
-              {% endif %}
-              <span class="ecl-teaser__stat-label">{{ stat.label }}</span>
-              <span class="ecl-teaser__stat-value">{{ stat.value }}</span>
-            </div>
-          {% endfor %}
-        </div>
-      </div>
-    {% endif %}
-  </div>
+							{% endif %}
+							<span class="ecl-teaser__stat-label">{{ stat.label }}</span>
+							<span class="ecl-teaser__stat-value">{{ stat.value }}</span>
+						</div>
+					{% endfor %}
+				</div>
+			</div>
+		{% endif %}
+	</div>
 </div>

--- a/lib/themes/eic_community/patterns/compositions/organisation/organisation.teaser.html.twig
+++ b/lib/themes/eic_community/patterns/compositions/organisation/organisation.teaser.html.twig
@@ -9,7 +9,7 @@
 		</a>
 	{% endif %}
 	<div class="ecl-teaser__main-wrapper">
-		{% if tags is not empty || group_state is not empty %}
+		{% if tags is not empty or group_state is not empty %}
 			<div class="ecl-teaser__meta-header">
 				<div class="ecl-teaser__tags">
 					{% for tag in tags %}

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/GlobalEventResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/GlobalEventResultItem.js
@@ -28,24 +28,22 @@ const GlobalEventResultItem = ({isAnonymous, result}) => {
     },
   ];
 
-  if (!isAnonymous) {
-    if (moderationState !== 'published') {
-      let moderationId = 'public';
-      switch(moderationState) {
-        case 'draft':
-        case 'blocked':
-          moderationId = 'private';
-          break;
-        case 'pending':
-          moderationId = 'restricted';
-          break;
-      }
-
-      tags = [...tags, {
-        label: moderationState.charAt(0).toUpperCase() + moderationState.slice(1),
-        id: moderationId,
-      }];
+  if (!isAnonymous && moderationState !== 'published') {
+    let moderationId = 'public';
+    switch(moderationState) {
+      case 'draft':
+      case 'blocked':
+        moderationId = 'private';
+        break;
+      case 'pending':
+        moderationId = 'restricted';
+        break;
     }
+
+    tags = [...tags, {
+      label: moderationState.charAt(0).toUpperCase() + moderationState.slice(1),
+      id: moderationId,
+    }];
   }
 
   return (

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/GlobalEventResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/GlobalEventResultItem.js
@@ -6,7 +6,7 @@ import {url} from "../../../../../Services/UrlHelper"
 
 const svg = require('../../../../../svg/svg')
 
-const GlobalEventResultItem = ({result}) => {
+const GlobalEventResultItem = ({isAnonymous, result}) => {
   const startDate = new Date(result?.ds_group_field_date_range)
   const endDate = new Date(result?.ds_group_field_date_range_end_value)
   const startDateMonth = startDate.toLocaleString('default', {month: 'short'})
@@ -19,6 +19,34 @@ const GlobalEventResultItem = ({result}) => {
   const groupImageFallback = '<use xlink:href="themes/custom/eic_community/dist/images/sprite/custom/sprites/custom.svg#custom--group_circle"></use>';
   const hasTeaser = result.ss_group_event_teaser_url_string !== undefined;
   const itemUrl = result.ss_url ? url(result.ss_url) : ''
+  const moderationState = result.ss_global_last_moderation_state;
+
+  let tags = [
+    {
+      label: result.ss_group_event_type_string,
+      id: result.ss_group_event_type_string && result.ss_group_event_type_string.toLowerCase(),
+    },
+  ];
+
+  if (!isAnonymous) {
+    if (moderationState !== 'published') {
+      let moderationId = 'public';
+      switch(moderationState) {
+        case 'draft':
+        case 'blocked':
+          moderationId = 'private';
+          break;
+        case 'pending':
+          moderationId = 'restricted';
+          break;
+      }
+
+      tags = [...tags, {
+        label: moderationState.charAt(0).toUpperCase() + moderationState.slice(1),
+        id: moderationId,
+      }];
+    }
+  }
 
   return (
     <div className={"ecl-teaser-overview__item"}>
@@ -41,9 +69,7 @@ const GlobalEventResultItem = ({result}) => {
               <div className="ecl-teaser__content">
                 <div className="ecl-teaser__tags-wrapper">
                   <div className="ecl-teaser__tags">
-                      <div className="ecl-teaser__tag">
-                        <span className="ecl-tag ecl-tag--display">{result?.ss_group_event_type_string}</span>
-                      </div>
+                    {tags.map((tag) => <div className={"ecl-teaser__tag"}><span className={`ecl-tag ecl-tag--display ecl-tag--is-${tag.id}`}>{tag.label}</span></div>)}
                   </div>
                 </div>
                 <h2 className="ecl-teaser__title">

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/GlobalEventResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/GlobalEventResultItem.js
@@ -28,7 +28,7 @@ const GlobalEventResultItem = ({isAnonymous, result}) => {
     },
   ];
 
-  if (!isAnonymous && moderationState !== 'published') {
+  if (moderationState !== 'published') {
     let moderationId = 'public';
     switch(moderationState) {
       case 'draft':

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/GroupResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/GroupResultItem.js
@@ -28,12 +28,13 @@ class GroupResultItem extends React.Component {
       this.props.result.ss_group_teaser_formatted_image !== ''
     );
 
-    let tags = [
-      {
-        label: this.props.result.ss_group_visibility_label,
-        id: this.props.result.ss_group_visibility_label && this.props.result.ss_group_visibility_label.toLowerCase(),
-      },
-    ];
+    let tags = !this.props.isAnonymous ?
+      [
+        {
+          label: this.props.result.ss_group_visibility_label,
+          id: this.props.result.ss_group_visibility_label && this.props.result.ss_group_visibility_label.toLowerCase(),
+        },
+      ] : [];
 
     if (moderationState !== 'published') {
       let moderationId = 'public';
@@ -78,7 +79,7 @@ class GroupResultItem extends React.Component {
 
           <div className="ecl-teaser__main-wrapper">
             <div className="ecl-teaser__meta-header">
-              {!this.props.isAnonymous && tags.map((tag) => <div className={"ecl-editorial-header__tag"}><span className={`ecl-tag ecl-tag--display ecl-tag--is-${tag.id}`}>{tag.label}</span></div>)}
+              {tags.map((tag) => <div className={"ecl-editorial-header__tag"}><span className={`ecl-tag ecl-tag--display ecl-tag--is-${tag.id}`}>{tag.label}</span></div>)}
             </div>
             <div className="ecl-teaser__content-wrapper">
               <div className="ecl-teaser__content">


### PR DESCRIPTION
### Improvements

- Add moderation state in events overview;
- Send group moderation state to the theme variables so that it can be rendered as a tag.

### Todo

- [x] Re-factor group teaser twig template so that it renders the moderation state if not empty. The variable name is `group_state`.

### Test

**As Anonymous and Trusted user:**

- [x] Make sure there are public archived events in the platform
- [x] Go to /events
- [x] Make sure "Archived" label is shown for archived events
- [x] Go to the homepage and make sure you have at least 1 public archived group listed there
- [x] Make sure the "Archived" label is shown
