### PR TITLE
EICNET-2763: Display user display name in authoring information.

### DIFF
--- a/composer.patches.json
+++ b/composer.patches.json
@@ -10,7 +10,8 @@
       "2582295 - Confirmation cancel links are incorrect if installed in a subdirectory": "https://www.drupal.org/files/issues/2021-08-23/2582295-52.patch",
       "2329253 - Allow the ChangedItem to skip updating the entity's \"changed\" timestamp when synchronizing (f.e. when migrating)": "https://www.drupal.org/files/issues/2022-05-30/2329253-90.patch",
       "3052115 - Mark an entity as 'syncing' during a migration update": "https://www.drupal.org/files/issues/2022-05-12/3052115-47.patch",
-      "2907760 - Notice: Undefined index: default in Drupal\\views\\Plugin\\views\\PluginBase->setOptionDefaults()": "https://www.drupal.org/files/issues/2022-05-26/2907760-11-9.3.x.patch"
+      "2907760 - Notice: Undefined index: default in Drupal\\views\\Plugin\\views\\PluginBase->setOptionDefaults()": "https://www.drupal.org/files/issues/2022-05-26/2907760-11-9.3.x.patch",
+      "3183509 - Use the user display name instead of the username on the user authoring information in the node edit form": "https://git.drupalcode.org/project/drupal/-/merge_requests/352.patch"
     },
     "drupal/address": {
       "2812659 - Integrate Address with Search API (adds a Search API processor to convert country code to full country name)": "https://www.drupal.org/files/issues/2021-06-14/integrate-address-searchapi-2812659-57_0.patch"


### PR DESCRIPTION
### Tests

- [x] Run `composer install`
- [x] As TU, make sure you have a first/last name
- [x] As TU, edit one of your contents
- [x] Make sure you see the user's display name and not the username

![2022-08-11 16_22_05-Edit Story erverv _ EIC-community-D8](https://user-images.githubusercontent.com/5821299/184155782-3cd6a08a-3f06-4a9c-83fd-272c378b2b97.png)

