### PR TITLE
EICNET-2776: SA and SCM do not have access to the UIT

### DIFF
--- a/config/sync/user.role.content_administrator.yml
+++ b/config/sync/user.role.content_administrator.yml
@@ -56,6 +56,7 @@ dependencies:
     - filter
     - flag
     - group
+    - locale
     - masquerade
     - media
     - message
@@ -221,6 +222,7 @@ permissions:
   - 'revert wiki_page revisions'
   - 'schedule publishing of nodes'
   - 'skip comment approval'
+  - 'translate interface'
   - 'unflag recommend_group'
   - 'update any basic block content'
   - 'update any cta_tiles block content'

--- a/config/sync/user.role.site_admin.yml
+++ b/config/sync/user.role.site_admin.yml
@@ -58,6 +58,7 @@ dependencies:
     - filter
     - flag
     - group
+    - locale
     - masquerade
     - media
     - message
@@ -225,6 +226,7 @@ permissions:
   - 'revert video revisions'
   - 'revert wiki_page revisions'
   - 'schedule publishing of nodes'
+  - 'translate interface'
   - 'unflag recommend_group'
   - 'update any basic block content'
   - 'update any cta_tiles block content'


### PR DESCRIPTION
### Fixes

- Allow SA/SCM users to access user interface translation.

### Test

- [x] As SA/SCM, make sure you can access user interface translation -> `/admin/config/regional/translate`