### PR TITLE
EICNET-2626: Remove unneeded entity types from search index.

### DIFF
--- a/config/sync/search_api.index.global.yml
+++ b/config/sync/search_api.index.global.yml
@@ -3,77 +3,76 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.group.field_date_range
-    - field.storage.group.field_location
-    - field.storage.group.field_event_registration_date
-    - field.storage.group.field_vocab_event_type
-    - field.storage.group.field_funding_source
     - field.storage.user.field_first_name
     - field.storage.user.field_last_name
     - field.storage.media.oe_media_image
     - field.storage.user.field_media
-    - field.storage.group.field_location_type
-    - field.storage.group.field_organisation_type
-    - field.storage.group.field_vocab_geo
-    - field.storage.group.field_vocab_services_products
-    - field.storage.group.field_vocab_target_markets
-    - field.storage.group.field_thumbnail
-    - field.storage.group.field_image
-    - field.storage.group.field_vocab_topics
-    - field.storage.group.field_body
-    - field.storage.message.field_entity_type
-    - field.storage.message.field_group_ref
-    - field.storage.message.field_operation_type
-    - field.storage.message.field_referenced_comment
-    - field.storage.message.field_referenced_node
-    - field.storage.node.field_vocab_topics
-    - field.storage.node.field_discussion_type
-    - field.storage.message.field_share_message
-    - field.storage.message.field_source_group
-    - field.storage.node.field_body
     - field.storage.node.field_comments
-    - field.storage.node.field_document_type
-    - field.storage.media.field_media_file
-    - field.storage.node.field_document_media
     - field.storage.node.field_location
+    - field.storage.node.field_document_media
+    - field.storage.node.field_document_type
     - field.storage.node.field_vocab_event_type
+    - field.storage.node.field_body
+    - field.storage.node.field_date_range
+    - field.storage.node.field_discussion_type
+    - field.storage.node.field_location_type
+    - field.storage.node.field_subtitle
+    - field.storage.node.field_vocab_geo
+    - field.storage.node.field_vocab_topics
+    - field.storage.media.oe_media_file
+    - field.storage.node.field_gallery_slides
+    - field.storage.paragraph.field_gallery_slide_media
+    - field.storage.paragraph.field_gallery_slide_legend
     - field.storage.node.field_image
     - field.storage.node.field_introduction
     - field.storage.node.field_language
-    - field.storage.node.field_location_type
-    - field.storage.node.field_vocab_geo
-    - field.storage.node.field_gallery_slides
-    - field.storage.paragraph.field_gallery_slide_legend
-    - field.storage.media.oe_media_file
-    - field.storage.paragraph.field_gallery_slide_media
-    - field.storage.node.field_date_range
-    - field.storage.node.field_subtitle
-    - field.storage.profile.field_body
+    - field.storage.message.field_referenced_node
+    - field.storage.group.field_funding_source
+    - field.storage.group.field_event_registration_date
+    - field.storage.group.field_image
+    - field.storage.message.field_share_message
+    - field.storage.media.field_media_file
+    - field.storage.group.field_date_range
+    - field.storage.group.field_location
+    - field.storage.group.field_vocab_event_type
+    - field.storage.group.field_body
+    - field.storage.group.field_location_type
+    - field.storage.group.field_organisation_type
+    - field.storage.group.field_vocab_geo
+    - field.storage.group.field_vocab_topics
+    - field.storage.message.field_group_ref
+    - field.storage.group.field_thumbnail
+    - field.storage.message.field_referenced_comment
+    - field.storage.message.field_operation_type
+    - field.storage.group.field_vocab_services_products
+    - field.storage.group.field_vocab_target_markets
+    - field.storage.message.field_source_group
+    - field.storage.message.field_entity_type
     - field.storage.profile.field_location_address
-    - field.storage.profile.field_vocab_job_title
+    - field.storage.profile.field_body
     - field.storage.profile.field_vocab_language
-    - field.storage.profile.field_social_links
-    - field.storage.profile.field_vocab_geo
     - field.storage.profile.field_vocab_topic_expertise
     - field.storage.profile.field_vocab_topic_interest
+    - field.storage.profile.field_vocab_geo
+    - field.storage.profile.field_vocab_job_title
+    - field.storage.profile.field_social_links
     - search_api.server.global
     - core.entity_view_mode.group.no_html
     - core.entity_view_mode.node.no_html
   module:
     - search_api_solr
-    - flag
-    - taxonomy
-    - group
+    - message
     - user
     - file
     - media
-    - content_moderation
-    - message
-    - comment
     - node
-    - eic_private_content
-    - path
+    - taxonomy
     - paragraphs
+    - eic_private_content
+    - content_moderation
+    - group
+    - comment
+    - path
     - profile
     - search_api
     - address
@@ -82,12 +81,12 @@ dependencies:
     - eic_search
     - flag_search_api
     - search_api_attachments
-    - group_permissions
 third_party_settings:
   search_api_solr:
     finalize: false
     commit_before_finalize: false
     commit_after_finalize: false
+    debug_finalize: false
     highlighter:
       maxAnalyzedChars: 51200
       fragmenter: gap
@@ -724,22 +723,6 @@ field_settings:
     type: integer
     indexed_locked: true
     type_locked: true
-  flagging_entity_id:
-    label: 'Entity ID'
-    datasource_id: 'entity:flagging'
-    property_path: entity_id
-    type: integer
-    dependencies:
-      module:
-        - flag
-  flagging_flag_id:
-    label: Flag
-    datasource_id: 'entity:flagging'
-    property_path: flag_id
-    type: string
-    dependencies:
-      module:
-        - flag
   group_changed:
     label: '[Group] Changed on'
     datasource_id: 'entity:group'
@@ -1624,14 +1607,6 @@ field_settings:
         - file
         - media
 datasource_settings:
-  'entity:content_moderation_state':
-    languages:
-      default: true
-      selected: {  }
-  'entity:flagging':
-    bundles:
-      default: true
-      selected: {  }
   'entity:group':
     bundles:
       default: true
@@ -1646,7 +1621,6 @@ datasource_settings:
     languages:
       default: true
       selected: {  }
-  'entity:group_permission': {  }
   'entity:message':
     bundles:
       default: false


### PR DESCRIPTION
### Improvements

- Removed following entity types from Global search index:
  - content_moderation_state
  - flagging
  - group_permission

### Tests

- [ ] Delete all data from your Solr core
- [ ] Re-index everything
- [ ] Go trough all overview pages (React and Views) and check if everything works fine

### Remarks

- If you use the migrated database, I suggest to run the indexation during the evening as it takes time