### PR TITLE
EICNET-2603: Add missing permissinons in Event GT.

### DIFF
--- a/config/sync/group.role.event-a416e6833.yml
+++ b/config/sync/group.role.event-a416e6833.yml
@@ -24,6 +24,7 @@ permissions:
   - 'access members overview'
   - 'access news overview'
   - 'access wiki overview'
+  - 'administer members'
   - 'delete any invitation'
   - 'delete own invitations'
   - 'edit all comments'

--- a/config/sync/group.role.event-bf4b46c3a.yml
+++ b/config/sync/group.role.event-bf4b46c3a.yml
@@ -24,6 +24,7 @@ permissions:
   - 'access members overview'
   - 'access news overview'
   - 'access wiki overview'
+  - 'administer members'
   - 'delete any invitation'
   - 'delete own invitations'
   - 'edit all comments'

--- a/config/sync/group.role.event-eca6128ca.yml
+++ b/config/sync/group.role.event-eca6128ca.yml
@@ -24,6 +24,7 @@ permissions:
   - 'access members overview'
   - 'access news overview'
   - 'access wiki overview'
+  - 'administer members'
   - 'delete any invitation'
   - 'delete own invitations'
   - 'edit all comments'


### PR DESCRIPTION
### Tests

- [x] As SA/SCM/DA (not GO/GA), go to an event
- [x] Make sure you can access the list of invitations

### Remarks

- You need to rebuild permissions if using an old Event