### PR TITLE
EICNET-2690: Change incomplete profile message.

### DIFF
--- a/lib/modules/eic_user/modules/eic_user_login/src/EventSubscriber/RequestEventSubscriber.php
+++ b/lib/modules/eic_user/modules/eic_user_login/src/EventSubscriber/RequestEventSubscriber.php
@@ -109,7 +109,7 @@ class RequestEventSubscriber implements EventSubscriberInterface {
       $event->setResponse($response);
 
       // Print a message to the user.
-      $message = $this->t("Don't forget to complete your profile - Your profile says a lot about who you are and helps other community members recognize your expertise.", [], ['context' => 'eic_user_login']);
+      $message = $this->t("Complete your profile in order to receive information and notifications on new contents, events, stories, groups, challenges that are important for you and increase your chances to network with the right people and companies.", [], ['context' => 'eic_user_login']);
       $this->messenger()->addWarning($message);
     }
   }


### PR DESCRIPTION
### Tests

- [ ] Login with a user that has an incomplete profile
- [ ] Make sure you are redirected to your pfoeil page with following message: `Complete your profile in order to receive information and notifications on new contents, events, stories, groups, challenges that are important for you and increase your chances to network with the right people and companies.`