### PR TITLE
EICNET-2778: [Event] News and stories created within an event should only be visible to the member of that event

### DIFF
--- a/lib/modules/eic_search/src/Search/Sources/NewsStorySourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/NewsStorySourceType.php
@@ -145,7 +145,11 @@ class NewsStorySourceType extends SourceType {
     // @todo In the future we should provide a configuration in the overview
     // block so that we can enable/disable this extra filter.
     return [
-      'its_global_group_parent_id' => '("-1")',
+      'AND' => [
+        'its_global_group_parent_id' => [
+          '("-1")'
+        ],
+      ],
     ];
   }
 

--- a/lib/modules/eic_search/src/Search/Sources/NewsStorySourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/NewsStorySourceType.php
@@ -141,6 +141,17 @@ class NewsStorySourceType extends SourceType {
   /**
    * @inheritDoc
    */
+  public function extraPrefilter(): array {
+    // @todo In the future we should provide a configuration in the overview
+    // block so that we can enable/disable this extra filter.
+    return [
+      'its_global_group_parent_id' => '("-1")',
+    ];
+  }
+
+  /**
+   * @inheritDoc
+   */
   public function getDefaultSort(): array {
     return ['ss_drupal_timestamp', 'DESC'];
   }


### PR DESCRIPTION
### Fixes

- Add extra pre filter in NewsStorySourceType used in global overview of News and Stories in order to discard News and Stories that belong to groups.

### Test

- [x] As SA/SCM, create a News inside a global event
- [x] Go to the global overview page of News and Stories -> `/articles`
- [x] Make sure only global news are shown in the results. News that belong to groups should not be shown.