### PR TITLE
EICNET-2544: Change order of the vertical navigation of the user profile

### DIFF
--- a/lib/themes/eic_community/patterns/compositions/member/member.full.html.twig
+++ b/lib/themes/eic_community/patterns/compositions/member/member.full.html.twig
@@ -23,10 +23,10 @@
   {% include "@theme/patterns/compositions/featured-content-sections.html.twig" with {
     as_tabs: true,
     items: [
-      flagged_groups|default({}),
-      flagged_projects|default({}),
       flagged_interests|default({}),
+      flagged_groups|default({}),
       flagged_events|default({}),
+      flagged_projects|default({}),
     ]
   } only %}
 {% endblock %}


### PR DESCRIPTION
### Improvements

- Re-order vertical tabs in my profile page.

### Test

- [ ] As TU, go to your profile page
- [ ] Make sure the vertical tabs are ordered as follow: "My interests", "My groups", "My events" and "My organisations"