### PR TITLE
[EICNET-2373]fix: If there are no usages of a media but current user is the owner, allow it

### DIFF
--- a/lib/modules/eic_media/eic_media.module
+++ b/lib/modules/eic_media/eic_media.module
@@ -38,6 +38,12 @@ function eic_media_media_access(EntityInterface $entity, $operation, AccountInte
   // Loads up the entity usage for the media.
   $media_usage = \Drupal::service('entity_usage.usage')->listSources($entity);
 
+  // If no usages on the media but current user is owner of media, return allowed
+  if (empty($media_usage) && (int) $account->id() === (int) $entity->getOwnerId()) {
+    return AccessResult::allowed()
+      ->cachePerUser();
+  }
+
   // We loop through all source entities and we try to find one the user has
   // access to.
   foreach (array_keys($media_usage) as $entity_type) {


### PR DESCRIPTION
How to test:

- [ ] As a TU, go on creation form of a group
- [ ] Upload a media, save it
- [ ] You should see the image in the library UI