### PR TITLE
EICNET-2634: Wiki tab is not present for GM (and below) in global events

### DIFF
--- a/lib/modules/eic_groups/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_groups/src/Hooks/EntityOperations.php
@@ -337,6 +337,9 @@ class EntityOperations implements ContainerInjectionInterface {
       ];
       $node = $this->entityTypeManager->getStorage('node')
         ->create($node_values);
+      if ($entity->get('status')->value) {
+        $node->set('moderation_state', DefaultContentModerationStates::PUBLISHED_STATE);
+      }
       $node->save();
       $entity->addContent($node, 'group_node:book');
     }
@@ -390,8 +393,14 @@ class EntityOperations implements ContainerInjectionInterface {
    *   The group entity.
    */
   private function publishGroupWiki(GroupInterface $group) {
+    $installedContentPlugins = $group->getGroupType()
+      ->getInstalledContentPlugins();
+    if (!$installedContentPlugins || in_array('group_node:book', $installedContentPlugins->getInstanceIds())) {
+      return;
+    }
+    $book_content_plugin_id = $group->getGroupType()->getContentPlugin('group_node:book')->getContentTypeConfigId();
     $query = $this->entityTypeManager->getStorage('group_content')->getQuery();
-    $query->condition('type', 'group-group_node-book');
+    $query->condition('type', $book_content_plugin_id);
     $query->condition('gid', $group->id());
     $query->range(0, 1);
     $results = $query->execute();


### PR DESCRIPTION
### Fixes

- Fix issue where global event wiki section was not published after publishing the event which was causing TUs, anonymous and GMs to not be able to view the wiki section.

### Test

- [x] As SA/SCM, create a global event and publish it
- [x] Enable all features
- [x] Invite a TU (to have a GM in this group)
- [x] Check your tabs as this GM and make sure the wiki section can be accessed