### PR TITLE
Feature/eicnet 2643 login splash page

### DIFF
--- a/config/development/eic_user_login.settings.yml
+++ b/config/development/eic_user_login.settings.yml
@@ -1,5 +1,6 @@
 check_sync_user: false
 allow_user_register: true
+user_registration_url: 'https://eic.eismea.eu/mydashboard/admissions/entry'
 endpoint_url: ''
 basic_auth_username: ''
 basic_auth_password: ''

--- a/config/sync/context.context.global_breadcrumbs.yml
+++ b/config/sync/context.context.global_breadcrumbs.yml
@@ -17,7 +17,7 @@ conditions:
     negate: true
     uuid: d8a54054-50a9-4f1a-a581-af9ee18b86af
     context_mapping: {  }
-    routes: "entity.overview_page.canonical\r\nentity.taxonomy_term.canonical\r\ncontact.site_page"
+    routes: "entity.overview_page.canonical\r\nentity.taxonomy_term.canonical\r\ncontact.site_page\r\neic_user_login.member_access"
 reactions:
   blocks:
     id: blocks

--- a/config/sync/context.context.global_member_access_page.yml
+++ b/config/sync/context.context.global_member_access_page.yml
@@ -31,7 +31,7 @@ reactions:
         id: 'block_content:a6aaef49-c248-4009-8dd5-0db08108067b'
         label: 'Member access description'
         provider: block_content
-        label_display: visible
+        label_display: '0'
         region: content_before
         weight: '0'
         custom_id: block_content_a6aaef49_c248_4009_8dd5_0db08108067b

--- a/config/sync/context.context.global_member_access_page.yml
+++ b/config/sync/context.context.global_member_access_page.yml
@@ -1,0 +1,67 @@
+uuid: 596ea851-fe04-4cd9-87ef-c178832ff4b5
+langcode: en
+status: true
+dependencies:
+  content:
+    - 'block_content:basic:a6aaef49-c248-4009-8dd5-0db08108067b'
+    - 'block_content:page_banner:8d5fdf72-3a4e-4f98-ae22-2652ed4be3d3'
+  module:
+    - block_content
+    - route_condition
+label: 'Global - Member access page'
+name: global_member_access_page
+group: Global
+description: ''
+requireAllConditions: false
+disabled: false
+conditions:
+  route:
+    id: route
+    negate: false
+    uuid: 394d895a-8cda-479c-9e6c-eaecb506ce50
+    context_mapping: {  }
+    routes: eic_user_login.member_access
+reactions:
+  blocks:
+    id: blocks
+    uuid: 3b103b3b-7d7b-4062-be9d-698de5e3dc01
+    blocks:
+      db961b1c-bf79-49d1-bf32-fe316be125e0:
+        uuid: db961b1c-bf79-49d1-bf32-fe316be125e0
+        id: 'block_content:a6aaef49-c248-4009-8dd5-0db08108067b'
+        label: 'Member access description'
+        provider: block_content
+        label_display: visible
+        region: content_before
+        weight: '0'
+        custom_id: block_content_a6aaef49_c248_4009_8dd5_0db08108067b
+        theme: eic_community
+        css_class: ''
+        unique: 0
+        context_id: global_member_access_page
+        context_mapping: {  }
+        status: true
+        info: ''
+        view_mode: full
+        third_party_settings: {  }
+      6e26f8f6-d8e6-4e31-bcc2-9f8ad6fadede:
+        uuid: 6e26f8f6-d8e6-4e31-bcc2-9f8ad6fadede
+        id: 'block_content:8d5fdf72-3a4e-4f98-ae22-2652ed4be3d3'
+        label: 'Member access page'
+        provider: block_content
+        label_display: visible
+        region: page_header
+        weight: '0'
+        custom_id: block_content_8d5fdf72_3a4e_4f98_ae22_2652ed4be3d3
+        theme: eic_community
+        css_class: ''
+        unique: 0
+        context_id: global_member_access_page
+        context_mapping: {  }
+        status: true
+        info: ''
+        view_mode: full
+        third_party_settings: {  }
+    include_default_blocks: 0
+    saved: false
+weight: 0

--- a/config/sync/context.context.global_member_access_page.yml
+++ b/config/sync/context.context.global_member_access_page.yml
@@ -8,6 +8,7 @@ dependencies:
   module:
     - block_content
     - route_condition
+    - system
 label: 'Global - Member access page'
 name: global_member_access_page
 group: Global
@@ -51,7 +52,7 @@ reactions:
         provider: block_content
         label_display: visible
         region: page_header
-        weight: '0'
+        weight: '-1'
         custom_id: block_content_8d5fdf72_3a4e_4f98_ae22_2652ed4be3d3
         theme: eic_community
         css_class: ''
@@ -61,6 +62,21 @@ reactions:
         status: true
         info: ''
         view_mode: full
+        third_party_settings: {  }
+      71030e22-8521-4f6c-bf41-c2b629772ce4:
+        uuid: 71030e22-8521-4f6c-bf41-c2b629772ce4
+        id: system_breadcrumb_block
+        label: Breadcrumbs
+        provider: system
+        label_display: '0'
+        region: page_header
+        weight: '0'
+        custom_id: system_breadcrumb_block
+        theme: eic_community
+        css_class: ''
+        unique: 0
+        context_id: global_member_access_page
+        context_mapping: {  }
         third_party_settings: {  }
     include_default_blocks: 0
     saved: false

--- a/config/sync/eic_user_login.settings.yml
+++ b/config/sync/eic_user_login.settings.yml
@@ -1,0 +1,3 @@
+check_sync_user: false
+allow_user_register: true
+user_registration_url: 'https://eic.eismea.eu/mydashboard/admissions/entry'

--- a/lib/modules/eic_default_content/src/Generator/BlockContentGenerator.php
+++ b/lib/modules/eic_default_content/src/Generator/BlockContentGenerator.php
@@ -24,6 +24,7 @@ class BlockContentGenerator extends CoreGenerator {
     $this->createNewsletterBlock();
     $this->createFiguresBlock();
     $this->createSiteInfoBlock();
+    $this->createMemberAccessBlocks();
   }
 
   /**
@@ -65,6 +66,34 @@ class BlockContentGenerator extends CoreGenerator {
     ];
 
     $block = BlockContent::create($values);
+    $block->save();
+  }
+
+  /**
+   * Creates member access page blocks.
+   */
+  private function createMemberAccessBlocks() {
+    $block = BlockContent::create([
+      'status' => TRUE,
+      'type' => 'page_banner',
+      // For BC reasons we keep the same UUIDs since they are referenced in configs.
+      'uuid' => '8d5fdf72-3a4e-4f98-ae22-2652ed4be3d3',
+      'field_title' => 'Member access',
+      'info' => 'Member access page - Banner',
+      'field_media' => $this->getRandomEntities('media', ['bundle' => 'image']),
+    ]);
+    $block->save();
+
+    $text = '<p>Your place to connect, find partners and share knowledge.</p>
+            <p>The community is open to all EIC beneficiaries.</p>';
+    $block = BlockContent::create([
+      'status' => TRUE,
+      'type' => 'basic',
+      'uuid' => 'a6aaef49-c248-4009-8dd5-0db08108067b',
+      'info' => 'Member access page - Description',
+      'field_title' => 'Welcome to the EIC Community!',
+      'body' => $this->getFormattedText('full_html', $text),
+    ]);
     $block->save();
   }
 

--- a/lib/modules/eic_user/modules/eic_user_login/config/schema/eic_user_login.schema.yml
+++ b/lib/modules/eic_user/modules/eic_user_login/config/schema/eic_user_login.schema.yml
@@ -7,6 +7,9 @@ eic_user_login.settings:
     allow_user_register:
       type: boolean
       label: 'Allow users to register within Drupal'
+    user_registration_url:
+      type: string
+      label: 'User registration URL'
     endpoint_url:
       type: string
       label: 'SMED Endpoint URL'

--- a/lib/modules/eic_user/modules/eic_user_login/eic_user_login.module
+++ b/lib/modules/eic_user/modules/eic_user_login/eic_user_login.module
@@ -148,3 +148,17 @@ function eic_user_login_form_profile_form_alter(&$form, FormStateInterface $form
   \Drupal::classResolver(FormAlter::class)
     ->formProfileFormAlter($form, $form_state, $form_id);
 }
+
+/**
+ * Implements hook_theme().
+ */
+function eic_user_login_theme($existing, $type, $theme, $path) {
+  return [
+    'member_access_page' => [
+      'variables' => [
+        'login_link' => NULL,
+        'register_link' => NULL,
+      ],
+    ],
+  ];
+}

--- a/lib/modules/eic_user/modules/eic_user_login/eic_user_login.routing.yml
+++ b/lib/modules/eic_user/modules/eic_user_login/eic_user_login.routing.yml
@@ -5,3 +5,12 @@ eic_user_login.settings:
     _form: 'Drupal\eic_user_login\Form\SettingsForm'
   requirements:
     _permission: 'administer site configuration'
+
+eic_user_login.member_access:
+  path: '/member-access'
+  defaults:
+    _title: 'Member access'
+    _controller: '\Drupal\eic_user_login\Controller\MemberAccessController::build'
+  requirements:
+    # This page should be accessible to anyone.
+    _access: 'TRUE'

--- a/lib/modules/eic_user/modules/eic_user_login/src/Controller/MemberAccessController.php
+++ b/lib/modules/eic_user/modules/eic_user_login/src/Controller/MemberAccessController.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Drupal\eic_user_login\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\Link;
+use Drupal\Core\Url;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+/**
+ * Provides route response the member access page.
+ */
+class MemberAccessController extends ControllerBase {
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountProxyInterface
+   */
+  protected $currentUser;
+
+  /**
+   * Constructor.
+   *
+   * @param \Drupal\Core\Session\AccountProxyInterface $current_user
+   *   The current user.
+   */
+  public function __construct(AccountProxyInterface $current_user) {
+    $this->currentUser = $current_user;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('current_user')
+    );
+  }
+
+  /**
+   * Returns the content for member access page.
+   *
+   * @return array
+   *   A renderable array.
+   */
+  public function build() {
+    // If user is already authenticated, there's no need for this page.
+    // Redirect to the homepage.
+    if ($this->currentUser->isAuthenticated()) {
+      $url = Url::fromRoute('<front>');
+      return new RedirectResponse($url->toString());
+    }
+
+    $login_url = new Url('cas.login', [], [
+      'attributes' => [
+        'class' => ['cas-login-link'],
+      ],
+    ]);
+    $register_url = new Url('cas.login', [], [
+      'attributes' => [
+        'class' => ['cas-login-link'],
+        'target' => '_blank',
+      ],
+    ]);
+
+    return [
+      '#theme' => 'member_access_page',
+      '#login_link' => Link::fromTextAndUrl($this->t('Log in'), $login_url),
+      '#register_link' => Link::fromTextAndUrl($this->t('Register'), $register_url),
+    ];
+  }
+
+}

--- a/lib/modules/eic_user/modules/eic_user_login/src/Controller/MemberAccessController.php
+++ b/lib/modules/eic_user/modules/eic_user_login/src/Controller/MemberAccessController.php
@@ -84,10 +84,13 @@ class MemberAccessController extends ControllerBase {
     // Redirect to the homepage.
     if ($this->currentUser->isAuthenticated()) {
       if (empty($destination)) {
-        $destination = '<front>';
+        $url = Url::fromRoute('<front>')->toString();
       }
-      $url = Url::fromRoute($destination);
-      return new RedirectResponse($url->toString());
+      else {
+        $url = $destination;
+      }
+
+      return new RedirectResponse($url);
     }
 
     $login_url = Url::fromRoute('cas.login', [], [

--- a/lib/modules/eic_user/modules/eic_user_login/src/Form/SettingsForm.php
+++ b/lib/modules/eic_user/modules/eic_user_login/src/Form/SettingsForm.php
@@ -47,6 +47,13 @@ class SettingsForm extends ConfigFormBase {
       '#description' => $this->t('Check this option if users should be able to register within Drupal without any initial check against the SMED.'),
       '#group' => 'user_settings',
     ];
+    $form['user_registration_url'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('User registration URL'),
+      '#default_value' => $this->config('eic_user_login.settings')->get('user_registration_url'),
+      '#required' => TRUE,
+      '#group' => 'user_settings',
+    ];
     $form['endpoint_url'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Endpoint URL'),
@@ -102,6 +109,7 @@ class SettingsForm extends ConfigFormBase {
     $this->config('eic_user_login.settings')
       ->set('check_sync_user', $form_state->getValue('check_sync_user'))
       ->set('allow_user_register', $form_state->getValue('allow_user_register'))
+      ->set('user_registration_url', $form_state->getValue('user_registration_url'))
       ->save();
     parent::submitForm($form, $form_state);
   }

--- a/lib/modules/eic_user/modules/eic_user_login/templates/member-access-page.html.twig
+++ b/lib/modules/eic_user/modules/eic_user_login/templates/member-access-page.html.twig
@@ -1,0 +1,21 @@
+{#
+/**
+ * @file
+ * Default theme implementation to present the member access page.
+ *
+ * Available variables:
+ * - login_link: link to log in.
+ * - register_link: link to register.
+ *
+ * @see template_preprocess_member_access_page()
+ */
+#}
+<div class="member-access-login">
+  <p>{{ 'Already a member?'|t }}</p>
+  {{ login_link }}
+</div>
+
+<div class="member-access-register">
+  <p>{{ 'Not a member yet?'|t }}</p>
+  {{ register_link }}
+</div>

--- a/lib/modules/eic_user/modules/eic_user_login/templates/member-access-page.html.twig
+++ b/lib/modules/eic_user/modules/eic_user_login/templates/member-access-page.html.twig
@@ -10,12 +10,16 @@
  * @see template_preprocess_member_access_page()
  */
 #}
-<div class="member-access-login">
-  <p>{{ 'Already a member?'|t }}</p>
-  {{ login_link }}
-</div>
+<div class="ecl-container">
+  <div class="member-acces">
+    <div class="member-acces__item member-access-login">
+      <p>{{ 'Already a member?'|t }}</p>
+      {{ login_link }}
+    </div>
 
-<div class="member-access-register">
-  <p>{{ 'Not a member yet?'|t }}</p>
-  {{ register_link }}
+    <div class="member-acces__item member-access-register">
+      <p>{{ 'Not a member yet?'|t }}</p>
+      {{ register_link }}
+    </div>
+  </div>
 </div>

--- a/lib/modules/eic_user/src/Plugin/Block/AccountHeaderBlock.php
+++ b/lib/modules/eic_user/src/Plugin/Block/AccountHeaderBlock.php
@@ -85,12 +85,21 @@ class AccountHeaderBlock extends BlockBase implements ContainerFactoryPluginInte
    */
   public function build() {
     if ($this->currentUser->isAnonymous()) {
+      // If there is a defined destination, preserve it, otherwise use the
+      // current page for the destination.
+      if (!empty($this->currentRequest->get('destination'))) {
+        $destination = $this->currentRequest->get('destination');
+      }
+      else {
+        $destination = $this->currentRequest->getRequestUri();
+      }
+
       $build['#login']['link'] = [
-        'label' => t('Log in'),
+        'label' => t('Member access'),
         'path' => Url::fromRoute(
-          'user.login',
+          'eic_user_login.member_access',
           [
-            'destination' => $this->currentRequest->getRequestUri(),
+            'destination' => $destination,
           ]
         ),
       ];

--- a/lib/themes/eic_community/includes/alter/theme_suggestions/block.inc
+++ b/lib/themes/eic_community/includes/alter/theme_suggestions/block.inc
@@ -17,6 +17,12 @@ function eic_community_theme_suggestions_block_alter(
   array &$suggestions,
   array $variables
 ) {
+  // Add suggestions per block type.
+  if (isset($variables['elements']['content']['#block_content'])) {
+    $bundle = $variables['elements']['content']['#block_content']->bundle();
+    array_splice($suggestions, 1, 0, 'block__block_content__' . $bundle);
+  }
+
   $is_taxonomy_page = TopicsManager::isTopicPage();
 
   if (
@@ -24,8 +30,7 @@ function eic_community_theme_suggestions_block_alter(
     && isset($variables['elements']['#configuration']['region'])
     && 'content' === $variables['elements']['#configuration']['region']
     && 'views' === $variables['elements']['#configuration']['provider']
-  )
-  {
+  ) {
     $suggestions[] = 'block__global_block_taxonomy_term_page';
   }
 

--- a/lib/themes/eic_community/includes/preprocess/blocks/block--page-banner.inc
+++ b/lib/themes/eic_community/includes/preprocess/blocks/block--page-banner.inc
@@ -26,7 +26,7 @@ function eic_community_preprocess_block__page_banner(&$variables, &$cache_tags =
         // @todo harmonise templates, so we don't need to make exceptions.
         switch ($variables['elements']['#id']) {
           case 'block_content_8d5fdf72_3a4e_4f98_ae22_2652ed4be3d3':
-            $variables['editorial_header'] = [
+            $variables['overview_header'] = [
               'title' => $block_content->field_title->value,
               'image' => [
                 'src' => $image_item->getSource(),

--- a/lib/themes/eic_community/includes/preprocess/blocks/block--page-banner.inc
+++ b/lib/themes/eic_community/includes/preprocess/blocks/block--page-banner.inc
@@ -22,6 +22,20 @@ function eic_community_preprocess_block__page_banner(&$variables, &$cache_tags =
       case 'image':
         $image_item = ImageValueObject::fromImageItem($media->get('oe_media_image')->first());
         $variables['hero']['image'] = $image_item->getSource();
+
+        // @todo harmonise templates, so we don't need to make exceptions.
+        switch ($variables['elements']['#id']) {
+          case 'block_content_8d5fdf72_3a4e_4f98_ae22_2652ed4be3d3':
+            $variables['editorial_header'] = [
+              'title' => $block_content->field_title->value,
+              'image' => [
+                'src' => $image_item->getSource(),
+                'alt' => $image_item->getAlt(),
+              ],
+            ];
+            break;
+        }
+
         break;
 
     }

--- a/lib/themes/eic_community/sass/compositions/_member-acces.scss
+++ b/lib/themes/eic_community/sass/compositions/_member-acces.scss
@@ -1,0 +1,42 @@
+.member-acces {
+  display: flex;
+  justify-content: space-between;
+  gap: $ecl-spacing-2-xl;
+  margin: $ecl-spacing-3-xl 0;
+
+  @include ecl-media-breakpoint-down('sm') {
+    flex-direction: column;
+  }
+
+  &__item {
+    border-top: .75em solid $ecl-color-blue;
+    width: 50%;
+    padding: $ecl-spacing-m;
+    display: flex;
+    flex-direction: column;
+
+    @include ecl-media-breakpoint-down('sm') {
+      width: 100%;
+    }
+
+    & p {
+      font-weight: bold;
+      margin-top: 0;
+      font-size: 1.25em;
+    }
+
+    & a {
+      display: inline-block;
+      align-self: flex-end;
+      @extend .ecl-button;
+      @extend .ecl-button--primary;
+      color: $ecl-color-blue;
+      background-color: $ecl-color-blue-5;
+      border-color: $ecl-color-blue-5  !important;
+
+      &:hover {
+        border-color: $ecl-color-blue  !important;
+      }
+    }
+  }
+}

--- a/lib/themes/eic_community/sass/eic_community.screen.scss
+++ b/lib/themes/eic_community/sass/eic_community.screen.scss
@@ -72,6 +72,7 @@
 @import "./compositions/language-selector";
 @import "./compositions/mainmenu";
 @import "./compositions/media-wrapper";
+@import "./compositions/member-acces";
 @import "./compositions/my-notifications";
 @import "./compositions/notification-banner";
 @import "./compositions/overview-header";

--- a/lib/themes/eic_community/templates/blocks/block--block-content--a6aaef49-c248-4009-8dd5-0db08108067b.html.twig
+++ b/lib/themes/eic_community/templates/blocks/block--block-content--a6aaef49-c248-4009-8dd5-0db08108067b.html.twig
@@ -1,0 +1,35 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ */
+#}
+<div{{ attributes }}>
+  {% if content.field_title is not empty %}
+    <h1 class="ecl-title ecl-title--display1">{{ content.field_title.0 }}</h1>
+  {% endif %}
+  {% block content %}
+    {{ content|without('field_title') }}
+  {% endblock %}
+</div>

--- a/lib/themes/eic_community/templates/blocks/block--block-content--page-banner.html.twig
+++ b/lib/themes/eic_community/templates/blocks/block--block-content--page-banner.html.twig
@@ -25,7 +25,7 @@
  * @see template_preprocess_block()
  */
 #}
-{% embed "@theme/patterns/compositions/editable-hero-banner.html.twig" with hero|default({})|merge({
+{% embed "@theme/patterns/compositions/editorial-header.html.twig" with editorial_header|default({})|merge({
   extra_classes: 'ecl-editable-hero-banner--is-blue',
 }) %}
   {% block content %}

--- a/lib/themes/eic_community/templates/blocks/block--block-content--page-banner.html.twig
+++ b/lib/themes/eic_community/templates/blocks/block--block-content--page-banner.html.twig
@@ -1,0 +1,60 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ */
+#}
+{% embed "@theme/patterns/compositions/editable-hero-banner.html.twig" with hero|default({})|merge({
+  extra_classes: 'ecl-editable-hero-banner--is-blue',
+}) %}
+  {% block content %}
+    {% if content.field_subtitle is not empty %}
+      <span class="ecl-description">{{ content.field_subtitle.0 }}</span>
+    {% endif %}
+
+    {% if content.field_title is not empty %}
+      <h1 class="ecl-title ecl-title--display1">{{ content.field_title.0 }}</h1>
+    {% endif %}
+
+    {% if content.field_body is not empty %}
+      <p class="ecl-description">{{ content.field_body.0 }}</p>
+    {% endif %}
+
+    {% if content.field_cta_links is not empty %}
+      {% set _items = [] %}
+      {% for item in content['#block_content'].field_cta_links %}
+        {% set  _items = _items|merge([{
+            link: {
+              label: item.title,
+              path: item.url,
+              type: item.link_type == 'default' ? 'standalone' : item.link_type,
+            },
+          }]) %}
+      {% endfor %}
+      {% include "@theme/patterns/components/inline-actions.html.twig" with {
+        items: _items
+      } only %}
+    {% endif %}
+  {% endblock %}
+{% endembed %}

--- a/lib/themes/eic_community/templates/blocks/block--block-content--page-banner.html.twig
+++ b/lib/themes/eic_community/templates/blocks/block--block-content--page-banner.html.twig
@@ -25,7 +25,7 @@
  * @see template_preprocess_block()
  */
 #}
-{% embed "@theme/patterns/compositions/editorial-header.html.twig" with editorial_header|default({})|merge({
+{% embed "@theme/patterns/compositions/overview-header.html.twig" with overview_header|default({})|merge({
   extra_classes: 'ecl-editable-hero-banner--is-blue',
 }) %}
   {% block content %}


### PR DESCRIPTION
### Improvements

- Added template suggestions for block_content bundles and created one for page_banner

### Tests

- [x] Run `drush fixtures:reload BlockContentGenerator`
- [x] Run `drush cr && drush cim -y`
- [x] As anonymous, go to the homepage
- [x] Make sure you have a "Member access"  link in the header instead of the "Log in" link
- [x] Click on it
- [x] Make sure you have the page designed as expected (check https://citnet.tech.ec.europa.eu/CITnet/jira/browse/EICNET-2643)
- [x] Go to `/user/login` and login as TU
- [x] Go to `/member-access` and make sure you are redirected to the homepage
- [x] Go to `/member-access?destination=/groups` and make sure you are redirected to `/groups`