### PR TITLE
EICNET-1334: Add latest comment to discussion teaser on discussions overview

### DIFF
--- a/lib/modules/eic_flags/eic_flags.services.yml
+++ b/lib/modules/eic_flags/eic_flags.services.yml
@@ -6,11 +6,15 @@ services:
   eic_flags.delete_request_handler:
     class: Drupal\eic_flags\Service\DeleteRequestHandler
     arguments: [ '@module_handler', '@entity_type.manager', '@flag', '@content_moderation.moderation_information', '@request_stack', '@entity_field.manager' ]
+    calls:
+      - [setDocumentProcessor, ['@?eic_search.solr_document_processor']]
     tags:
       - { name: request_handler }
   eic_flags.delete_archive_handler:
     class: Drupal\eic_flags\Service\ArchiveRequestHandler
     arguments: [ '@module_handler', '@entity_type.manager', '@flag', '@content_moderation.moderation_information', '@request_stack', '@entity_field.manager' ]
+    calls:
+      - [setDocumentProcessor, ['@?eic_search.solr_document_processor']]
     tags:
       - { name: request_handler }
   eic_flags.block_request_handler:

--- a/lib/modules/eic_flags/src/Service/ArchiveRequestHandler.php
+++ b/lib/modules/eic_flags/src/Service/ArchiveRequestHandler.php
@@ -11,6 +11,7 @@ use Drupal\eic_content\Constants\DefaultContentModerationStates;
 use Drupal\eic_flags\RequestStatus;
 use Drupal\eic_flags\RequestTypes;
 use Drupal\eic_groups\GroupsModerationHelper;
+use Drupal\eic_search\Service\SolrDocumentProcessor;
 use Drupal\flag\FlaggingInterface;
 
 /**
@@ -19,6 +20,23 @@ use Drupal\flag\FlaggingInterface;
  * @package Drupal\eic_flags\Service
  */
 class ArchiveRequestHandler extends AbstractRequestHandler {
+
+  /**
+   * The Solr document processor service.
+   *
+   * @var \Drupal\eic_search\Service\SolrDocumentProcessor
+   */
+  private $solrDocumentProcessor;
+
+  /**
+   * Injects SOLR document processor service.
+   *
+   * @param \Drupal\eic_search\Service\SolrDocumentProcessor|null $solr_document_processor
+   *   The EIC Search Solr Document Processor.
+   */
+  public function setDocumentProcessor(?SolrDocumentProcessor $solr_document_processor) {
+    $this->solrDocumentProcessor = $solr_document_processor;
+  }
 
   /**
    * {@inheritdoc}
@@ -76,6 +94,13 @@ class ArchiveRequestHandler extends AbstractRequestHandler {
         ]);
         $content_entity->set('field_comment_is_archived', TRUE);
         $content_entity->save();
+
+        // Reindex user entity to update data like most_active_score.
+        $this->solrDocumentProcessor->lateReIndexEntities([$content_entity->getOwner()]);
+
+        // Reindex commented entity to update overview teaser and
+        // most_active_score.
+        $this->solrDocumentProcessor->reIndexEntities([$content_entity->getCommentedEntity()]);
       }
       else {
         $content_entity->set('status', FALSE);

--- a/lib/modules/eic_groups/src/Controller/DiscussionController.php
+++ b/lib/modules/eic_groups/src/Controller/DiscussionController.php
@@ -371,6 +371,13 @@ class DiscussionController extends ControllerBase {
       return new JsonResponse($e->getMessage(), Response::HTTP_BAD_REQUEST);
     }
 
+    // Reindex user entity to update data like most_active_score.
+    $this->solrDocumentProcessor->lateReIndexEntities([$comment->getOwner()]);
+
+    // Reindex commented entity to update overview teaser and
+    // most_active_score.
+    $this->solrDocumentProcessor->reIndexEntities([$comment->getCommentedEntity()]);
+
     return new JsonResponse([]);
   }
 
@@ -418,6 +425,13 @@ class DiscussionController extends ControllerBase {
 
       return new JsonResponse($e->getMessage(), Response::HTTP_BAD_REQUEST);
     }
+
+    // Reindex user entity to update data like most_active_score.
+    $this->solrDocumentProcessor->lateReIndexEntities([$comment->getOwner()]);
+
+    // Reindex commented entity to update overview teaser and
+    // most_active_score.
+    $this->solrDocumentProcessor->reIndexEntities([$comment->getCommentedEntity()]);
 
     return new JsonResponse([]);
   }


### PR DESCRIPTION
### Improvements

- Re-index discussion when comment is deleted or archived in order to update the latest comment in discussions overview.

### Test

- [x] As SA/SCM, add some comments to a discussion
- [x] As TU, go to the discussion overview and make sure the comment is displayed 
- [x] Go to the discussion detail and request archival or deletion of the comment
- [x] As SA/SCM, accept the request
- [x] As TU, go to the discussion overview and make sure the soft archival/delete comment is shown with the correct text
- [x] As SA/SCM, add a new comment
- [x] Make sure the new comment is shown in the discussion overview
- [x] Try to edit the comment and change the text
- [x] Make sure the updated version of the comment is shown in the discussion overview
- [x] Delete the comment
- [x] Make sure the soft deleted comment is shown with the correct text