### PR TITLE
EICNET-2660: migrated bookpage challenges generates error with non admin user

### DIFF
--- a/lib/modules/eic_content/modules/eic_content_book/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_content/modules/eic_content_book/src/Hooks/EntityOperations.php
@@ -88,7 +88,11 @@ class EntityOperations implements ContainerInjectionInterface {
           $add_book_page_urls = $this->getBookPageAddFormUrls($entity);
 
           // If user can't access the route.
-          if (!$add_book_page_urls['add_child_book_page']->access($this->currentUser)) {
+          if (
+            empty($add_book_page_urls) ||
+            !array_key_exists('add_child_book_page', $add_book_page_urls) ||
+            !$add_book_page_urls['add_child_book_page']->access($this->currentUser)
+          ) {
             return;
           }
 

--- a/lib/modules/eic_content/modules/eic_content_book/src/Plugin/Block/EICBookNavigationBlock.php
+++ b/lib/modules/eic_content/modules/eic_content_book/src/Plugin/Block/EICBookNavigationBlock.php
@@ -103,6 +103,11 @@ class EICBookNavigationBlock extends BookNavigationBlock {
       return [];
     }
 
+    // Ignore book pages that don't have a bid.
+    if (empty($node->book['bid'])) {
+      return [];
+    }
+
     $data = $this->bookManager->bookTreeAllData($node->book['bid']);
     $book_data = reset($data);
 


### PR DESCRIPTION
### Fixes

- Fix error when trying to access book pages as TU.

### Test

- [x] As SA/SCM, create a new book page and publish it
- [x] As TU, go to the book page and make sure there is no error 500 and you can see the detail page normally