### PR TITLE
EICNET-2695: Migration: missing group features for Events/Organisations

### DIFF
--- a/config/sync/migrate_plus.migration.upgrade_d7_node_complete_organisation.yml
+++ b/config/sync/migrate_plus.migration.upgrade_d7_node_complete_organisation.yml
@@ -69,7 +69,7 @@ process:
       migration:
         - upgrade_d7_user
   revision_log_message: log
-  revision_created: revision_timestamp
+  revision_created: timestamp
   field_address:
     -
       plugin: addressfield

--- a/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_organisation.yml
+++ b/lib/modules/eic_migrate/config/install/migrate_plus.migration.upgrade_d7_node_complete_organisation.yml
@@ -62,7 +62,7 @@ process:
       migration:
         - upgrade_d7_user
   revision_log_message: log
-  revision_created: revision_timestamp
+  revision_created: timestamp
   # features:
   #   - plugin: eic_group_features
   #     group_bundle: organisation

--- a/lib/modules/eic_migrate/src/EventSubscriber/PostMigrationSubscriber.php
+++ b/lib/modules/eic_migrate/src/EventSubscriber/PostMigrationSubscriber.php
@@ -184,6 +184,21 @@ class PostMigrationSubscriber implements EventSubscriberInterface {
         }
         break;
 
+      case 'upgrade_d7_node_complete_event_site':
+      case 'upgrade_d7_node_complete_organisation':
+        // Check if we have a group ID.
+        if (!$gid = $event->getDestinationIdValues()[0]) {
+          return;
+        }
+
+        // Load the migrated group.
+        if ($group = $this->entityTypeManager->getStorage('group')->load($gid)) {
+          // We enable syncing to avoid creating new revisions.
+          $group->setSyncing(TRUE);
+          $this->setGroupFeatures($group, $event);
+        }
+        break;
+
       case 'upgrade_d7_node_complete_article':
       case 'upgrade_d7_node_complete_news':
         // Check if we have a node revision ID.


### PR DESCRIPTION
### Features

- Fix revision timestamp for organisation migration.

### Test

- [x] Run `drush mim upgrade_d7_node_complete_organisation --idlist=8266:9171:und --update --limit=1`
- [x] Go to `/organisations/onomotion-gmbh` and make sure there are group features enabled
- [x] Go to `/organisations/onomotion-gmbh/revisions` and make sure there are no errors
- [x] Run `drush mim upgrade_d7_node_complete_event_site --idlist=17699:24830:und --update --limit=1`
- [x] Go to `/events/eic-webinars-pathfinder-and-transition` and make sure there are group features enabled
- [x] Go to `/events/eic-webinars-pathfinder-and-transition/revisions` and make sure there are no errors