### PR TITLE
EICNET-1320: Story migration (Set default disclaimer during migration)

### DIFF
--- a/lib/modules/eic_default_content/eic_default_content.services.yml
+++ b/lib/modules/eic_default_content/eic_default_content.services.yml
@@ -11,3 +11,8 @@ services:
     class: Drupal\eic_default_content\Generator\OverviewPageGenerator
     tags:
       - { name: data_fixtures, priority: 1 }
+  eic_default_content.fragment_generator:
+    class: Drupal\eic_default_content\Generator\FragmentGenerator
+    arguments: [ '@entity_type.manager' ]
+    tags:
+      - { name: data_fixtures, priority: -1 }

--- a/lib/modules/eic_default_content/modules/eic_dummy_content/eic_dummy_content.services.yml
+++ b/lib/modules/eic_default_content/modules/eic_dummy_content/eic_dummy_content.services.yml
@@ -22,9 +22,11 @@ services:
       - { name: data_fixtures }
   eic_default_content.story_generator:
     class: Drupal\eic_dummy_content\Generator\StoryGenerator
+    arguments: [ '@entity_type.manager' ]
     tags:
       - { name: data_fixtures }
   eic_default_content.news_generator:
     class: Drupal\eic_dummy_content\Generator\NewsGenerator
+    arguments: [ '@entity_type.manager' ]
     tags:
       - { name: data_fixtures }

--- a/lib/modules/eic_default_content/modules/eic_dummy_content/src/Generator/NewsGenerator.php
+++ b/lib/modules/eic_default_content/modules/eic_dummy_content/src/Generator/NewsGenerator.php
@@ -80,7 +80,7 @@ class NewsGenerator extends CoreGenerator {
     if (empty($fragments)) {
       $fragment = Fragment::create([
         'type' => 'disclaimer',
-        'title' => 'Disclaimer',
+        'title' => 'Default disclaimer',
         'field_body' => $this->getFormattedText(
           'full_html',
           'DISCLAIMER: This information is provided in the interest of knowledge sharing and should not be interpreted as the official view of the European Commission, or any other organisation.'

--- a/lib/modules/eic_default_content/modules/eic_dummy_content/src/Generator/NewsGenerator.php
+++ b/lib/modules/eic_default_content/modules/eic_dummy_content/src/Generator/NewsGenerator.php
@@ -83,7 +83,7 @@ class NewsGenerator extends CoreGenerator {
         'title' => 'Disclaimer',
         'field_body' => $this->getFormattedText(
           'full_html',
-          $this->t('DISCLAIMER: This information is provided in the interest of knowledge sharing and should not be interpreted as the official view of the European Commission, or any other organisation.')
+          'DISCLAIMER: This information is provided in the interest of knowledge sharing and should not be interpreted as the official view of the European Commission, or any other organisation.'
         ),
       ]);
       $fragment->save();

--- a/lib/modules/eic_default_content/modules/eic_dummy_content/src/Generator/NewsGenerator.php
+++ b/lib/modules/eic_default_content/modules/eic_dummy_content/src/Generator/NewsGenerator.php
@@ -89,7 +89,7 @@ class NewsGenerator extends CoreGenerator {
       $fragment->save();
       return $fragment;
     }
-    return !empty($fragments) ? reset($fragments) : NULL;
+    return reset($fragments);
   }
 
   /**

--- a/lib/modules/eic_default_content/modules/eic_dummy_content/src/Generator/NewsGenerator.php
+++ b/lib/modules/eic_default_content/modules/eic_dummy_content/src/Generator/NewsGenerator.php
@@ -2,9 +2,12 @@
 
 namespace Drupal\eic_dummy_content\Generator;
 
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\eic_default_content\Generator\CoreGenerator;
 use Drupal\eic_moderation\Constants\EICContentModeration;
 use Drupal\eic_private_content\PrivateContentConst;
+use Drupal\fragments\Entity\Fragment;
+use Drupal\fragments\Entity\FragmentInterface;
 use Drupal\node\Entity\Node;
 
 /**
@@ -15,9 +18,27 @@ use Drupal\node\Entity\Node;
 class NewsGenerator extends CoreGenerator {
 
   /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    parent::__construct();
+
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function load() {
+    $disclaimer = $this->getFragmentDisclaimer();
+
     for ($i = 0; $i < 5; $i++) {
       $values = [
         'title' => "News #$i",
@@ -33,6 +54,7 @@ class NewsGenerator extends CoreGenerator {
         'field_image_caption' => $this->faker->sentence(10),
         'field_vocab_topics' => $this->getRandomEntities('taxonomy_term', ['vid' => 'topics'], 1),
         'field_vocab_geo' => $this->getRandomEntities('taxonomy_term', ['vid' => 'geo'], 1),
+        'field_disclaimer' => $disclaimer,
         'moderation_state' => EICContentModeration::STATE_PUBLISHED,
         PrivateContentConst::FIELD_NAME => FALSE,
       ];
@@ -40,6 +62,34 @@ class NewsGenerator extends CoreGenerator {
       $node = Node::create($values);
       $node->save();
     }
+  }
+
+  /**
+   * Gets the default disclaimer fragment.
+   *
+   * @return \Drupal\fragments\Entity\FragmentInterface|null
+   *   The fragment entity.
+   */
+  public function getFragmentDisclaimer(): ?FragmentInterface {
+    $fragments = $this->entityTypeManager->getStorage('fragment')
+      ->loadByProperties([
+        'type' => 'disclaimer',
+      ]
+    );
+
+    if (empty($fragments)) {
+      $fragment = Fragment::create([
+        'type' => 'disclaimer',
+        'title' => 'Disclaimer',
+        'field_body' => $this->getFormattedText(
+          'full_html',
+          $this->t('DISCLAIMER: This information is provided in the interest of knowledge sharing and should not be interpreted as the official view of the European Commission, or any other organisation.')
+        ),
+      ]);
+      $fragment->save();
+      return $fragment;
+    }
+    return !empty($fragments) ? reset($fragments) : NULL;
   }
 
   /**

--- a/lib/modules/eic_default_content/modules/eic_dummy_content/src/Generator/StoryGenerator.php
+++ b/lib/modules/eic_default_content/modules/eic_dummy_content/src/Generator/StoryGenerator.php
@@ -3,7 +3,6 @@
 namespace Drupal\eic_dummy_content\Generator;
 
 use Drupal\eic_moderation\Constants\EICContentModeration;
-use Drupal\eic_default_content\Generator\CoreGenerator;
 use Drupal\node\Entity\Node;
 
 /**
@@ -11,12 +10,14 @@ use Drupal\node\Entity\Node;
  *
  * @package Drupal\eic_dummy_content\Generator
  */
-class StoryGenerator extends CoreGenerator {
+class StoryGenerator extends NewsGenerator {
 
   /**
    * {@inheritdoc}
    */
   public function load() {
+    $disclaimer = $this->getFragmentDisclaimer();
+
     for ($i = 0; $i < 5; $i++) {
       $values = [
         'title' => "Story #$i",
@@ -32,6 +33,7 @@ class StoryGenerator extends CoreGenerator {
         'field_image_caption' => $this->faker->sentence(10),
         'field_vocab_topics' => $this->getRandomEntities('taxonomy_term', ['vid' => 'topics'], 1),
         'field_vocab_geo' => $this->getRandomEntities('taxonomy_term', ['vid' => 'geo'], 1),
+        'field_disclaimer' => $disclaimer,
         'moderation_state' => EICContentModeration::STATE_PUBLISHED,
       ];
 

--- a/lib/modules/eic_default_content/src/Generator/FragmentGenerator.php
+++ b/lib/modules/eic_default_content/src/Generator/FragmentGenerator.php
@@ -4,10 +4,11 @@ namespace Drupal\eic_default_content\Generator;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\fragments\Entity\Fragment;
 use Drupal\fragments\Entity\FragmentInterface;
 
 /**
- * Class FragmentGenerator
+ * Class to generate fragments using fixtures.
  *
  * @package Drupal\eic_default_content\Generator
  */

--- a/lib/modules/eic_default_content/src/Generator/FragmentGenerator.php
+++ b/lib/modules/eic_default_content/src/Generator/FragmentGenerator.php
@@ -36,7 +36,7 @@ class FragmentGenerator extends CoreGenerator {
    * {@inheritdoc}
    */
   public function load() {
-    $this->createNewsDislcaimerFragment();
+    $this->createNewsDisclaimerFragment();
   }
 
   /**
@@ -45,7 +45,7 @@ class FragmentGenerator extends CoreGenerator {
    * @return \Drupal\fragments\Entity\FragmentInterface
    *   The fragment entity.
    */
-  private function createNewsDislcaimerFragment(): FragmentInterface {
+  private function createNewsDisclaimerFragment(): FragmentInterface {
     $fragments = $this->entityTypeManager->getStorage('fragment')
       ->loadByProperties([
         'type' => 'disclaimer',

--- a/lib/modules/eic_default_content/src/Generator/FragmentGenerator.php
+++ b/lib/modules/eic_default_content/src/Generator/FragmentGenerator.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Drupal\eic_default_content\Generator;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\fragments\Entity\FragmentInterface;
+
+/**
+ * Class FragmentGenerator
+ *
+ * @package Drupal\eic_default_content\Generator
+ */
+class FragmentGenerator extends CoreGenerator {
+
+  use StringTranslationTrait;
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    parent::__construct();
+
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function load() {
+    $this->createNewsDislcaimerFragment();
+  }
+
+  /**
+   * Creates a new disclaimer fragment for the News and Stories.
+   *
+   * @return \Drupal\fragments\Entity\FragmentInterface
+   *   The fragment entity.
+   */
+  private function createNewsDislcaimerFragment(): FragmentInterface {
+    $fragments = $this->entityTypeManager->getStorage('fragment')
+      ->loadByProperties([
+        'type' => 'disclaimer',
+      ]
+    );
+
+    if (!empty($fragments)) {
+      return reset($fragments);
+    }
+
+    $fragment = Fragment::create([
+      'type' => 'disclaimer',
+      'title' => 'Disclaimer',
+      'field_body' => $this->getFormattedText(
+        'full_html',
+        $this->t('DISCLAIMER: This information is provided in the interest of knowledge sharing and should not be interpreted as the official view of the European Commission, or any other organisation.')
+      ),
+    ]);
+    $fragment->save();
+    return $fragment;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function unLoad() {
+    $this->unloadEntities('fragment', ['type' => 'disclaimer']);
+  }
+
+}

--- a/lib/modules/eic_default_content/src/Generator/FragmentGenerator.php
+++ b/lib/modules/eic_default_content/src/Generator/FragmentGenerator.php
@@ -61,7 +61,7 @@ class FragmentGenerator extends CoreGenerator {
       'title' => 'Disclaimer',
       'field_body' => $this->getFormattedText(
         'full_html',
-        $this->t('DISCLAIMER: This information is provided in the interest of knowledge sharing and should not be interpreted as the official view of the European Commission, or any other organisation.')
+        'DISCLAIMER: This information is provided in the interest of knowledge sharing and should not be interpreted as the official view of the European Commission, or any other organisation.'
       ),
     ]);
     $fragment->save();

--- a/lib/modules/eic_default_content/src/Generator/FragmentGenerator.php
+++ b/lib/modules/eic_default_content/src/Generator/FragmentGenerator.php
@@ -58,7 +58,7 @@ class FragmentGenerator extends CoreGenerator {
 
     $fragment = Fragment::create([
       'type' => 'disclaimer',
-      'title' => 'Disclaimer',
+      'title' => 'Default Disclaimer',
       'field_body' => $this->getFormattedText(
         'full_html',
         'DISCLAIMER: This information is provided in the interest of knowledge sharing and should not be interpreted as the official view of the European Commission, or any other organisation.'


### PR DESCRIPTION
### Improvements

- Create fixture to generate default fragments;;
- Adds default News and Story disclaimer when migrating from D7.

### Test

- [x] Import migrated DB
- [x] Run `drush cr && drush cim -y`
- [x] Make sure the module `eic_default_content` is enabled if not run `drush en eic_default_content`
- [x] Run `drush fixtures:reload FragmentGenerator`
- [x] Run `drush mim upgrade_d7_node_complete_article --update` and drush mim `upgrade_d7_node_complete_news --update`
- [x] Make sure all the migrated stories and news have a default disclaimer

Test with fresh install

- [x] Run fresh install
- [x] Make sure all the generated News and Stories have a default disclaimer