### PR TITLE
EICNET-1091: As a GM I can see when content has been shared inside my group

### DIFF
--- a/lib/modules/eic_groups/modules/eic_share_content/src/Service/ShareManager.php
+++ b/lib/modules/eic_groups/modules/eic_share_content/src/Service/ShareManager.php
@@ -416,7 +416,7 @@ class ShareManager {
     // Dispatch the message.
     $this->messageBus->dispatch([
       'template' => ActivityStreamMessageTemplates::SHARE_CONTENT,
-      'uid' => $node->getOwnerId(),
+      'uid' => $this->currentUser->id(),
       'field_operation_type' => ActivityStreamOperationTypes::SHARED_ENTITY,
       'field_referenced_node' => $node->id(),
       'field_entity_type' => $node->bundle(),


### PR DESCRIPTION
### Fixes

- Fix wrong author name of the user that triggered the shared the content with another group.

### Test

- [x] As TU (member), try to share a discussion with another group. Make sure you are not the author of the discussion.
- [x] Go to the activity stream of the group where the discussion was shared
- [x] Make sure the author name of the message is the user that shared the content and not the author of the entity