### PR TITLE
EICNET-2636: Accepting request to archive as SA/SCM on news articles within global event returns server error

### DIFF
--- a/lib/modules/eic_flags/src/Service/ArchiveRequestHandler.php
+++ b/lib/modules/eic_flags/src/Service/ArchiveRequestHandler.php
@@ -11,6 +11,7 @@ use Drupal\eic_content\Constants\DefaultContentModerationStates;
 use Drupal\eic_flags\RequestStatus;
 use Drupal\eic_flags\RequestTypes;
 use Drupal\eic_groups\GroupsModerationHelper;
+use Drupal\eic_moderation\Constants\EICContentModeration;
 use Drupal\flag\FlaggingInterface;
 
 /**
@@ -58,7 +59,22 @@ class ArchiveRequestHandler extends AbstractRequestHandler {
     ContentEntityInterface $content_entity
   ) {
     if ($this->moderationInformation->isModeratedEntity($content_entity)) {
-      $content_entity->set('moderation_state', 'archived');
+      $workflow = $this->moderationInformation->getWorkflowForEntity($content_entity);
+
+      switch ($workflow->id()) {
+        case EICContentModeration::MACHINE_NAME:
+          $content_entity->set('moderation_state', EICContentModeration::STATE_UNPUBLISHED);
+          break;
+
+        case GroupsModerationHelper::WORKFLOW_MACHINE_NAME:
+          $content_entity->set('moderation_state', GroupsModerationHelper::GROUP_ARCHIVED_STATE);
+          break;
+
+        default:
+          $content_entity->set('moderation_state', DefaultContentModerationStates::ARCHIVED_STATE);
+          break;
+      }
+
     }
     else {
       if ($content_entity instanceof CommentInterface) {
@@ -116,15 +132,14 @@ class ArchiveRequestHandler extends AbstractRequestHandler {
           }
           break;
 
-        case 'groups':
+        case GroupsModerationHelper::WORKFLOW_MACHINE_NAME:
           if ($entity->get('moderation_state')->value === GroupsModerationHelper::GROUP_ARCHIVED_STATE) {
             $is_archived = TRUE;
           }
           break;
 
-        case 'news_stories':
-          // @todo Create a constant class for the news_stories workflow.
-          if ($entity->get('moderation_state')->value === 'archived') {
+        case EICContentModeration::MACHINE_NAME:
+          if ($entity->get('moderation_state')->value === EICContentModeration::STATE_UNPUBLISHED) {
             $is_archived = TRUE;
           }
           break;

--- a/lib/modules/eic_groups/src/GroupsModerationHelper.php
+++ b/lib/modules/eic_groups/src/GroupsModerationHelper.php
@@ -52,6 +52,13 @@ class GroupsModerationHelper {
   const GROUP_ARCHIVED_STATE = 'archived';
 
   /**
+   * The worflow machine name.
+   *
+   * @var string
+   */
+  const WORKFLOW_MACHINE_NAME = 'groups';
+
+  /**
    * Checks if a group is archived.
    *
    * @param \Drupal\group\Entity\GroupInterface $group

--- a/lib/modules/eic_moderation/src/Constants/EICContentModeration.php
+++ b/lib/modules/eic_moderation/src/Constants/EICContentModeration.php
@@ -43,6 +43,13 @@ final class EICContentModeration {
   const STATE_PUBLISHED = 'published';
 
   /**
+   * The 'Unpublished' state machine name.
+   *
+   * @var string
+   */
+  const STATE_UNPUBLISHED = 'unpublished';
+
+  /**
    * The 'Content ready for review' message template machine name.
    *
    * @var string


### PR DESCRIPTION
### Fixes

- Fix error when trying to accept archival request for News and Story content types.

### Test

- [x] As SA/SCM, create a News in a global event and publish it
- [x] Request to archive this News
- [x] Go to the list of archive requests and click "Accept" on this request
- [ ] Make sure the News is unpublished
- [x] Try to publish the News again
- [x] Request deletion
- [x] Go to the list of delete request and click "Archive" on this request
- [ ] Make sure the News is unpublished