### PR TITLE
EICNET-2686: Remove fake ogranisation from user card.

### DIFF
--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/UserGalleryResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/UserGalleryResultItem.js
@@ -103,9 +103,6 @@ class UserGalleryResultItem extends React.Component {
               </h2>
 
               <p className="ecl-teaser__description">{this.props.result.sm_user_profile_job_string}</p>
-              <div className="ecl-teaser__links">
-                <a className="ecl-teaser__link" href="?organisation=boxface_inc">Boxface Inc.</a>
-              </div>
 
               {this.props.result.ss_user_profile_city_string && this.props.result.ss_user_profile_field_location_address_country_code &&
                 <address className="ecl-teaser__description">{this.props.result.ss_user_profile_city_string}, {this.props.result.ss_user_profile_field_location_address_country_code}</address>

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/UserListResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/UserListResultItem.js
@@ -61,9 +61,6 @@ class UserListResultItem extends React.Component {
               </h2>
 
               <p className="ecl-teaser__description">{this.props.result.sm_user_profile_job_string}</p>
-              <div className="ecl-teaser__links">
-                <a className="ecl-teaser__link" href="?organisation=boxface_inc">Boxface Inc.</a>
-              </div>
 
               {this.props.result.ss_user_profile_city_string && this.props.result.ss_user_profile_field_location_address_country_code &&
               <address className="ecl-teaser__description">{this.props.result.ss_user_profile_city_string}, {this.props.result.ss_user_profile_field_location_address_country_code}</address>


### PR DESCRIPTION
### Tests

- [ ] Run `make build-front`
- [ ] Run `drush cr`
- [ ] Go to `/people` and make sure no Boxface link is shown anymore
- [ ] Go to `/groups/<group-name>/people` and make sure no Boxface link is shown anymore