### PR TITLE
EICNET-2684: Remove email address from user profile page.

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/users/user.inc
+++ b/lib/themes/eic_community/includes/preprocess/users/user.inc
@@ -76,17 +76,7 @@ function eic_community_preprocess_user(array &$variables) {
         'type' => _eic_community_get_user_type($user, $member_profile),
         'job_titles' => _eic_community_get_user_job_titles($user, $member_profile),
         'image' => _get_profile_image_array($user),
-        'meta' => [
-          [
-            'label' => t('Email'),
-            'items' => [
-              [
-                'label' => $user->getEmail(),
-                'path' => "mailto:{$user->getEmail()}",
-              ],
-            ],
-          ],
-        ],
+        'meta' => [],
       ];
 
       // Gets user operation links.
@@ -248,7 +238,8 @@ function _get_render_block_search_overview(string $source): array {
   $access_result = $plugin_block->access(\Drupal::currentUser());
   if (is_object($access_result) && $access_result->isForbidden() || is_bool($access_result) && !$access_result) {
     return [];
-  } else {
+  }
+  else {
     return $plugin_block->build();
   }
 }


### PR DESCRIPTION
### Tests

- [ ] Make sure to visit a user profile who has an email address
- [ ] Run `drush cr`
- [ ] Make sure the email address is not shown anymore in the `Contact information` block