### PR TITLE
EICNET-2708: [Event] Link to event registration does not work.

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/events.inc
+++ b/lib/themes/eic_community/includes/preprocess/events.inc
@@ -111,7 +111,11 @@ function _eic_community_render_event_detail_page(array &$variables, EntityInterf
   $action = [];
 
   // We only show signup in global event (group type: event).
-  if ('group' === $entity_type && $signup_link = $entity->get('field_link')->getString()) {
+  if (
+    'group' === $entity_type &&
+    !$entity->get('field_link')->isEmpty() &&
+    $signup_link = $entity->get('field_link')->uri
+  ) {
     $action = [
       'title' => t('Sign up to this event', [], ['context' => 'eic_community']),
       'text' => t('Get notified of the latest changes and take part in the discussion linked to this event.', [],


### PR DESCRIPTION
### Fixes

- Fix issue where group event sign up link was showing a duplicated URL.

### Test with migrated DB

- [x] Go to `/events/eic-ghg-co-creation-peer-peer-2nd-cohort` and make sure the Sign up link doesn't show a concatenated url like the following (`https://eic.eismea.eu/mydashboard/form/266, https://eic.eismea.eu/mydashboard/form/266`)