### PR TITLE
EICNET-2717: Stories - Posting date is wrong by default

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -6697,6 +6697,9 @@
                         "status": "not-covered",
                         "message": "Beta releases are not covered by Drupal security advisories."
                     }
+                },
+                "patches_applied": {
+                    "#3066317 - Provide computed properties that return the publication date or the created/updated date": "https://www.drupal.org/files/issues/2019-07-07/3066317-3.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -10428,16 +10431,6 @@
             "homepage": "http://github.com/myclabs/php-enum",
             "keywords": [
                 "enum"
-            ],
-            "funding": [
-                {
-                    "url": "https://github.com/mnapoli",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/myclabs/php-enum",
-                    "type": "tidelift"
-                }
             ],
             "time": "2021-07-05T08:18:36+00:00"
         },

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -81,6 +81,9 @@
     "drupal/migrate_plus": {
       "3007709 - Add XPath-style filtering ability in JSON data parser plugin" : "https://www.drupal.org/files/issues/2020-11-16/migrate_plus-json-xpath-filtering-3007709-24.patch"
     },
+    "drupal/publication_date": {
+      "#3066317 - Provide computed properties that return the publication date or the created/updated date": "https://www.drupal.org/files/issues/2019-07-07/3066317-3.patch"
+    },
     "drupal/realname": {
       "#3059311 - Autocomplete suggestions should respect the entity reference View": "patches/realname/autocomplete-condition-fix-3059311-5.patch"
     },

--- a/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorGlobal.php
+++ b/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorGlobal.php
@@ -6,6 +6,7 @@ use Drupal\Component\Utility\Unicode;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\Core\File\FileUrlGeneratorInterface;
+use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
 use Drupal\eic_content\Constants\DefaultContentModerationStates;
 use Drupal\eic_groups\EICGroupsHelper;
 use Drupal\eic_user\UserHelper;
@@ -124,6 +125,12 @@ class ProcessorGlobal extends DocumentProcessor {
           }
 
           $last_moderation_state = $this->getLastRevisionModerationState($node);
+
+          // For News and Stories, the published date should be saved.
+          if (in_array($node->bundle(), ['news', 'story'])) {
+            $date = \Drupal::service('date.formatter')
+              ->format($node->get('published_at')->published_at_or_created, 'custom', DateTimeItemInterface::DATETIME_STORAGE_FORMAT);
+          }
         }
         break;
       case 'entity:group':

--- a/lib/themes/eic_community/includes/preprocess/content/node--news--story.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--news--story.inc
@@ -50,7 +50,9 @@ function _eic_community_preprocess_node_news_story(array &$variables) {
       ],
     ],
     'timestamp' => [
-      'label' => eic_community_get_teaser_time_display($node->get('published_at')->value),
+      'label' => $node->get('published_at')->isEmpty() ?
+        eic_community_get_teaser_time_display($node->get('created')->value) :
+        eic_community_get_teaser_time_display($node->get('published_at')->value),
     ],
     'author' => eic_community_get_teaser_user_display($node->getOwner()),
   ];

--- a/lib/themes/eic_community/includes/preprocess/content/node--news--story.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--news--story.inc
@@ -52,7 +52,7 @@ function _eic_community_preprocess_node_news_story(array &$variables) {
     'timestamp' => [
       'label' => $node->get('published_at')->isEmpty() ?
         eic_community_get_teaser_time_display($node->get('created')->value) :
-        eic_community_get_teaser_time_display($node->get('published_at')->value),
+        eic_community_get_teaser_time_display($node->get('published_at')->published_at_or_created),
     ],
     'author' => eic_community_get_teaser_user_display($node->getOwner()),
   ];

--- a/lib/themes/eic_community/includes/preprocess/layout/page.inc
+++ b/lib/themes/eic_community/includes/preprocess/layout/page.inc
@@ -166,7 +166,7 @@ function _preprocess_node_page(&$variables) {
                 \Drupal::service('date.formatter')
                   ->format($node->get('created')->value, 'custom', $publish_date_format) :
                 \Drupal::service('date.formatter')
-                  ->format($node->get('published_at')->value, 'custom', $publish_date_format),
+                  ->format($node->get('published_at')->published_at_or_created, 'custom', $publish_date_format),
             ],
           ],
           'title' => $node->label(),

--- a/lib/themes/eic_community/includes/preprocess/layout/page.inc
+++ b/lib/themes/eic_community/includes/preprocess/layout/page.inc
@@ -146,7 +146,7 @@ function _preprocess_node_page(&$variables) {
         }
         /* @todo Missing follow author flag when user is logged in. */
 
-        $publish_date_format = $variables['node']->getType() === 'news' ? 'd F' : 'd F Y';
+        $publish_date_format = 'd F Y';
         $is_restricted = $node->private->value === '1';
         $tag = [
           'type' => 'display',
@@ -162,8 +162,11 @@ function _preprocess_node_page(&$variables) {
           'meta' => [
             ['label' => $node->type->entity->label()],
             [
-              'label' => \Drupal::service('date.formatter')
-                ->format($node->get('published_at')->value, 'custom', $publish_date_format),
+              'label' => $node->get('published_at')->isEmpty() ?
+                \Drupal::service('date.formatter')
+                  ->format($node->get('created')->value, 'custom', $publish_date_format) :
+                \Drupal::service('date.formatter')
+                  ->format($node->get('published_at')->value, 'custom', $publish_date_format),
             ],
           ],
           'title' => $node->label(),


### PR DESCRIPTION
### Fixes

- Apply patch to fix issue with default publication date when node is not published;
- Show the same date format for News and Story CTypes.

### Test

- [x] Create a new story or news in draft and set the authored date to 3 days ago
- [x] Edit the node and publish it
- [x] Make sure the publication date is set to today when viewing the node detail page
- [x] Make sure the publication date is shown correctly in overview pages