### PR TITLE
EICNET-2734: [User profile] A trusted user should be able to edit his role.

### DIFF
--- a/lib/modules/eic_user/eic_user.module
+++ b/lib/modules/eic_user/eic_user.module
@@ -72,14 +72,20 @@ function eic_user_field_widget_social_links_form_alter(&$element, FormStateInter
 }
 
 /**
- * @param $form
- * @param \Drupal\Core\Form\FormStateInterface $form_state
- * @param $form_id
+ * Implements hook_form_alter().
  */
 function eic_user_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
-  if ('bulk_group_invitation' === $form_id) {
-    \Drupal::classResolver(\Drupal\eic_user\Hooks\FormAlter::class)
-      ->alterBulkGroupInvitation($form, $form_state, $form_id);
+  switch ($form_id) {
+    case 'bulk_group_invitation':
+      \Drupal::classResolver(\Drupal\eic_user\Hooks\FormAlter::class)
+        ->alterBulkGroupInvitation($form, $form_state, $form_id);
+      break;
+
+    case 'profile_member_edit_form':
+    case 'profile_member_add_form':
+      \Drupal::classResolver(\Drupal\eic_user\Hooks\FormAlter::class)
+        ->alterProfileMemberForm($form, $form_state, $form_id);
+      break;
   }
 }
 

--- a/lib/modules/eic_user/src/Hooks/FormAlter.php
+++ b/lib/modules/eic_user/src/Hooks/FormAlter.php
@@ -218,14 +218,11 @@ class FormAlter implements ContainerInjectionInterface {
     /** @var \Drupal\profile\Entity\Profile $profile */
     $profile = $form_state->getFormObject()->getEntity();
     $user = $profile->getOwner();
-    $is_admin = UserHelper::isPowerUser($this->currentUser);
+    $current_user_is_admin = UserHelper::isPowerUser($this->currentUser);
+    $is_smed_user = UserHelper::isSmedUser($user);
 
     // If the user has a SMED ID, we make the job title field as readonly.
-    if (
-      !$is_admin &&
-      $user->hasField('field_smed_id') &&
-      !$user->get('field_smed_id')->isEmpty()
-    ) {
+    if (!$current_user_is_admin && $is_smed_user) {
       $form['field_vocab_job_title']['#disabled'] = TRUE;
     }
   }

--- a/lib/modules/eic_user/src/Hooks/FormAlter.php
+++ b/lib/modules/eic_user/src/Hooks/FormAlter.php
@@ -215,12 +215,10 @@ class FormAlter implements ContainerInjectionInterface {
    *   The form ID.
    */
   public function alterProfileMemberForm(array &$form, FormStateInterface $form_state, string $form_id) {
-    $user = \Drupal::routeMatch()->getParameter('user');
+    /** @var \Drupal\profile\Entity\Profile $profile */
+    $profile = $form_state->getFormObject()->getEntity();
+    $user = $profile->getOwner();
     $is_admin = UserHelper::isPowerUser($this->currentUser);
-
-    if (!$user instanceof UserInterface) {
-      return;
-    }
 
     // If the user has a SMED ID, we make the job title field as readonly.
     if (

--- a/lib/modules/eic_user/src/Hooks/FormAlter.php
+++ b/lib/modules/eic_user/src/Hooks/FormAlter.php
@@ -5,11 +5,13 @@ namespace Drupal\eic_user\Hooks;
 use Drupal\Component\Render\FormattableMarkup;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Url;
 use Drupal\eic_content\Plugin\Field\FieldWidget\EntityTreeWidget;
 use Drupal\eic_content\Services\EntityTreeManager;
 use Drupal\eic_search\Search\Sources\UserInvitesListSourceType;
+use Drupal\eic_user\UserHelper;
 use Drupal\group\Entity\GroupInterface;
 use Drupal\user\Entity\User;
 use Drupal\user\UserInterface;
@@ -32,13 +34,26 @@ class FormAlter implements ContainerInjectionInterface {
   private $treeManager;
 
   /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountProxyInterface
+   */
+  private $currentUser;
+
+  /**
    * Constructs a new EntityOperations object.
    *
    * @param \Drupal\eic_content\Services\EntityTreeManager $entity_tree_manager
    *   The EIC Content entity tree manager service.
+   * @param \Drupal\Core\Session\AccountProxyInterface $current_user
+   *   The current user.
    */
-  public function __construct(EntityTreeManager $entity_tree_manager) {
+  public function __construct(
+    EntityTreeManager $entity_tree_manager,
+    AccountProxyInterface $current_user
+  ) {
     $this->treeManager = $entity_tree_manager;
+    $this->currentUser = $current_user;
   }
 
   /**
@@ -46,7 +61,8 @@ class FormAlter implements ContainerInjectionInterface {
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('eic_content.entity_tree_manager')
+      $container->get('eic_content.entity_tree_manager'),
+      $container->get('current_user')
     );
   }
 
@@ -186,6 +202,34 @@ class FormAlter implements ContainerInjectionInterface {
 
     $tempstore_params['emails'] = $emails;
     $tempstore->set('params', $tempstore_params);
+  }
+
+  /**
+   * Form alter implementation for profile_member form.
+   *
+   * @param array $form
+   *   An associative array containing the structure of the form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   * @param string $form_id
+   *   The form ID.
+   */
+  public function alterProfileMemberForm(array &$form, FormStateInterface $form_state, string $form_id) {
+    $user = \Drupal::routeMatch()->getParameter('user');
+    $is_admin = UserHelper::isPowerUser($this->currentUser);
+
+    if (!$user instanceof UserInterface) {
+      return;
+    }
+
+    // If the user has a SMED ID, we make the job title field as readonly.
+    if (
+      !$is_admin &&
+      $user->hasField('field_smed_id') &&
+      !$user->get('field_smed_id')->isEmpty()
+    ) {
+      $form['field_vocab_job_title']['#disabled'] = TRUE;
+    }
   }
 
   /**

--- a/lib/modules/eic_user/src/UserHelper.php
+++ b/lib/modules/eic_user/src/UserHelper.php
@@ -332,4 +332,17 @@ class UserHelper {
     return (int) $user_flag_counters[FlagType::FOLLOW_USER];
   }
 
+  /**
+   * Checks if a user is a SMED user.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The user account to check if is SMED user.
+   *
+   * @return bool
+   *   TRUE if user is a SMED user.
+   */
+  public static function isSmedUser(AccountInterface $account) {
+    return $account->hasField('field_smed_id') && !$account->get('field_smed_id')->isEmpty();
+  }
+
 }


### PR DESCRIPTION
### Fixes

- Disable job title field for SMED users.

### Test

- [x] As TU (with SMED ID), try to edit your profile information
- [x] Make sure the Job title field is readonly
- [x] As SA/SCM, edit the profile information of the previous TU
- [x] Make sure you can edit the Job title field
- [x] As TU (without SMED ID), try to edit your profile information
- [x] Make sure you can edit the Job title field. This should only happen for users without SMED ID.