### PR TITLE
EICNET-2622: I cannot manage members as SCM/SA in a group

### DIFF
--- a/config/sync/group.role.event-a416e6833.yml
+++ b/config/sync/group.role.event-a416e6833.yml
@@ -24,6 +24,7 @@ permissions:
   - 'access members overview'
   - 'access news overview'
   - 'access wiki overview'
+  - 'administer members'
   - 'delete any invitation'
   - 'delete own invitations'
   - 'edit all comments'

--- a/config/sync/group.role.event-bf4b46c3a.yml
+++ b/config/sync/group.role.event-bf4b46c3a.yml
@@ -24,6 +24,7 @@ permissions:
   - 'access members overview'
   - 'access news overview'
   - 'access wiki overview'
+  - 'administer members'
   - 'delete any invitation'
   - 'delete own invitations'
   - 'edit all comments'

--- a/config/sync/group.role.event-eca6128ca.yml
+++ b/config/sync/group.role.event-eca6128ca.yml
@@ -24,6 +24,7 @@ permissions:
   - 'access members overview'
   - 'access news overview'
   - 'access wiki overview'
+  - 'administer members'
   - 'delete any invitation'
   - 'delete own invitations'
   - 'edit all comments'


### PR DESCRIPTION
### Improvements

- Add missing permission "Administer group members" to SA/SCM users in global events.

### Test

- [x] As SA/SCM (not DA), go to any global event page
- [x] Go to the "Manage members" page of the global event (from the Manage dropdown in the group header)
- [x] Make sure you can see the options to view/edit/delete membership of each group member

### Notes

- For old global events we need to rebuild permissions