### PR TITLE
EICNET-2643: Make sure to redirect users to the member access page on log in or register CTAs

### DIFF
--- a/lib/modules/eic_comments/src/Plugin/Block/LoginBlock.php
+++ b/lib/modules/eic_comments/src/Plugin/Block/LoginBlock.php
@@ -120,10 +120,10 @@ class LoginBlock extends BlockBase implements ContainerFactoryPluginInterface {
       $register_text = $config['register_text'];
     }
 
-    $register_route = Url::fromRoute('user.register');
+    $register_route = Url::fromRoute('eic_user_login.member_access');
     $registration_link = Link::fromTextAndUrl($register_text, $register_route);
 
-    $login_route = Url::fromRoute('user.login');
+    $login_route = Url::fromRoute('eic_user_login.member_access');
     $login_link = Link::fromTextAndUrl($login_text, $login_route);
 
     $build['title'] = $title;

--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
@@ -380,7 +380,7 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
             'destination' => Url::fromRoute('<current>')->toString(),
           ],
         ];
-        $link['url'] = Url::fromRoute('user.login', [], $login_link_options);
+        $link['url'] = Url::fromRoute('eic_user_login.member_access', [], $login_link_options);
         switch ($joining_methods[0]['plugin_id']) {
           case 'tu_open_method':
             $link['title'] = $this->t('Log in to join group');


### PR DESCRIPTION
### Tests

- [ ] As anonymous go to a group page
- [ ] Make sure the "Log in/Register to join..." is pointing to the Member access page
- [ ] Go to a discussion
- [ ] Make sure the "Please log in to see comments and contribute" links both point to the Member access page