### PR TITLE
EICNET-2649: Display the shared content message in activity stream item.

### DIFF
--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/ActivityStreamResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/ActivityStreamResultItem.js
@@ -89,12 +89,12 @@ class ActivityStreamResultItem extends React.Component {
       },
     }
     const fullname = `${this.props.result.ss_author_first_name} ${this.props.result.ss_author_last_name}`;
-    const message = `${this.props.result.tm_X3b_en_field_share_message && this.props.result.tm_X3b_en_field_share_message.length > 0 ? this.props.result.tm_X3b_en_field_share_message.shift() : ''}`;
 
     if (!this.props.result || !this.props.result.ss_type || this.props.result.ss_type == undefined || this.state.loading) {
       return <></>;
     }
 
+    const message = `${this.props.result.tm_X3b_en_field_share_message && this.props.result.tm_X3b_en_field_share_message.length > 0 ? this.props.result.tm_X3b_en_field_share_message.shift() : ''}`;
     const entity_bundle = this.props.result.ss_type.replace(' ', '_').toLowerCase();
 
     return (<ResultItemWrapper


### PR DESCRIPTION
### Tests

- [x] Make sure you run `make build-front`
- [x] As logged-in user share a content to a group, with a message
- [x] Go to the target group acivity stream
- [x] Make sure you see the activity stream item with the message