### PR TITLE
EICNET-2601: I cannot highlight items in global events

### DIFF
--- a/config/sync/group.role.event-admin.yml
+++ b/config/sync/group.role.event-admin.yml
@@ -43,6 +43,7 @@ permissions:
   - 'edit all comments'
   - 'edit group'
   - 'edit own comments'
+  - 'highlight group content'
   - 'invite users to group'
   - 'leave group'
   - 'post comments'

--- a/lib/modules/eic_groups/src/Access/HighlightGroupContentAccessCheck.php
+++ b/lib/modules/eic_groups/src/Access/HighlightGroupContentAccessCheck.php
@@ -16,14 +16,10 @@ use Drupal\node\NodeInterface;
 class HighlightGroupContentAccessCheck implements AccessInterface {
 
   const SUPPORTED_PLUGIN_IDS = [
-    'group-group_node-document',
-    'group-group_node-discussion',
-    'group-group_node-video',
-    'group-group_node-gallery',
-    'event-group_node-document',
-    'event-group_node-discussion',
-    'event-group_node-video',
-    'event-group_node-gallery',
+    'group_node:document',
+    'group_node:discussion',
+    'group_node:video',
+    'group_node:gallery',
   ];
 
   /**
@@ -54,8 +50,23 @@ class HighlightGroupContentAccessCheck implements AccessInterface {
         ->setCacheMaxAge(0);
     }
 
+    $supported_plugins = [];
+    foreach (self::SUPPORTED_PLUGIN_IDS as $plugin_id) {
+      if (!$group->getGroupType()->hasContentPlugin($plugin_id)) {
+        continue;
+      }
+      $supported_plugins[] = $group->getGroupType()
+        ->getContentPlugin($plugin_id)
+        ->getContentTypeConfigId();
+    }
+
+    if (empty($supported_plugins)) {
+      return AccessResult::forbidden('Content not supported')
+        ->setCacheMaxAge(0);
+    }
+
     $group_content = $group->getContentEntities(NULL, [
-      'type' => self::SUPPORTED_PLUGIN_IDS,
+      'type' => $supported_plugins,
       'entity_id' => $node->id(),
     ]);
 

--- a/lib/modules/eic_groups/src/EICGroupsHelper.php
+++ b/lib/modules/eic_groups/src/EICGroupsHelper.php
@@ -238,8 +238,8 @@ class EICGroupsHelper implements EICGroupsHelperInterface {
       $is_admin = in_array(
         $role->id(),
         [
-          self::GROUP_ADMINISTRATOR_ROLE,
-          self::GROUP_OWNER_ROLE,
+          self::getGroupTypeRole($group->bundle(), self::GROUP_TYPE_ADMINISTRATOR_ROLE),
+          self::getGroupTypeRole($group->bundle(), self::GROUP_TYPE_OWNER_ROLE),
         ]
       );
 

--- a/lib/modules/eic_search/src/Plugin/Block/SearchOverviewBlock.php
+++ b/lib/modules/eic_search/src/Plugin/Block/SearchOverviewBlock.php
@@ -246,6 +246,8 @@ class SearchOverviewBlock extends BlockBase implements ContainerFactoryPluginInt
       'admins' => [],
     ];
 
+    $user_is_anonymous = \Drupal::currentUser()->isAnonymous();
+
     $post_content_actions = [];
     if ($current_group_route) {
       $account = \Drupal::currentUser();
@@ -314,22 +316,24 @@ class SearchOverviewBlock extends BlockBase implements ContainerFactoryPluginInt
     }
 
     $build['#attached']['drupalSettings']['overview'] = [
-      'is_group_owner' => array_key_exists(
-        EICGroupsHelper::getGroupTypeRole(
-          $current_group_route->bundle(),
-          EICGroupsHelper::GROUP_TYPE_OWNER_ROLE
-        ),
-        $user_group_roles
-      ),
+      'is_group_owner' => $current_group_route ?
+        array_key_exists(
+          EICGroupsHelper::getGroupTypeRole(
+            $current_group_route->bundle(),
+            EICGroupsHelper::GROUP_TYPE_OWNER_ROLE
+          ),
+          $user_group_roles
+        ) : FALSE,
       'label_my_groups' => $source->getLabelFilterMyGroups(),
       'open_registration_filter' => $this->t('Open registration', [], ['context' => 'eic_search']),
-      'is_group_admin' => array_key_exists(
-        EICGroupsHelper::getGroupTypeRole(
-          $current_group_route->bundle(),
-          EICGroupsHelper::GROUP_TYPE_ADMINISTRATOR_ROLE
-        ),
-        $user_group_roles
-      ),
+      'is_group_admin' => $current_group_route ?
+        array_key_exists(
+          EICGroupsHelper::getGroupTypeRole(
+            $current_group_route->bundle(),
+            EICGroupsHelper::GROUP_TYPE_ADMINISTRATOR_ROLE
+          ),
+          $user_group_roles
+        ) : FALSE,
       'is_power_user' => $account instanceof AccountInterface && UserHelper::isPowerUser(
         $account
       ),
@@ -368,12 +372,12 @@ class SearchOverviewBlock extends BlockBase implements ContainerFactoryPluginInt
         '#enable_search' => $this->configuration['enable_search'],
         '#enable_date_filter' => $this->configuration['enable_date_filter'] ?? FALSE,
         '#url' => Url::fromRoute('eic_search.solr_search')->toString(),
-        '#isAnonymous' => \Drupal::currentUser()->isAnonymous(),
+        '#isAnonymous' => $user_is_anonymous,
         '#currentGroup' => $current_group_route instanceof GroupInterface ? $current_group_route->id() : NULL,
         '#currentGroupUrl' => $current_group_route instanceof GroupInterface ? $current_group_route->toUrl()->toString(
         ) : NULL,
-        '#enable_facet_interests' => $this->configuration['add_facet_interests'],
-        '#enable_facet_my_groups' => $this->configuration['add_facet_my_groups'],
+        '#enable_facet_interests' => !$user_is_anonymous ? $this->configuration['add_facet_interests'] : 0,
+        '#enable_facet_my_groups' => !$user_is_anonymous ? $this->configuration['add_facet_my_groups'] : 0,
         '#isGroupOwner' => array_key_exists(
           EICGroupsHelper::GROUP_OWNER_ROLE,
           $user_group_roles

--- a/lib/modules/eic_search/src/Plugin/Block/SearchOverviewBlock.php
+++ b/lib/modules/eic_search/src/Plugin/Block/SearchOverviewBlock.php
@@ -245,7 +245,7 @@ class SearchOverviewBlock extends BlockBase implements ContainerFactoryPluginInt
       'owner' => -1,
       'admins' => [],
     ];
-    
+
     $post_content_actions = [];
     if ($current_group_route) {
       $account = \Drupal::currentUser();
@@ -315,18 +315,24 @@ class SearchOverviewBlock extends BlockBase implements ContainerFactoryPluginInt
 
     $build['#attached']['drupalSettings']['overview'] = [
       'is_group_owner' => array_key_exists(
-        EICGroupsHelper::GROUP_OWNER_ROLE,
+        EICGroupsHelper::getGroupTypeRole(
+          $current_group_route->bundle(),
+          EICGroupsHelper::GROUP_TYPE_OWNER_ROLE
+        ),
         $user_group_roles
       ),
       'label_my_groups' => $source->getLabelFilterMyGroups(),
       'open_registration_filter' => $this->t('Open registration', [], ['context' => 'eic_search']),
       'is_group_admin' => array_key_exists(
-        EICGroupsHelper::GROUP_ADMINISTRATOR_ROLE,
+        EICGroupsHelper::getGroupTypeRole(
+          $current_group_route->bundle(),
+          EICGroupsHelper::GROUP_TYPE_ADMINISTRATOR_ROLE
+        ),
         $user_group_roles
       ),
       'is_power_user' => $account instanceof AccountInterface && UserHelper::isPowerUser(
-          $account
-        ),
+        $account
+      ),
       'source_bundle_id' => $source->getEntityBundle(),
       'default_sorting_option' => $default_sort,
       'filter_label' => [


### PR DESCRIPTION
### Fixes

- Allow GO/GA to highlight content in global events.

### Test

- [x] As GO/GA (not SA/SCM/DA), go to your global event (make sure the event has discussions, documents, video and galleries)
- [x] Go to the discussion overview or files overview
- [x] Make sure you can highlight content
- [x] As TU (member), make sure you cannot highlight any content in discussion overview or files overview
- [x] As anonymous user, go to `/events` and `/groups` and make sure you don't have the facet to filter by "My groups" and "My interests"