### PR TITLE
EICNET-2651: Share modal: share groups alphabetically.

### DIFF
--- a/lib/modules/eic_groups/modules/eic_share_content/src/Controller/ShareContentController.php
+++ b/lib/modules/eic_groups/modules/eic_share_content/src/Controller/ShareContentController.php
@@ -123,8 +123,16 @@ class ShareContentController extends ControllerBase {
     }
 
     $groups = $this->shareManager->getShareableTargetGroupsForUser($this->currentUser, $group, $node);
-    $formatted_groups = [];
+
+    // Sort groups alphabetically.
+    $sorted_groups = [];
     foreach ($groups as $group) {
+      $sorted_groups[$group->label()] = $group;
+    }
+    ksort($sorted_groups);
+
+    $formatted_groups = [];
+    foreach ($sorted_groups as $group) {
       $formatted_groups[$group->getGroupType()->label()][] = [
         'id' => $group->id(),
         'label' => $group->label(),

--- a/lib/modules/eic_groups/modules/eic_share_content/src/Controller/ShareContentController.php
+++ b/lib/modules/eic_groups/modules/eic_share_content/src/Controller/ShareContentController.php
@@ -139,6 +139,9 @@ class ShareContentController extends ControllerBase {
       ];
     }
 
+    // Also sort on group type.
+    ksort($formatted_groups);
+
     return new JsonResponse($formatted_groups);
   }
 


### PR DESCRIPTION
### Tests

Either use the migrated database, or make sure you have a user who belongs to multiple groups/events/organisations.
If using the migrated database you can use `drush uli --uid=4`

- [x] Go to a discussion in a public group (e.g. `/groups/business-development/discussions/new-business-opportunity-orascom-construction-seeking` with the migrated database)
- [x] Click on Share with another group
- [x] Make sure groups/events/organisations are sorted alphabetically