### PR TITLE
EICNET-901: Show user display name in message notification about content recommendation

### DIFF
--- a/config/sync/core.entity_form_display.message.notify_content_recommendation.default.yml
+++ b/config/sync/core.entity_form_display.message.notify_content_recommendation.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.message.notify_content_recommendation.field_receiver_email
     - field.field.message.notify_content_recommendation.field_referenced_flag
     - field.field.message.notify_content_recommendation.field_rendered_content
     - message.template.notify_content_recommendation
@@ -13,6 +14,14 @@ targetEntityType: message
 bundle: notify_content_recommendation
 mode: default
 content:
+  field_receiver_email:
+    type: email_default
+    weight: 3
+    region: content
+    settings:
+      placeholder: ''
+      size: 60
+    third_party_settings: {  }
   field_referenced_flag:
     type: entity_reference_autocomplete
     weight: 0

--- a/config/sync/core.entity_view_display.message.notify_content_recommendation.default.yml
+++ b/config/sync/core.entity_view_display.message.notify_content_recommendation.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.message.notify_content_recommendation.field_receiver_email
     - field.field.message.notify_content_recommendation.field_referenced_flag
     - field.field.message.notify_content_recommendation.field_rendered_content
     - message.template.notify_content_recommendation
@@ -13,6 +14,13 @@ targetEntityType: message
 bundle: notify_content_recommendation
 mode: default
 content:
+  field_receiver_email:
+    type: basic_string
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 4
+    region: content
   field_referenced_flag:
     type: entity_reference_label
     label: above

--- a/config/sync/core.entity_view_display.message.notify_content_recommendation.mail_body.yml
+++ b/config/sync/core.entity_view_display.message.notify_content_recommendation.mail_body.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.message.mail_body
+    - field.field.message.notify_content_recommendation.field_receiver_email
     - field.field.message.notify_content_recommendation.field_referenced_flag
     - field.field.message.notify_content_recommendation.field_rendered_content
     - message.template.notify_content_recommendation
@@ -23,6 +24,7 @@ content:
     weight: 0
     region: content
 hidden:
+  field_receiver_email: true
   field_referenced_flag: true
   field_rendered_content: true
   partial_0: true

--- a/config/sync/core.entity_view_display.message.notify_content_recommendation.mail_subject.yml
+++ b/config/sync/core.entity_view_display.message.notify_content_recommendation.mail_subject.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.message.mail_subject
+    - field.field.message.notify_content_recommendation.field_receiver_email
     - field.field.message.notify_content_recommendation.field_referenced_flag
     - field.field.message.notify_content_recommendation.field_rendered_content
     - message.template.notify_content_recommendation
@@ -18,6 +19,7 @@ content:
     weight: 0
     region: content
 hidden:
+  field_receiver_email: true
   field_referenced_flag: true
   field_rendered_content: true
   partial_1: true

--- a/config/sync/field.field.message.notify_content_recommendation.field_receiver_email.yml
+++ b/config/sync/field.field.message.notify_content_recommendation.field_receiver_email.yml
@@ -1,0 +1,19 @@
+uuid: 297127f0-ea41-4b02-9e23-72d8349bf609
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_receiver_email
+    - message.template.notify_content_recommendation
+id: message.notify_content_recommendation.field_receiver_email
+field_name: field_receiver_email
+entity_type: message
+bundle: notify_content_recommendation
+label: 'Receiver email'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: email

--- a/config/sync/field.storage.message.field_receiver_email.yml
+++ b/config/sync/field.storage.message.field_receiver_email.yml
@@ -1,0 +1,18 @@
+uuid: e601c3d5-aef2-48ae-ad13-c0b2ec50cd1f
+langcode: en
+status: true
+dependencies:
+  module:
+    - message
+id: message.field_receiver_email
+field_name: field_receiver_email
+entity_type: message
+type: email
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/lib/modules/eic_recommend_content/src/EventSubscriber/FlagEventSubscriber.php
+++ b/lib/modules/eic_recommend_content/src/EventSubscriber/FlagEventSubscriber.php
@@ -132,6 +132,7 @@ class FlagEventSubscriber implements EventSubscriberInterface {
 
     // Sends notification to all emails.
     foreach ($emails as $email) {
+      $message->set('field_receiver_email', $email);
       $this->messageBus->dispatch(
         $message,
         [

--- a/lib/themes/eic_community/includes/preprocess/content/message.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/message.inc
@@ -45,6 +45,14 @@ function eic_community_preprocess_message(&$variables) {
   ];
 
   $message = $variables['message'];
+
+  switch ($message->bundle()) {
+    case 'notify_content_recommendation':
+      _eic_community_preprocess_message_receiver_name($variables);
+      break;
+
+  }
+
   if (!$message instanceof MessageInterface
     || !array_key_exists($message->bundle(), $supported_templates)
   ) {
@@ -155,4 +163,31 @@ function _eic_community_preprocess_digest_message(&$variables) {
     'rendered_entity' => \Drupal::entityTypeManager()->getViewBuilder($entity->getEntityTypeId())
       ->view($entity, 'mail_teaser'),
   ];
+}
+
+/**
+ * Adds user display name to the message body from field_receiver_email.
+ */
+function _eic_community_preprocess_message_receiver_name(&$variables) {
+  $message = $variables['message'];
+
+  if (!$message->hasField('field_receiver_email')) {
+    return;
+  }
+
+  if ($receiver_email = $message->get('field_receiver_email')->value) {
+    /** @var \Drupal\user\UserInterface $user */
+    $users = \Drupal::entityTypeManager()
+      ->getStorage('user')
+      ->loadByProperties([
+          'mail' => $receiver_email,
+        ]
+      );
+    $intro_text = t('Dear');
+    if ($users) {
+      $user = reset($users);
+      $intro_text = t('Dear @user_full_name', ['@user_full_name' => $user->getDisplayName()]);
+    }
+    $variables['content']['partial_1']['#markup'] = "<p>$intro_text,</p>" . $variables['content']['partial_1']['#markup'];
+  }
 }


### PR DESCRIPTION
### Improvements

- Show user display name in message notification about content recommendation.

### Test

- [x] As SA/SCM, try to recommend a group to internal and external users
- [x] Run cron
- [x] Make sure the users get a notification and the text "Dear <name>" (for platform users) or "Dear" (for external users) is presented in the notification email
