### PR TITLE
EICNET-1160: As a TU I can upload a document when creating a story (Improvements in media language display)

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/content/node--news--story.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--news--story.inc
@@ -190,6 +190,14 @@ function _eic_community_story_document_field(&$variables) {
         break;
     }
 
+    $language = $media->language()->getName();
+    if ($media_language = _eic_community_get_entity_field_language($media)) {
+      $language = $media_language;
+    }
+    elseif ($node_language = _eic_community_get_entity_field_language($node)) {
+      $language = $node_language;
+    }
+
     $author_url = $media->getOwner()->toUrl();
     $download_url = MediaHelper::formatMediaDownloadLink($media)->toString();
     $file_type = strstr($file->get('filemime')->getString(), '/', TRUE);
@@ -200,7 +208,7 @@ function _eic_community_story_document_field(&$variables) {
         'name' => $media->getOwner()->getDisplayName(),
         'path' => $author_url->access() ? $media->getOwner()->toUrl()->toString() : NULL,
       ],
-      'language' => $media->language()->getName(),
+      'language' => $language,
       'timestamp' => eic_community_get_teaser_time_display($media->get('changed')->getString()),
       'filesize' => format_size($file->get('filesize')->getString()),
       'highlight' => FALSE,

--- a/lib/themes/eic_community/includes/preprocess/field/field--media--eic-document.inc
+++ b/lib/themes/eic_community/includes/preprocess/field/field--media--eic-document.inc
@@ -47,13 +47,18 @@ function eic_community_preprocess_field__field_related_downloads(array &$variabl
       break;
     }
 
+    $language = $media->language()->getName();
+    if ($media_language = _eic_community_get_entity_field_language($media)) {
+      $language = $media_language;
+    }
+
     $file_type = strstr($file->get('filemime')->getString(), '/', TRUE);
 
     $download_url = MediaHelper::formatMediaDownloadLink($media)->toString();
 
     $document = [
       'title' => $media->getName(),
-      'language' => $media->language()->getName(),
+      'language' => $language,
       'timestamp' => eic_community_get_teaser_time_display($media->get('changed')->getString()),
       'filesize' => format_size($file->get('filesize')->getString()),
       'entity' => $media,

--- a/lib/themes/eic_community/includes/preprocess/field/field.inc
+++ b/lib/themes/eic_community/includes/preprocess/field/field.inc
@@ -5,6 +5,8 @@
  * Contains implementation for hook_preprocess_field().
  */
 
+use Drupal\Core\Entity\EntityInterface;
+
 /**
  * Implements hook_preprocess_field().
  *
@@ -67,4 +69,28 @@ function eic_community_preprocess_field(&$variables, $hook): void {
       break;
 
   }
+}
+
+/**
+ * Gets the language field of a given entity.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ *   The entity object.
+ *
+ * @return string|bool
+ *   Return the language term name or FALSE if not found.
+ */
+function _eic_community_get_entity_field_language(EntityInterface $entity) {
+  $language = FALSE;
+  // Gets the entity language field if exists.
+  if ($entity->hasField('field_language') && !$entity->get('field_language')->isEmpty()) {
+    /** @var \Drupal\taxonomy\TermInterface[] $languages */
+    $languages = $entity->get('field_language')->referencedEntities();
+    $language = $languages[0]->getName();
+    if ($languages[0]->hasTranslation($entity->language()->getId())) {
+      $language = $languages[0]->getTranslation($entity->language()->getId())
+        ->getName();
+    }
+  }
+  return $language;
 }


### PR DESCRIPTION
### Improvements

- Show media language based on media language field or node language field.

### Test

- [x] As SA/SCM, upload documents to News, Stories and discussions
- [x] Go to the detail page of each content
- [x] Make sure the downloadble medias show the correct language. If the language field is empty in the media, it should display the one set for the node.