### PR TITLE
[EICNET-2688]fix: Set field to not required for field_vocab_geo

### DIFF
--- a/config/sync/field.field.profile.member.field_vocab_geo.yml
+++ b/config/sync/field.field.profile.member.field_vocab_geo.yml
@@ -12,7 +12,7 @@ entity_type: profile
 bundle: member
 label: 'Target Region & Countries'
 description: "Select all countries and/or regions which you are targetting.\r\nYou can select maximum 3 regions and an unlimited number of subregions or countries."
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''


### PR DESCRIPTION
How to test:

- [x] Edit a profile and check that Region and countries is not required