### PR TITLE
EICNET-2457: Fix date created and timestamp sorting options for group source types

### DIFF
--- a/config/sync/context.context.drafts.yml
+++ b/config/sync/context.context.drafts.yml
@@ -24,7 +24,41 @@ reactions:
     uuid: 9f7f9eb5-1a04-4d53-9b5a-bb5606f75eec
     blocks:
       8e094a5e-bc46-4c6e-a8ca-529ab1dac953:
-        uuid: 8e094a5e-bc46-4c6e-a8ca-529ab1dac953
+        id: eic_search_overview
+        label: ''
+        provider: eic_search
+        label_display: visible
+        context_mapping: {  }
+        source_type: Drupal\eic_search\Search\Sources\Profile\DraftSourceType
+        facets:
+          ss_global_content_type: ss_global_content_type
+          sm_content_field_vocab_topics_string: sm_content_field_vocab_topics_string
+          sm_content_field_vocab_geo_string: sm_content_field_vocab_geo_string
+          ss_content_language_string: ss_content_language_string
+          ss_group_user_fullname: 0
+        sort_options:
+          ss_global_created_date: ss_global_created_date
+          timestamp: timestamp
+          ss_global_title: ss_global_title
+          score: score
+          ss_group_user_fullname: 0
+          its_document_download_total: 0
+          its_statistics_view: 0
+          its_content_comment_count: 0
+          its_flag_like_content: 0
+          dm_aggregated_changed: 0
+          its_last_comment_timestamp: 0
+          its_last_flagged_like_content: 0
+          its_last_flagged_bookmark_content: 0
+          its_last_flagged_highlight_content: 0
+        enable_search: 1
+        page_options: normal
+        prefilter_group: 0
+        enable_date_filter: 0
+        add_facet_interests: 0
+        add_facet_my_groups: 0
+      8e84ec8c-17f4-4b38-9f9c-0ef6e4b69813:
+        uuid: 8e84ec8c-17f4-4b38-9f9c-0ef6e4b69813
         id: eic_search_overview
         label: ''
         provider: eic_search
@@ -46,6 +80,7 @@ reactions:
           ss_group_user_fullname: 0
         sort_options:
           ss_global_created_date: ss_global_created_date
+          timestamp: timestamp
           ss_global_title: ss_global_title
           score: score
           ss_group_user_fullname: 0

--- a/config/sync/context.context.drafts.yml
+++ b/config/sync/context.context.drafts.yml
@@ -23,40 +23,6 @@ reactions:
     id: blocks
     uuid: 9f7f9eb5-1a04-4d53-9b5a-bb5606f75eec
     blocks:
-      8e094a5e-bc46-4c6e-a8ca-529ab1dac953:
-        id: eic_search_overview
-        label: ''
-        provider: eic_search
-        label_display: visible
-        context_mapping: {  }
-        source_type: Drupal\eic_search\Search\Sources\Profile\DraftSourceType
-        facets:
-          ss_global_content_type: ss_global_content_type
-          sm_content_field_vocab_topics_string: sm_content_field_vocab_topics_string
-          sm_content_field_vocab_geo_string: sm_content_field_vocab_geo_string
-          ss_content_language_string: ss_content_language_string
-          ss_group_user_fullname: 0
-        sort_options:
-          ss_global_created_date: ss_global_created_date
-          timestamp: timestamp
-          ss_global_title: ss_global_title
-          score: score
-          ss_group_user_fullname: 0
-          its_document_download_total: 0
-          its_statistics_view: 0
-          its_content_comment_count: 0
-          its_flag_like_content: 0
-          dm_aggregated_changed: 0
-          its_last_comment_timestamp: 0
-          its_last_flagged_like_content: 0
-          its_last_flagged_bookmark_content: 0
-          its_last_flagged_highlight_content: 0
-        enable_search: 1
-        page_options: normal
-        prefilter_group: 0
-        enable_date_filter: 0
-        add_facet_interests: 0
-        add_facet_my_groups: 0
       8e84ec8c-17f4-4b38-9f9c-0ef6e4b69813:
         uuid: 8e84ec8c-17f4-4b38-9f9c-0ef6e4b69813
         id: eic_search_overview

--- a/config/sync/context.context.events.yml
+++ b/config/sync/context.context.events.yml
@@ -23,37 +23,6 @@ reactions:
     id: blocks
     uuid: 55edfcc0-d241-43a4-9cda-a839fdc3d28c
     blocks:
-      f713fec5-e0c9-49a3-89c7-d8af3d27606d:
-        id: eic_search_overview
-        label: ''
-        provider: eic_search
-        label_display: visible
-        context_mapping: {  }
-        source_type: Drupal\eic_search\Search\Sources\Profile\MyEventsSourceType
-        facets:
-          sm_group_topic_name: sm_group_topic_name
-          ss_group_event_type_string: ss_group_event_type_string
-          ss_content_language_string: ss_content_language_string
-          ss_group_field_vocab_geo_string: ss_group_field_vocab_geo_string
-          ss_group_visibility: ss_group_visibility
-          ss_event_weight_state_label: ss_event_weight_state_label
-          sm_event_funding_source_string: sm_event_funding_source_string
-          sm_group_field_location_type: 0
-          ss_group_event_country: 0
-        sort_options:
-          its_event_weight_state: its_event_weight_state
-          ss_global_created_date: ss_global_created_date
-          timestamp: timestamp
-          ss_group_label_string: ss_group_label_string
-          its_content_field_date_range_start_value: its_content_field_date_range_start_value
-          score: score
-          its_last_flagged_like_content: 0
-        enable_search: 1
-        page_options: normal
-        prefilter_group: 0
-        enable_date_filter: 1
-        add_facet_interests: 0
-        add_facet_my_groups: 0
       c3fc1797-cc5a-4ce7-b5b3-79749b1bcd53:
         uuid: c3fc1797-cc5a-4ce7-b5b3-79749b1bcd53
         id: eic_search_overview

--- a/config/sync/context.context.events.yml
+++ b/config/sync/context.context.events.yml
@@ -24,12 +24,44 @@ reactions:
     uuid: 55edfcc0-d241-43a4-9cda-a839fdc3d28c
     blocks:
       f713fec5-e0c9-49a3-89c7-d8af3d27606d:
-        uuid: f713fec5-e0c9-49a3-89c7-d8af3d27606d
+        id: eic_search_overview
+        label: ''
+        provider: eic_search
+        label_display: visible
+        context_mapping: {  }
+        source_type: Drupal\eic_search\Search\Sources\Profile\MyEventsSourceType
+        facets:
+          sm_group_topic_name: sm_group_topic_name
+          ss_group_event_type_string: ss_group_event_type_string
+          ss_content_language_string: ss_content_language_string
+          ss_group_field_vocab_geo_string: ss_group_field_vocab_geo_string
+          ss_group_visibility: ss_group_visibility
+          ss_event_weight_state_label: ss_event_weight_state_label
+          sm_event_funding_source_string: sm_event_funding_source_string
+          sm_group_field_location_type: 0
+          ss_group_event_country: 0
+        sort_options:
+          its_event_weight_state: its_event_weight_state
+          ss_global_created_date: ss_global_created_date
+          timestamp: timestamp
+          ss_group_label_string: ss_group_label_string
+          its_content_field_date_range_start_value: its_content_field_date_range_start_value
+          score: score
+          its_last_flagged_like_content: 0
+        enable_search: 1
+        page_options: normal
+        prefilter_group: 0
+        enable_date_filter: 1
+        add_facet_interests: 0
+        add_facet_my_groups: 0
+      c3fc1797-cc5a-4ce7-b5b3-79749b1bcd53:
+        uuid: c3fc1797-cc5a-4ce7-b5b3-79749b1bcd53
         id: eic_search_overview
         label: ''
         provider: eic_search
         label_display: visible
         region: content
+        weight: '0'
         custom_id: eic_search_overview
         theme: eic_community
         css_class: ''
@@ -49,6 +81,7 @@ reactions:
           ss_group_event_country: 0
         sort_options:
           its_event_weight_state: its_event_weight_state
+          ss_global_created_date: ss_global_created_date
           timestamp: timestamp
           ss_group_label_string: ss_group_label_string
           its_content_field_date_range_start_value: its_content_field_date_range_start_value

--- a/config/sync/context.context.groups.yml
+++ b/config/sync/context.context.groups.yml
@@ -24,12 +24,38 @@ reactions:
     uuid: 51f37ab4-072e-402d-83ae-1f389f21e09e
     blocks:
       79680eb5-d2aa-4cdf-ae18-6a558fe7a72a:
-        uuid: 79680eb5-d2aa-4cdf-ae18-6a558fe7a72a
+        id: eic_search_overview
+        label: ''
+        provider: eic_search
+        label_display: visible
+        context_mapping: {  }
+        source_type: Drupal\eic_search\Search\Sources\Profile\MyGroupsSourceType
+        facets:
+          ss_group_visibility_label: ss_group_visibility_label
+          sm_group_topic_name: sm_group_topic_name
+          ss_group_field_vocab_geo_string: ss_group_field_vocab_geo_string
+          ss_group_user_fullname: 0
+        sort_options:
+          ss_global_created_date: ss_global_created_date
+          timestamp: timestamp
+          ss_global_title: 0
+          ss_group_user_fullname: 0
+          its_last_flagged_like_content: 0
+          score: 0
+        enable_search: 1
+        page_options: normal
+        prefilter_group: 0
+        enable_date_filter: 0
+        add_facet_interests: 0
+        add_facet_my_groups: 0
+      43aaa1ef-c809-4fbf-886d-f9d1d3274573:
+        uuid: 43aaa1ef-c809-4fbf-886d-f9d1d3274573
         id: eic_search_overview
         label: ''
         provider: eic_search
         label_display: visible
         region: content
+        weight: '0'
         custom_id: eic_search_overview
         theme: eic_community
         css_class: ''
@@ -43,8 +69,8 @@ reactions:
           ss_group_field_vocab_geo_string: ss_group_field_vocab_geo_string
           ss_group_user_fullname: 0
         sort_options:
-          ss_drupal_changed_timestamp: ss_drupal_changed_timestamp
-          timestamp: 0
+          ss_global_created_date: ss_global_created_date
+          timestamp: timestamp
           ss_global_title: 0
           ss_group_user_fullname: 0
           its_last_flagged_like_content: 0

--- a/config/sync/context.context.groups.yml
+++ b/config/sync/context.context.groups.yml
@@ -23,31 +23,6 @@ reactions:
     id: blocks
     uuid: 51f37ab4-072e-402d-83ae-1f389f21e09e
     blocks:
-      79680eb5-d2aa-4cdf-ae18-6a558fe7a72a:
-        id: eic_search_overview
-        label: ''
-        provider: eic_search
-        label_display: visible
-        context_mapping: {  }
-        source_type: Drupal\eic_search\Search\Sources\Profile\MyGroupsSourceType
-        facets:
-          ss_group_visibility_label: ss_group_visibility_label
-          sm_group_topic_name: sm_group_topic_name
-          ss_group_field_vocab_geo_string: ss_group_field_vocab_geo_string
-          ss_group_user_fullname: 0
-        sort_options:
-          ss_global_created_date: ss_global_created_date
-          timestamp: timestamp
-          ss_global_title: 0
-          ss_group_user_fullname: 0
-          its_last_flagged_like_content: 0
-          score: 0
-        enable_search: 1
-        page_options: normal
-        prefilter_group: 0
-        enable_date_filter: 0
-        add_facet_interests: 0
-        add_facet_my_groups: 0
       43aaa1ef-c809-4fbf-886d-f9d1d3274573:
         uuid: 43aaa1ef-c809-4fbf-886d-f9d1d3274573
         id: eic_search_overview

--- a/lib/modules/eic_default_content/src/Generator/OverviewPageGenerator.php
+++ b/lib/modules/eic_default_content/src/Generator/OverviewPageGenerator.php
@@ -3,14 +3,17 @@
 namespace Drupal\eic_default_content\Generator;
 
 use Drupal\eic_events\Constants\Event;
+use Drupal\eic_flags\FlagType;
 use Drupal\eic_overviews\Entity\OverviewPage;
 use Drupal\eic_overviews\GlobalOverviewPages;
+use Drupal\eic_search\Search\DocumentProcessor\DocumentProcessorInterface;
 use Drupal\eic_search\Search\Sources\GlobalSourceType;
 use Drupal\eic_search\Search\Sources\GlobalEventSourceType;
 use Drupal\eic_search\Search\Sources\GroupSourceType;
 use Drupal\eic_search\Search\Sources\NewsStorySourceType;
 use Drupal\eic_search\Search\Sources\OrganisationSourceType;
 use Drupal\eic_search\Search\Sources\UserGallerySourceType;
+use Drupal\eic_search\Service\SolrDocumentProcessor;
 
 /**
  * Class OverviewPageGenerator
@@ -30,6 +33,21 @@ class OverviewPageGenerator extends CoreGenerator {
         'sm_content_field_vocab_topics_string' => 'sm_content_field_vocab_topics_string',
         'sm_content_field_vocab_geo_string' => 'sm_content_field_vocab_geo_string',
       ],
+      'sort_options' => [
+        'ss_global_created_date' => 'ss_global_created_date',
+        'timestamp' => 'timestamp',
+        'ss_group_user_fullname' => 'ss_group_user_fullname',
+        'its_document_download_total' => 'its_document_download_total',
+        'its_statistics_view' => 'its_statistics_view',
+        'its_content_comment_count' => 'its_content_comment_count',
+        'its_flag_like_content' => 'its_flag_like_content',
+        'dm_aggregated_changed' => 'dm_aggregated_changed',
+        'its_last_comment_timestamp' => 'its_last_comment_timestamp',
+        'its_' . SolrDocumentProcessor::LAST_FLAGGED_KEY . '_' . FlagType::LIKE_CONTENT => (
+          'its_' . SolrDocumentProcessor::LAST_FLAGGED_KEY . '_' . FlagType::LIKE_CONTENT
+        ),
+        'score' => 'score',
+      ],
       'source_type' => GlobalSourceType::class,
     ], 'Global search', '/search',
       GlobalOverviewPages::GLOBAL_SEARCH
@@ -39,6 +57,15 @@ class OverviewPageGenerator extends CoreGenerator {
       'enable_search' => TRUE,
       'facets' => [
         'sm_group_topic_name' => 'sm_group_topic_name',
+      ],
+      'sort_options' => [
+        DocumentProcessorInterface::SOLR_MOST_ACTIVE_ID => DocumentProcessorInterface::SOLR_MOST_ACTIVE_ID,
+        'ss_global_created_date' => 'ss_global_created_date',
+        'timestamp' => 'timestamp',
+        'its_' . SolrDocumentProcessor::LAST_FLAGGED_KEY . '_' . FlagType::LIKE_CONTENT => (
+          'its_' . SolrDocumentProcessor::LAST_FLAGGED_KEY . '_' . FlagType::LIKE_CONTENT
+        ),
+        'score' => 'score',
       ],
       'source_type' => GroupSourceType::class,
     ], 'Groups', '/groups',
@@ -54,6 +81,13 @@ class OverviewPageGenerator extends CoreGenerator {
         'ss_user_profile_field_location_address_country_code' => 'ss_user_profile_field_location_address_country_code',
         'sm_user_profile_field_vocab_language_array' => 'sm_user_profile_field_vocab_language_array'
       ],
+      'sort_options' => [
+        DocumentProcessorInterface::SOLR_MOST_ACTIVE_ID => DocumentProcessorInterface::SOLR_MOST_ACTIVE_ID,
+        'ss_global_created_date' => 'ss_global_created_date',
+        'timestamp' => 'timestamp',
+        'ds_user_access' => 'ds_user_access',
+        'score' => 'score',
+      ],
       'source_type' => UserGallerySourceType::class,
     ], 'Members', '/people',
       GlobalOverviewPages::MEMBERS
@@ -65,6 +99,13 @@ class OverviewPageGenerator extends CoreGenerator {
         'ss_content_type' => 'ss_content_type',
         'sm_content_field_vocab_topics_string' => 'sm_content_field_vocab_topics_string',
         'sm_content_field_vocab_geo_string' => 'sm_content_field_vocab_geo_string',
+      ],
+      'sort_options' => [
+        'ss_drupal_changed_timestamp' => 'ss_drupal_changed_timestamp',
+        'ss_drupal_timestamp' => 'ss_drupal_timestamp',
+        'its_statistics_view' => 'its_statistics_view',
+        'its_flag_like_content' => 'its_flag_like_content',
+        'its_content_comment_count' => 'its_content_comment_count',
       ],
       'source_type' => NewsStorySourceType::class,
     ], 'News & Stories', '/articles',
@@ -79,6 +120,14 @@ class OverviewPageGenerator extends CoreGenerator {
         Event::SOLR_FIELD_ID_WEIGHT_STATE_LABEL => Event::SOLR_FIELD_ID_WEIGHT_STATE_LABEL,
         'ss_group_event_country' => 'ss_group_event_country',
       ],
+      'sort_options' => [
+        Event::SOLR_FIELD_ID_WEIGHT_STATE => Event::SOLR_FIELD_ID_WEIGHT_STATE,
+        'ss_global_created_date' => 'ss_global_created_date',
+        'timestamp' => 'timestamp',
+        'ss_group_label_string' => 'ss_group_label_string',
+        'its_content_field_date_range_start_value' => 'its_content_field_date_range_start_value',
+        'score' => 'score',
+      ],
       'source_type' => GlobalEventSourceType::class,
     ], 'Events', '/events',
       GlobalOverviewPages::EVENTS
@@ -90,6 +139,12 @@ class OverviewPageGenerator extends CoreGenerator {
         'sm_group_organisation_type_string' => 'sm_group_organisation_type_string',
         'sm_group_topic_name' => 'sm_group_topic_name',
         'sm_group_field_locations_string' => 'sm_group_field_locations_string',
+      ],
+      'sort_options' => [
+        DocumentProcessorInterface::SOLR_MOST_ACTIVE_ID => DocumentProcessorInterface::SOLR_MOST_ACTIVE_ID,
+        'ss_global_created_date' => 'ss_global_created_date',
+        'timestamp' => 'timestamp',
+        'score' => 'score',
       ],
       'source_type' => OrganisationSourceType::class,
     ], 'Organisations', '/organisations',

--- a/lib/modules/eic_search/src/Search/Sources/GlobalEventSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/GlobalEventSourceType.php
@@ -59,9 +59,12 @@ class GlobalEventSourceType extends SourceType {
         'label' => $this->t('State (1. ongoing, 2. future, 3. past)', [], ['context' => 'eic_search']),
         'ASC' => $this->t('Ongoing/upcoming', [], ['context' => 'eic_search'])
       ],
+      'ss_global_created_date' => [
+        'label' => $this->t('Date created', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Date created', [], ['context' => 'eic_search']),
+      ],
       'timestamp' => [
         'label' => $this->t('Timestamp', [], ['context' => 'eic_search']),
-        'ASC' => $this->t('Old', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Recent', [], ['context' => 'eic_search']),
       ],
       'ss_group_label_string' => [

--- a/lib/modules/eic_search/src/Search/Sources/GlobalEventSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/GlobalEventSourceType.php
@@ -65,7 +65,7 @@ class GlobalEventSourceType extends SourceType {
       ],
       'timestamp' => [
         'label' => $this->t('Timestamp', [], ['context' => 'eic_search']),
-        'DESC' => $this->t('Recent', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Recently updated', [], ['context' => 'eic_search']),
       ],
       'ss_group_label_string' => [
         'label' => $this->t('Event name', [], ['context' => 'eic_search']),

--- a/lib/modules/eic_search/src/Search/Sources/GlobalSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/GlobalSourceType.php
@@ -58,9 +58,8 @@ class GlobalSourceType extends SourceType {
   public function getAvailableSortOptions(): array {
     return [
       'ss_global_created_date' => [
-        'label' => $this->t('Timestamp', [], ['context' => 'eic_search']),
-        'ASC' => $this->t('Old', [], ['context' => 'eic_search']),
-        'DESC' => $this->t('Recent', [], ['context' => 'eic_search']),
+        'label' => $this->t('Date created', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Date created', [], ['context' => 'eic_search']),
       ],
       'ss_global_title' => [
         'label' => $this->t('Title', [], ['context' => 'eic_search']),

--- a/lib/modules/eic_search/src/Search/Sources/GlobalSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/GlobalSourceType.php
@@ -61,6 +61,10 @@ class GlobalSourceType extends SourceType {
         'label' => $this->t('Date created', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Date created', [], ['context' => 'eic_search']),
       ],
+      'timestamp' => [
+        'label' => $this->t('Timestamp', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Recently updated', [], ['context' => 'eic_search']),
+      ],
       'ss_global_title' => [
         'label' => $this->t('Title', [], ['context' => 'eic_search']),
         'ASC' => $this->t('Title A-Z', [], ['context' => 'eic_search']),
@@ -154,7 +158,7 @@ class GlobalSourceType extends SourceType {
    * @inheritDoc
    */
   public function getDefaultSort(): array {
-    return ['ss_global_created_date', 'DESC'];
+    return ['timestamp', 'DESC'];
   }
 
 }

--- a/lib/modules/eic_search/src/Search/Sources/GroupEventSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/GroupEventSourceType.php
@@ -62,9 +62,12 @@ class GroupEventSourceType extends SourceType {
         'label' => $this->t('State (1. ongoing, 2. future, 3. past)', [], ['context' => 'eic_search']),
         'ASC' => $this->t('Ongoing/upcoming', [], ['context' => 'eic_search'])
       ],
-      'ss_drupal_timestamp' => [
+      'ss_global_created_date' => [
+        'label' => $this->t('Date created', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Date created', [], ['context' => 'eic_search']),
+      ],
+      'timestamp' => [
         'label' => $this->t('Timestamp', [], ['context' => 'eic_search']),
-        'ASC' => $this->t('Old', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Recent', [], ['context' => 'eic_search']),
       ],
       'ss_content_title' => [

--- a/lib/modules/eic_search/src/Search/Sources/GroupSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/GroupSourceType.php
@@ -62,7 +62,7 @@ class GroupSourceType extends SourceType {
       ],
       'timestamp' => [
         'label' => $this->t('Timestamp', [], ['context' => 'eic_search']),
-        'DESC' => $this->t('Recent', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Recently updated', [], ['context' => 'eic_search']),
       ],
       'tm_global_title' => [
         'label' => $this->t('Group label', [], ['context' => 'eic_search']),

--- a/lib/modules/eic_search/src/Search/Sources/GroupSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/GroupSourceType.php
@@ -56,9 +56,12 @@ class GroupSourceType extends SourceType {
         'label' => $this->t('Most active', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Most active', [], ['context' => 'eic_search']),
       ],
+      'ss_global_created_date' => [
+        'label' => $this->t('Date created', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Date created', [], ['context' => 'eic_search']),
+      ],
       'timestamp' => [
         'label' => $this->t('Timestamp', [], ['context' => 'eic_search']),
-        'ASC' => $this->t('Old', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Recent', [], ['context' => 'eic_search']),
       ],
       'tm_global_title' => [

--- a/lib/modules/eic_search/src/Search/Sources/OrganisationSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/OrganisationSourceType.php
@@ -59,9 +59,12 @@ class OrganisationSourceType extends SourceType {
         'label' => $this->t('Most active', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Most active', [], ['context' => 'eic_search']),
       ],
+      'ss_global_created_date' => [
+        'label' => $this->t('Date created', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Date created', [], ['context' => 'eic_search']),
+      ],
       'timestamp' => [
         'label' => $this->t('Timestamp', [], ['context' => 'eic_search']),
-        'ASC' => $this->t('Old', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Recent', [], ['context' => 'eic_search']),
       ],
       'ss_global_title' => [

--- a/lib/modules/eic_search/src/Search/Sources/OrganisationSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/OrganisationSourceType.php
@@ -65,7 +65,7 @@ class OrganisationSourceType extends SourceType {
       ],
       'timestamp' => [
         'label' => $this->t('Timestamp', [], ['context' => 'eic_search']),
-        'DESC' => $this->t('Recent', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Recently updated', [], ['context' => 'eic_search']),
       ],
       'ss_global_title' => [
         'label' => $this->t('Group label', [], ['context' => 'eic_search']),

--- a/lib/modules/eic_search/src/Search/Sources/Profile/DraftSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/Profile/DraftSourceType.php
@@ -65,7 +65,7 @@ class DraftSourceType extends SourceType {
       ],
       'timestamp' => [
         'label' => $this->t('Timestamp', [], ['context' => 'eic_search']),
-        'DESC' => $this->t('Recent', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Recently updated', [], ['context' => 'eic_search']),
       ],
       'ss_global_title' => [
         'label' => $this->t('Title', [], ['context' => 'eic_search']),

--- a/lib/modules/eic_search/src/Search/Sources/Profile/DraftSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/Profile/DraftSourceType.php
@@ -60,8 +60,11 @@ class DraftSourceType extends SourceType {
   public function getAvailableSortOptions(): array {
     return [
       'ss_global_created_date' => [
+        'label' => $this->t('Date created', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Date created', [], ['context' => 'eic_search']),
+      ],
+      'timestamp' => [
         'label' => $this->t('Timestamp', [], ['context' => 'eic_search']),
-        'ASC' => $this->t('Old', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Recent', [], ['context' => 'eic_search']),
       ],
       'ss_global_title' => [

--- a/lib/modules/eic_search/src/Search/Sources/Profile/MyEventsSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/Profile/MyEventsSourceType.php
@@ -65,9 +65,12 @@ class MyEventsSourceType extends SourceType {
         'label' => $this->t('State (1. ongoing, 2. future, 3. past)', [], ['context' => 'eic_search']),
         'ASC' => $this->t('Ongoing/upcoming', [], ['context' => 'eic_search'])
       ],
+      'ss_global_created_date' => [
+        'label' => $this->t('Date created', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Date created', [], ['context' => 'eic_search']),
+      ],
       'timestamp' => [
         'label' => $this->t('Timestamp', [], ['context' => 'eic_search']),
-        'ASC' => $this->t('Old', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Recent', [], ['context' => 'eic_search']),
       ],
       'ss_group_label_string' => [

--- a/lib/modules/eic_search/src/Search/Sources/Profile/MyEventsSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/Profile/MyEventsSourceType.php
@@ -71,7 +71,7 @@ class MyEventsSourceType extends SourceType {
       ],
       'timestamp' => [
         'label' => $this->t('Timestamp', [], ['context' => 'eic_search']),
-        'DESC' => $this->t('Recent', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Recently updated', [], ['context' => 'eic_search']),
       ],
       'ss_group_label_string' => [
         'label' => $this->t('Event name', [], ['context' => 'eic_search']),

--- a/lib/modules/eic_search/src/Search/Sources/Profile/MyGroupsSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/Profile/MyGroupsSourceType.php
@@ -60,7 +60,7 @@ class MyGroupsSourceType extends SourceType {
       ],
       'timestamp' => [
         'label' => $this->t('Timestamp', [], ['context' => 'eic_search']),
-        'DESC' => $this->t('Recent', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Recently updated', [], ['context' => 'eic_search']),
       ],
       'ss_global_title' => [
         'label' => $this->t('Group label', [], ['context' => 'eic_search']),

--- a/lib/modules/eic_search/src/Search/Sources/Profile/MyGroupsSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/Profile/MyGroupsSourceType.php
@@ -54,13 +54,12 @@ class MyGroupsSourceType extends SourceType {
    */
   public function getAvailableSortOptions(): array {
     return [
+      'ss_global_created_date' => [
+        'label' => $this->t('Date created', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Date created', [], ['context' => 'eic_search']),
+      ],
       'timestamp' => [
         'label' => $this->t('Timestamp', [], ['context' => 'eic_search']),
-        'ASC' => $this->t('Old', [], ['context' => 'eic_search']),
-        'DESC' => $this->t('Recent', [], ['context' => 'eic_search']),
-      ],
-      'ss_drupal_changed_timestamp' => [
-        'label' => $this->t('Recently updated', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Recent', [], ['context' => 'eic_search']),
       ],
       'ss_global_title' => [
@@ -133,7 +132,7 @@ class MyGroupsSourceType extends SourceType {
    * @inheritDoc
    */
   public function getDefaultSort(): array {
-    return ['ss_drupal_changed_timestamp', 'DESC'];
+    return ['timestamp', 'DESC'];
   }
 
   /**

--- a/lib/modules/eic_search/src/Search/Sources/UserProfile/MyEventsSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/UserProfile/MyEventsSourceType.php
@@ -55,13 +55,12 @@ class MyEventsSourceType extends SourceType {
    */
   public function getAvailableSortOptions(): array {
     return [
+      'ss_global_created_date' => [
+        'label' => $this->t('Date created', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Date created', [], ['context' => 'eic_search']),
+      ],
       'timestamp' => [
         'label' => $this->t('Timestamp', [], ['context' => 'eic_search']),
-        'ASC' => $this->t('Old', [], ['context' => 'eic_search']),
-        'DESC' => $this->t('Recent', [], ['context' => 'eic_search']),
-      ],
-      'ss_drupal_changed_timestamp' => [
-        'label' => $this->t('Recently updated', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Recent', [], ['context' => 'eic_search']),
       ],
       'ss_global_title' => [

--- a/lib/modules/eic_search/src/Search/Sources/UserProfile/MyEventsSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/UserProfile/MyEventsSourceType.php
@@ -61,7 +61,7 @@ class MyEventsSourceType extends SourceType {
       ],
       'timestamp' => [
         'label' => $this->t('Timestamp', [], ['context' => 'eic_search']),
-        'DESC' => $this->t('Recent', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Recently updated', [], ['context' => 'eic_search']),
       ],
       'ss_global_title' => [
         'label' => $this->t('Group label', [], ['context' => 'eic_search']),

--- a/lib/modules/eic_search/src/Search/Sources/UserProfile/MyGroupsSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/UserProfile/MyGroupsSourceType.php
@@ -60,7 +60,7 @@ class MyGroupsSourceType extends SourceType {
       ],
       'timestamp' => [
         'label' => $this->t('Timestamp', [], ['context' => 'eic_search']),
-        'DESC' => $this->t('Recent', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Recently updated', [], ['context' => 'eic_search']),
       ],
       'ss_global_title' => [
         'label' => $this->t('Group label', [], ['context' => 'eic_search']),

--- a/lib/modules/eic_search/src/Search/Sources/UserProfile/MyGroupsSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/UserProfile/MyGroupsSourceType.php
@@ -54,13 +54,12 @@ class MyGroupsSourceType extends SourceType {
    */
   public function getAvailableSortOptions(): array {
     return [
+      'ss_global_created_date' => [
+        'label' => $this->t('Date created', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Date created', [], ['context' => 'eic_search']),
+      ],
       'timestamp' => [
         'label' => $this->t('Timestamp', [], ['context' => 'eic_search']),
-        'ASC' => $this->t('Old', [], ['context' => 'eic_search']),
-        'DESC' => $this->t('Recent', [], ['context' => 'eic_search']),
-      ],
-      'ss_drupal_changed_timestamp' => [
-        'label' => $this->t('Recently updated', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Recent', [], ['context' => 'eic_search']),
       ],
       'ss_global_title' => [
@@ -140,7 +139,7 @@ class MyGroupsSourceType extends SourceType {
    * @inheritDoc
    */
   public function getDefaultSort(): array {
-    return ['ss_drupal_changed_timestamp', 'DESC'];
+    return ['timestamp', 'DESC'];
   }
 
   /**

--- a/lib/modules/eic_search/src/Search/Sources/UserProfile/MyOrganisationsSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/UserProfile/MyOrganisationsSourceType.php
@@ -60,9 +60,12 @@ class MyOrganisationsSourceType extends SourceType {
         'label' => $this->t('Most active', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Most active', [], ['context' => 'eic_search']),
       ],
+      'ss_global_created_date' => [
+        'label' => $this->t('Date created', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Date created', [], ['context' => 'eic_search']),
+      ],
       'timestamp' => [
         'label' => $this->t('Timestamp', [], ['context' => 'eic_search']),
-        'ASC' => $this->t('Old', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Recent', [], ['context' => 'eic_search']),
       ],
       'ss_global_title' => [

--- a/lib/modules/eic_search/src/Search/Sources/UserProfile/MyOrganisationsSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/UserProfile/MyOrganisationsSourceType.php
@@ -66,7 +66,7 @@ class MyOrganisationsSourceType extends SourceType {
       ],
       'timestamp' => [
         'label' => $this->t('Timestamp', [], ['context' => 'eic_search']),
-        'DESC' => $this->t('Recent', [], ['context' => 'eic_search']),
+        'DESC' => $this->t('Recently updated', [], ['context' => 'eic_search']),
       ],
       'ss_global_title' => [
         'label' => $this->t('Group label', [], ['context' => 'eic_search']),

--- a/lib/modules/eic_search/src/Service/SolrSearchManager.php
+++ b/lib/modules/eic_search/src/Service/SolrSearchManager.php
@@ -350,6 +350,7 @@ class SolrSearchManager {
    * @param array|null $facets_fields
    */
   public function buildFacets(?array $facets_fields) {
+    $facets_fields = $facets_fields ?? [];
     $facets_fields = array_map(function ($facet) {
       if (!in_array($facet, DocumentProcessorInterface::SOLR_FIELD_NEED_GROUP_INJECT)) {
         return $facet;

--- a/lib/themes/eic_community/includes/preprocess/users/user.inc
+++ b/lib/themes/eic_community/includes/preprocess/users/user.inc
@@ -237,8 +237,11 @@ function _get_render_block_search_overview(string $source): array {
     'enable_search' => 0,
     'facets' => [],
     'sort_options' => [],
+    'page_options' => [],
     'prefilter_group' => 0,
     'enable_date_filter' => 0,
+    'add_facet_my_groups' => 0,
+    'add_facet_interests' => 0,
   ];
 
   $plugin_block = $block_manager->createInstance('eic_search_overview', $config);


### PR DESCRIPTION
### Improvements

- Fix date created and timestamp sorting options for group source types.

### Test

- [x] As TU, make sure the date sorting options (**Date created** and **Recent**) are ok in `/groups`, `/events`, `/organisation`, `/users/<user>/activity/groups`, `/users/<user>/activity/events`, `/users/<user>/activity/drafts`