### PR TITLE
EICNET-2559: Fix group default permissions for all group types.

### DIFF
--- a/config/sync/group.role.event-owner.yml
+++ b/config/sync/group.role.event-owner.yml
@@ -12,7 +12,6 @@ audience: member
 group_type: event
 permissions_ui: true
 permissions:
-  - 'access discussions overview'
   - 'access group search overview'
   - 'access group_node overview'
   - 'access members management'

--- a/config/sync/group.role.group-a416e6833.yml
+++ b/config/sync/group.role.group-a416e6833.yml
@@ -24,6 +24,7 @@ permissions:
   - 'access latest activity stream'
   - 'access members management'
   - 'access members overview'
+  - 'access news overview'
   - 'access wiki overview'
   - 'administer members'
   - 'administer membership requests'

--- a/config/sync/group.role.group-anonymous.yml
+++ b/config/sync/group.role.group-anonymous.yml
@@ -12,5 +12,4 @@ audience: anonymous
 group_type: group
 permissions_ui: true
 permissions:
-  - 'access latest activity stream'
   - 'view group'

--- a/config/sync/group.role.group-bf4b46c3a.yml
+++ b/config/sync/group.role.group-bf4b46c3a.yml
@@ -25,6 +25,7 @@ permissions:
   - 'access latest activity stream'
   - 'access members management'
   - 'access members overview'
+  - 'access news overview'
   - 'access wiki overview'
   - 'administer members'
   - 'administer membership requests'

--- a/config/sync/group.role.group-eca6128ca.yml
+++ b/config/sync/group.role.group-eca6128ca.yml
@@ -24,6 +24,7 @@ permissions:
   - 'access latest activity stream'
   - 'access members management'
   - 'access members overview'
+  - 'access news overview'
   - 'access wiki overview'
   - 'administer members'
   - 'administer membership requests'

--- a/config/sync/group.role.organisation-dcb2f93df.yml
+++ b/config/sync/group.role.organisation-dcb2f93df.yml
@@ -15,15 +15,7 @@ audience: outsider
 group_type: organisation
 permissions_ui: false
 permissions:
-  - 'access discussions overview'
-  - 'access events overview'
-  - 'access files overview'
   - 'access group content menu overview'
-  - 'access group search overview'
-  - 'access latest activity stream'
-  - 'access members overview'
-  - 'access news overview'
-  - 'access wiki overview'
   - 'join group'
   - 'share content between groups'
   - 'view comments'

--- a/config/sync/group.role.organisation-outsider.yml
+++ b/config/sync/group.role.organisation-outsider.yml
@@ -12,14 +12,6 @@ audience: outsider
 group_type: organisation
 permissions_ui: true
 permissions:
-  - 'access discussions overview'
-  - 'access events overview'
-  - 'access files overview'
-  - 'access group search overview'
-  - 'access latest activity stream'
-  - 'access members overview'
-  - 'access news overview'
-  - 'access wiki overview'
   - 'join group'
   - 'view group'
   - 'view group_node:event content'


### PR DESCRIPTION
### Tests

- [ ] Create a new Organisation (or rebuild permissions of an existing one `/admin/community/groups/rebuild-permissions`)
- [ ] As GO/GA (not SA/SCM/DA) enable all the features
- [ ] Open all the related overviews (`/events`, `/news` and `/team`) and check that you have access
- [ ] Disable all the features
- [ ] Check that you get access denied for the same overviews

### Remarks

- I also fixed some wrong permissions in Event and Group types.