### PR TITLE
Feature/eicnet 2720 groups sorting options

### DIFF
--- a/lib/modules/eic_flags/src/EventSubscriber/FlagEventSubscriber.php
+++ b/lib/modules/eic_flags/src/EventSubscriber/FlagEventSubscriber.php
@@ -73,7 +73,7 @@ class FlagEventSubscriber implements EventSubscriberInterface {
     $group = $this->groupHelper->getGroupFromContent($entity);
     $extra_resync = [];
 
-    if ($group instanceof GroupInterface && $flagging->getFlagId() === FlagType::RECOMMEND_GROUP) {
+    if ($group instanceof GroupInterface && $flagging->getFlagId() === FlagType::LIKE_GROUP) {
       /** @var \Drupal\eic_search\Service\SolrDocumentProcessor $solr_helper */
       // Reindex group parent to have correct most active score.
       $extra_resync[] = $group;
@@ -97,7 +97,7 @@ class FlagEventSubscriber implements EventSubscriberInterface {
     $group = $this->groupHelper->getGroupFromContent($flagging->getFlaggable());
     $extra_resync = [];
 
-    if ($group instanceof GroupInterface && $flagging->getFlagId() === FlagType::RECOMMEND_GROUP) {
+    if ($group instanceof GroupInterface && $flagging->getFlagId() === FlagType::LIKE_GROUP) {
       /** @var \Drupal\eic_search\Service\SolrDocumentProcessor $solr_helper */
       // Reindex group parent to have correct most active score.
       $extra_resync[] = $group;

--- a/lib/modules/eic_flags/src/FlagType.php
+++ b/lib/modules/eic_flags/src/FlagType.php
@@ -25,10 +25,10 @@ final class FlagType {
 
   const LIKE_CONTENT = 'like_content';
 
+  const LIKE_GROUP = 'recommend_group';
+
   const RECOMMEND_NODE = 'recommend_content';
 
   const RECOMMEND_CONTENT_GROUP = 'recommend_content_group';
-
-  const RECOMMEND_GROUP = 'recommend_group';
 
 }

--- a/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorFlags.php
+++ b/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorFlags.php
@@ -116,6 +116,9 @@ class ProcessorFlags extends DocumentProcessor {
       case 'entity:group':
         $entity_id = $fields['its_group_id_integer'];
         $entity_type = 'group';
+        $last_flagging_flag_types = [
+          FlagType::LIKE_GROUP,
+        ];
 
         $group = Group::load($entity_id);
 

--- a/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorGroup.php
+++ b/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorGroup.php
@@ -118,8 +118,8 @@ class ProcessorGroup extends DocumentProcessor {
 
     // Count likes and follows.
     $flag_counts = $this->flagCountManager->getEntityFlagCounts($group);
-    $total_likes = array_key_exists(FlagType::RECOMMEND_GROUP, $flag_counts) ?
-      (int) $flag_counts[FlagType::RECOMMEND_GROUP] :
+    $total_likes = array_key_exists(FlagType::LIKE_GROUP, $flag_counts) ?
+      (int) $flag_counts[FlagType::LIKE_GROUP] :
       0;
     $total_follows = array_key_exists(FlagType::FOLLOW_GROUP, $flag_counts) ?
       (int) $flag_counts[FlagType::FOLLOW_GROUP] :

--- a/lib/modules/eic_search/src/Search/Sources/GlobalEventSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/GlobalEventSourceType.php
@@ -77,7 +77,7 @@ class GlobalEventSourceType extends SourceType {
         'ASC' => $this->t('First events in time', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Last events in time', [], ['context' => 'eic_search']),
       ],
-      'its_' . SolrDocumentProcessor::LAST_FLAGGED_KEY . '_' . FlagType::LIKE_CONTENT => [
+      'its_' . SolrDocumentProcessor::LAST_FLAGGED_KEY . '_' . FlagType::LIKE_GROUP => [
         'label' => $this->t('Last liked', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Last liked', [], ['context' => 'eic_search']),
       ],

--- a/lib/modules/eic_search/src/Search/Sources/GroupSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/GroupSourceType.php
@@ -74,7 +74,7 @@ class GroupSourceType extends SourceType {
         'ASC' => $this->t('Fullname A-Z', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Fullname Z-A', [], ['context' => 'eic_search']),
       ],
-      'its_' . SolrDocumentProcessor::LAST_FLAGGED_KEY . '_' . FlagType::LIKE_CONTENT => [
+      'its_' . SolrDocumentProcessor::LAST_FLAGGED_KEY . '_' . FlagType::LIKE_GROUP => [
         'label' => $this->t('Last liked', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Last liked', [], ['context' => 'eic_search']),
       ],

--- a/lib/modules/eic_search/src/Search/Sources/OrganisationSourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/OrganisationSourceType.php
@@ -77,7 +77,7 @@ class OrganisationSourceType extends SourceType {
         'ASC' => $this->t('Fullname A-Z', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Fullname Z-A', [], ['context' => 'eic_search']),
       ],
-      'its_' . SolrDocumentProcessor::LAST_FLAGGED_KEY . '_' . FlagType::LIKE_CONTENT => [
+      'its_' . SolrDocumentProcessor::LAST_FLAGGED_KEY . '_' . FlagType::LIKE_GROUP => [
         'label' => $this->t('Last liked', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Last liked', [], ['context' => 'eic_search']),
       ],


### PR DESCRIPTION
### Tests

- [x] Make sure to re-save the Groups overview and enable the Last liked sorting otion
- [x] Like a random group
- [x] Run `drush cron`
- [x] Sort by Last liked in the groups overview and make sure it appears first