### PR TITLE
EICNET-2659: Adapt SMED webservices response in case of existing entity.

### DIFF
--- a/lib/modules/eic_webservices/src/Plugin/rest/resource/EicUserResource.php
+++ b/lib/modules/eic_webservices/src/Plugin/rest/resource/EicUserResource.php
@@ -80,9 +80,14 @@ class EicUserResource extends EntityResource {
 
     // If user already exists, return a customised response.
     if ($user_exists) {
+      $url = $user->toUrl('canonical', ['absolute' => TRUE]);
       // Send custom response.
       $data = [
         'message' => 'Unprocessable Entity: validation failed. User already exists.',
+        'uid' => $user->id(),
+        'username' => $entity->getAccountName(),
+        'email' => $entity->getEmail(),
+        'uri' => $url->toString(TRUE)->getGeneratedUrl(),
         $smed_id_field => $user->{$smed_id_field}->value,
       ];
 

--- a/lib/modules/eic_webservices/src/Plugin/rest/resource/EventResource.php
+++ b/lib/modules/eic_webservices/src/Plugin/rest/resource/EventResource.php
@@ -33,12 +33,16 @@ class EventResource extends GroupResourceBase {
 
     // Check if event already exists.
     if (!empty($entity->{$smed_id_field}->value) &&
-      $organisation = $this->wsHelper->getGroupBySmedId($entity->{$smed_id_field}->value, 'event')) {
+      $event = $this->wsHelper->getGroupBySmedId($entity->{$smed_id_field}->value, 'event')) {
+      $url = $event->toUrl('canonical', ['absolute' => TRUE]);
 
       // Send custom response.
       $data = [
         'message' => 'Unprocessable Entity: validation failed. Event already exists.',
-        $smed_id_field => $organisation->{$smed_id_field}->value,
+        'gid' => $event->id(),
+        'label' => $event->label(),
+        'uri' => $url->toString(TRUE)->getGeneratedUrl(),
+        $smed_id_field => $event->{$smed_id_field}->value,
       ];
 
       return new ResourceResponse($data, 422);

--- a/lib/modules/eic_webservices/src/Plugin/rest/resource/OrganisationResource.php
+++ b/lib/modules/eic_webservices/src/Plugin/rest/resource/OrganisationResource.php
@@ -34,10 +34,14 @@ class OrganisationResource extends GroupResourceBase {
     // Check if organisation already exists.
     if (!empty($entity->{$smed_id_field}->value) &&
       $organisation = $this->wsHelper->getGroupBySmedId($entity->{$smed_id_field}->value, 'organisation')) {
+      $url = $organisation->toUrl('canonical', ['absolute' => TRUE]);
 
       // Send custom response.
       $data = [
         'message' => 'Unprocessable Entity: validation failed. Organisation already exists.',
+        'gid' => $organisation->id(),
+        'label' => $organisation->label(),
+        'uri' => $url->toString(TRUE)->getGeneratedUrl(),
         $smed_id_field => $organisation->{$smed_id_field}->value,
       ];
 


### PR DESCRIPTION
### Tests

- [x] Use the `/smed/api/v1/user` webservice and try to create an already existing user
- [x] Make sure you get response with following information: `message`, `uid`, `username`, `email`, `uri`, `field_smed_id`
- [x] Use the `/smed/api/v1/organisation` webservice and try to create an already existing organisation
- [x] Make sure you get response with following information: `message`, `gid`, `label`, `uri`, `field_smed_id`
- [x] Use the `/smed/api/v1/event` webservice and try to create an already existing event
- [x] Make sure you get response with following information: `message`, `gid`, `label`, `uri`, `field_smed_id`