### PR TITLE
EICNET-2632: fix pagination display

### DIFF
--- a/lib/themes/eic_community/react/components/Block/Overview/Search/Pagination.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/Pagination.js
@@ -7,7 +7,7 @@ const Pagination = (props) => {
   const { items } = usePagination({
     page: Number(props.page),
     count: Number(props.total),
-    siblingCount: 0,
+    siblingCount: 1,
     onChange: (event, value) => {
       event.preventDefault();
       props.changePage(value);


### PR DESCRIPTION
# How to test

- [x] Go to a page with a pagination (groups / events / orgs)
- [x] Check the pagination works correctly
- [x] If there are more than 3 items the following element next to the `3` should not be `...` 