### PR TITLE
EICNET-1144: Show latest members on the group activity stream page (Hide for anonymous)

### DIFF
--- a/lib/modules/eic_groups/src/Plugin/GroupFeature/GroupLatestActivityStream.php
+++ b/lib/modules/eic_groups/src/Plugin/GroupFeature/GroupLatestActivityStream.php
@@ -3,7 +3,6 @@
 namespace Drupal\eic_groups\Plugin\GroupFeature;
 
 use Drupal\Core\Url;
-use Drupal\group\Entity\GroupInterface;
 
 /**
  * Group feature plugin implementation for Latest activity stream.
@@ -34,15 +33,6 @@ class GroupLatestActivityStream extends EicGroupsGroupFeaturePluginBase {
     // Set a specific weight for the menu item.
     $menu_item->set('weight', 1);
     return $menu_item;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  protected function getGroupPublicRoleIds(GroupInterface $group) {
-    return [
-      $group->getGroupType()->getOutsiderRoleId(),
-    ];
   }
 
 }

--- a/lib/modules/eic_search/src/Plugin/Block/ActivityStreamBlock.php
+++ b/lib/modules/eic_search/src/Plugin/Block/ActivityStreamBlock.php
@@ -330,7 +330,7 @@ class ActivityStreamBlock extends BlockBase implements ContainerFactoryPluginInt
 
       return [
         'joined_date' => $this->dateFormatter->format($groupContent->getCreatedTime(), 'eu_short_date'),
-        'full_name' => $user->get('field_first_name')->value . ' ' . $user->get('field_last_name')->value,
+        'full_name' => $user->getDisplayName(),
         'email' => $user->getEmail(),
         'picture' => $file_url,
         'url' => $user_profile_url,

--- a/lib/modules/eic_search/src/Plugin/Block/ActivityStreamBlock.php
+++ b/lib/modules/eic_search/src/Plugin/Block/ActivityStreamBlock.php
@@ -216,12 +216,13 @@ class ActivityStreamBlock extends BlockBase implements ContainerFactoryPluginInt
       'contexts' => [
         'url.path',
         'url.query_args',
+        'user.roles',
       ],
     ];
 
     // Send members data and cache tags.
     $members = [];
-    if ($show_members) {
+    if ($show_members && !$this->currentUser->isAnonymous()) {
       $members = $this->getMembersData($group);
       $cache['tags'] = [];
       foreach ($members as $member) {
@@ -229,12 +230,12 @@ class ActivityStreamBlock extends BlockBase implements ContainerFactoryPluginInt
           Cache::mergeTags($cache['tags'], $member['cache_tags']) :
           $cache['tags'];
       }
+      $build['#members'] = $members;
     }
 
     return $build += [
       '#theme' => 'eic_group_last_activities_members',
       '#cache' => $cache,
-      '#members' => $members,
       '#url' => Url::fromRoute('eic_search.solr_search', [], $url_options)->toString(),
       '#translations' => [
         'no_results_title' => $this->t('We haven’t found any search results', [], ['context' => 'eic_group']),


### PR DESCRIPTION
### Improvements

- Hide latest members block from activity stream when current user is anonymous.

### Test

- [x] As anonymous, go to the activity stream section of a public group
- [x] Make sure you can't see the "Latest members" block
- [x] Login as any user, and make sure you can see the "Latest members" block