### PR TITLE
[EICNET]feat: Use expertise field from user instead of topics

### DIFF
--- a/lib/modules/eic_topics/src/TopicsManager.php
+++ b/lib/modules/eic_topics/src/TopicsManager.php
@@ -146,7 +146,7 @@ class TopicsManager {
     }
 
     $filters = [
-      Topics::TERM_TOPICS_ID_FIELD_USER_SOLR => $term->label(),
+      'sm_user_profile_topic_expertise_string' => $term->label(),
     ];
 
     $query_options = [


### PR DESCRIPTION
How to test it:

- [ ] Go to topic detail page
- [ ] Click on experts stats number
- [ ] Check if it's prefiltered by the expertise field