### PR TITLE
EICNET-2720: Switch 'Recently updated' from timestamp to changed time.

### DIFF
--- a/lib/modules/eic_search/src/Search/Sources/GlobalEventSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/GlobalEventSourceType.php
@@ -63,8 +63,8 @@ class GlobalEventSourceType extends SourceType {
         'label' => $this->t('Date created', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Date created', [], ['context' => 'eic_search']),
       ],
-      'timestamp' => [
-        'label' => $this->t('Timestamp', [], ['context' => 'eic_search']),
+      'ss_drupal_changed_timestamp' => [
+        'label' => $this->t('Recently updated', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Recently updated', [], ['context' => 'eic_search']),
       ],
       'ss_group_label_string' => [

--- a/lib/modules/eic_search/src/Search/Sources/GroupSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/GroupSourceType.php
@@ -60,8 +60,8 @@ class GroupSourceType extends SourceType {
         'label' => $this->t('Date created', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Date created', [], ['context' => 'eic_search']),
       ],
-      'timestamp' => [
-        'label' => $this->t('Timestamp', [], ['context' => 'eic_search']),
+      'ss_drupal_changed_timestamp' => [
+        'label' => $this->t('Recently updated', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Recently updated', [], ['context' => 'eic_search']),
       ],
       'tm_global_title' => [


### PR DESCRIPTION
### Tests

- [x] Go to `/admin/community/overview-pages/3/edit` and `/admin/community/overview-pages/5/edit` and enable "Recently updated"
- [x] Go to `/groups` and sort by Recently updated
- [x] Now go to an old group and update it
- [x] Go back to `/groups` and sort by Recently updated
- [x] Check that the updated group shows first
- [x] Repeat the same for `/events`

### Notes

- Since the overview configuration is content, it has to be manually updated in PROD