### PR TITLE
EICNET-2698: Wiki tab is missing on production env

### DIFF
--- a/lib/modules/eic_groups/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_groups/src/Hooks/EntityOperations.php
@@ -408,7 +408,10 @@ class EntityOperations implements ContainerInjectionInterface {
   private function publishGroupWiki(GroupInterface $group) {
     $installedContentPlugins = $group->getGroupType()
       ->getInstalledContentPlugins();
-    if (!$installedContentPlugins || in_array('group_node:book', $installedContentPlugins->getInstanceIds())) {
+    if (
+      !$installedContentPlugins ||
+      !in_array('group_node:book', $installedContentPlugins->getInstanceIds())
+    ) {
       return;
     }
     $book_content_plugin_id = $group->getGroupType()->getContentPlugin('group_node:book')->getContentTypeConfigId();
@@ -420,7 +423,11 @@ class EntityOperations implements ContainerInjectionInterface {
 
     if (!empty($results)) {
       $group_content = GroupContent::load(reset($results));
-      if (($node_book = $group_content->getEntity()) && $node_book instanceof NodeInterface) {
+      if (
+        ($node_book = $group_content->getEntity()) &&
+        $node_book instanceof NodeInterface &&
+        $node_book->get('moderation_state')->value !== DefaultContentModerationStates::PUBLISHED_STATE
+      ) {
         $node_book->set('moderation_state', DefaultContentModerationStates::PUBLISHED_STATE);
         $node_book->save();
       }


### PR DESCRIPTION
### Fixes

- Fix issue where group wiki section was not published after migrating groups.

### Test

- [ ] Update group/event migrations -> `drush mim upgrade_d7_node_complete_group --update` and `drush mim upgrade_d7_node_complete_event_site --update`
- [ ] Make sure the wiki section of migrated groups and events is published

### Regression tests:

- [ ] As SA/SCM, create a new public group as draft
- [ ] Edit the group and make sure the wiki feature is enable and publish the group
- [ ] Make sure as anonymous you can see the wiki tab