### PR TITLE
Feature/eicnet 2624 organisation type migration web service

### DIFF
--- a/config/sync/core.entity_form_display.taxonomy_term.organisation_types.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.organisation_types.default.yml
@@ -1,0 +1,60 @@
+uuid: 65c00ec2-1085-46a0-8b71-614f26d2d43e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.organisation_types.field_smed_id
+    - taxonomy.vocabulary.organisation_types
+  module:
+    - path
+    - text
+id: taxonomy_term.organisation_types.default
+targetEntityType: taxonomy_term
+bundle: organisation_types
+mode: default
+content:
+  description:
+    type: text_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_smed_id:
+    type: string_textfield
+    weight: 101
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 100
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+hidden: {  }

--- a/config/sync/core.entity_view_display.taxonomy_term.organisation_types.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.organisation_types.default.yml
@@ -1,0 +1,32 @@
+uuid: 12c6cbd4-213a-4465-ac98-b56ac4aaf9d8
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.organisation_types.field_smed_id
+    - taxonomy.vocabulary.organisation_types
+  module:
+    - text
+id: taxonomy_term.organisation_types.default
+targetEntityType: taxonomy_term
+bundle: organisation_types
+mode: default
+content:
+  description:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_smed_id:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  langcode: true
+  search_api_excerpt: true

--- a/config/sync/field.field.taxonomy_term.organisation_types.field_smed_id.yml
+++ b/config/sync/field.field.taxonomy_term.organisation_types.field_smed_id.yml
@@ -1,0 +1,19 @@
+uuid: 866a5d35-78e9-4446-9c93-54571ef53575
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_smed_id
+    - taxonomy.vocabulary.organisation_types
+id: taxonomy_term.organisation_types.field_smed_id
+field_name: field_smed_id
+entity_type: taxonomy_term
+bundle: organisation_types
+label: 'SME Dashboard ID'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/migrate_plus.migration.upgrade_d7_taxonomy_term_c4m_vocab_organisation_types.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_taxonomy_term_c4m_vocab_organisation_types.yml
@@ -35,7 +35,7 @@ process:
       plugin: default_value
       default_value: 0
       source: '@parent_id'
-  forum_container: is_container
+  field_smed_id: c4m_dashboard_key
   changed: timestamp
   langcode: language
 destination:

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_taxonomy_term_c4m_vocab_organisation_types.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_taxonomy_term_c4m_vocab_organisation_types.yml
@@ -40,7 +40,7 @@ process:
     - plugin: default_value
       default_value: 0
       source: '@parent_id'
-  forum_container: is_container
+  field_smed_id: c4m_dashboard_key
   changed: timestamp
   langcode: language
 destination:

--- a/lib/modules/eic_webservices/src/Utility/SmedTaxonomyHelper.php
+++ b/lib/modules/eic_webservices/src/Utility/SmedTaxonomyHelper.php
@@ -25,6 +25,7 @@ class SmedTaxonomyHelper {
     'job_titles',
     'languages',
     'organisation_sizes',
+    'organisation_types',
     'services_and_products',
     'target_markets',
     'topics',


### PR DESCRIPTION
### Tests

- [x] Run `drush mim upgrade_d7_taxonomy_term_c4m_vocab_organisation_types --update`
- [x] Create an organisation through webservice with values 35 and 50 for `field_organisation_type` field
- [x] Make sure your organisation is tagged with Corporates and Covid for `field_organisation_type` field