### PR TITLE
EICNET-2066: Show/hide wiki page add links depending on the group state

### DIFF
--- a/lib/modules/eic_content/modules/eic_content_book/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_content/modules/eic_content_book/src/Hooks/EntityOperations.php
@@ -137,6 +137,10 @@ class EntityOperations implements ContainerInjectionInterface {
     }
     $links = [];
     foreach ($link_options as $key => $options) {
+      $url = Url::fromRoute('node.add', $route_parameters, $options);
+      if (!$url->access()) {
+        continue;
+      }
       $links[$key] = Url::fromRoute('node.add', $route_parameters, $options);
     }
     return $links;

--- a/lib/modules/eic_groups/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_groups/src/Hooks/EntityOperations.php
@@ -287,6 +287,11 @@ class EntityOperations implements ContainerInjectionInterface {
             // Unsets book navigation since we already have that show in the
             // eic_groups_wiki_book_navigation block plugin.
             unset($build['book_navigation']);
+            // Adds group cache tags otherwise links won't get updated if the
+            // group changes moderation state.
+            if ($group = $this->eicGroupsHelper->getOwnerGroupByEntity($entity)) {
+              $build['#cache']['tags'] = Cache::mergeTags($build['#cache']['tags'], $group->getCacheTags());
+            }
             // Adds user group permissions cache.
             $build['#cache']['contexts'][] = 'user.group_permissions';
           }
@@ -309,8 +314,17 @@ class EntityOperations implements ContainerInjectionInterface {
               }
             }
           }
+
+          $build['#cache']['tags'] = !empty($build['#cache']['tags']) ? $build['#cache']['tags'] : [];
+          // Adds group cache tags otherwise links won't get updated if the
+          // group changes moderation state.
+          if ($group = $this->eicGroupsHelper->getOwnerGroupByEntity($entity)) {
+            $build['#cache']['tags'] = Cache::mergeTags($build['#cache']['tags'], $group->getCacheTags());
+          }
+
           // Adds user group permissions cache.
           $build['#cache']['contexts'][] = 'user.group_permissions';
+
         }
         break;
 

--- a/lib/modules/eic_groups/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_groups/src/Hooks/EntityOperations.php
@@ -324,7 +324,6 @@ class EntityOperations implements ContainerInjectionInterface {
 
           // Adds user group permissions cache.
           $build['#cache']['contexts'][] = 'user.group_permissions';
-
         }
         break;
 


### PR DESCRIPTION
### Improvements

- Show/hide wiki page add links depending on the group state.

### Tests

- [ ] As SA/SCM, archive a group
- [ ] As TU (member), go to the wiki section of the archived group
- [ ] Make sure you don't see the links to add new wiki pages
- [ ] As SA/SCM, publish the group again
- [ ] As TU (member), go to the wiki page section of the group
- [ ] Make sure you can see the links to add new wiki pages