### PR TITLE
EICNET-2642: Anonymous users see broken avatar images

### DIFF
--- a/lib/themes/eic_community/react/components/Block/ActivityStream/partials/ResultItemWrapper.js
+++ b/lib/themes/eic_community/react/components/Block/ActivityStream/partials/ResultItemWrapper.js
@@ -17,8 +17,8 @@ const ResultItemWrapper = (props) => {
             <span className="ecl-author__label ">{fullname}</span>
           </div>
           <div className="ecl-author__aside">
-            <AuthorMediaWrapper isAnonymous={!props.isAnonymous} url={props.result.ss_global_user_url}>
-              {props.result.ss_author_formatted_profile_picture ?
+            <AuthorMediaWrapper isAnonymous={props.isAnonymous} url={props.result.ss_global_user_url}>
+              {!props.isAnonymous && props.result.ss_author_formatted_profile_picture ?
                 <figure className="ecl-media-container ecl-author__media">
                   <img alt={fullname}
                        className="ecl-media-container__media"
@@ -44,7 +44,7 @@ const ResultItemWrapper = (props) => {
 }
 
 const AuthorMediaWrapper = ({isAnonymous, url, children}) => {
-  return isAnonymous
+  return !isAnonymous
     ? <a href={url} className="ecl-author__media-wrapper">{children}</a>
     : <div className="ecl-author__media-wrapper">{children}</div>
 }

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/GroupResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/GroupResultItem.js
@@ -111,7 +111,7 @@ class GroupResultItem extends React.Component {
                       figureClassName={'ecl-author__media'}
                       imgClassName={'ecl-media-container__media'}
                       figureEmptyClassName={'ecl-author__media ecl-author__media--empty'}
-                      src={this.props.result.ss_group_teaser_user_formatted_image}
+                      src={!this.props.isAnonymous ? this.props.result.ss_group_teaser_user_formatted_image : null}
                       alt={this.props.result.ss_global_fullname}
                       url={!this.props.isAnonymous ? this.props.result.ss_global_user_url : null}
                     />


### PR DESCRIPTION
### Fixes

- Show empty avatar image when viewing user avatars in groups overview page and latest activity stream section.

### Test

- [ ] As anonymous, go to `/groups`
- [ ] Make sure the empty user avatar image is shown for each group teaser item
- [ ] Go to activity stream section of a group
- [ ] Make sure the empty user avatar image is shown for each activity stream item 
