### PR TITLE
Feature/eicnet 2750 events visibility

### DIFF
--- a/lib/modules/eic_groups/eic_groups.api.php
+++ b/lib/modules/eic_groups/eic_groups.api.php
@@ -24,5 +24,24 @@ function hook_eic_groups_group_predelete(array $entities) {
 }
 
 /**
+ * Allows to dynamically alter the public availability of a group feature.
+ *
+ * @param bool $is_publicly_available
+ *   Wether the feature should be public.
+ * @param array $context
+ *   Array containing:
+ *   - group: the group entity.
+ *   - group_feature: the plugin ID.
+ */
+function hook_eic_groups_group_feature_public_alter(bool &$is_publicly_available, array $context) {
+  /** @var \Drupal\group\Entity\GroupInterface $group */
+  $group = $context['group'];
+  $feature_id = $context['group_feature'];
+  if ($group->getGroupType()->id() == 'group' && $feature_id == 'private_feature') {
+    $is_publicly_available = FALSE;
+  }
+}
+
+/**
  * @} End of "addtogroup hooks".
  */

--- a/lib/modules/eic_groups/eic_groups.install
+++ b/lib/modules/eic_groups/eic_groups.install
@@ -13,6 +13,7 @@ use Drupal\eic_groups\Constants\GroupJoiningMethodType;
 use Drupal\eic_groups\Constants\NodeProperty;
 use Drupal\eic_groups\EICGroupsHelper;
 use Drupal\eic_groups\GroupsModerationHelper;
+use Drupal\group\Entity\Group;
 use Drupal\group_content_menu\GroupContentMenuInterface;
 use Drupal\group_flex\Plugin\GroupVisibilityInterface;
 use Drupal\group_permissions\Entity\GroupPermission;
@@ -461,6 +462,40 @@ function eic_groups_update_9008(&$sandbox) {
 }
 
 /**
+ * Rebuilds group feature permissions for event groups.
+ */
+function eic_groups_update_9009(&$sandbox) {
+  $batch_builder = (new BatchBuilder())
+    ->setTitle(t('Rebuild group feature permissions for Event groups.'))
+    ->setFinishCallback('_eic_groups_batch_finished')
+    ->setInitMessage(t('Batch is starting'))
+    ->setProgressMessage(t('Processed @current out of @total.'))
+    ->setErrorMessage(t('Batch has encountered an error'));
+
+  $groups = \Drupal::entityQuery('group')
+    ->condition('type', 'event')
+    ->execute();
+
+  $max_groups = count($groups);
+  $progress = 0;
+  $groups_per_batch = 50;
+
+  for ($progress = 0; $progress < $max_groups; $progress += $groups_per_batch) {
+    $batch_builder->addOperation(
+      '_eic_groups_batch_rebuild_group_feature_permissions',
+      [
+        'event',
+        $progress,
+        $progress + $groups_per_batch,
+        $max_groups,
+      ]
+    );
+  }
+
+  batch_set($batch_builder->toArray());
+}
+
+/**
  * Operation batch for publishing group wiki section.
  */
 function _eic_groups_batch_publish_group_wiki(int $progress, int $max, int $total, &$context) {
@@ -591,6 +626,28 @@ function _eic_groups_batch_remove_group_permission(string $permission_to_remove,
     $group_permission->save();
 
     Cache::invalidateTags($group->getCacheTags());
+  }
+}
+
+/**
+ * Operation batch to rebuild group feature permissions.
+ */
+function _eic_groups_batch_rebuild_group_feature_permissions(string $group_type, int $progress, int $max, int $total, &$context) {
+  $context['message'] = t('Rebuild group feature permissions - @progress of @total', [
+    '@progress' => $progress,
+    '@total' => $total,
+  ]);
+
+  $results = \Drupal::entityQuery('group')
+    ->condition('type', $group_type)
+    ->range($progress, $max)
+    ->accessCheck(FALSE)
+    ->execute();
+
+  $groups = Group::loadMultiple($results);
+
+  foreach ($groups as $group) {
+    \Drupal::service('oec_group_features.helper')->rebuildPermissions($group);
   }
 }
 

--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -99,6 +99,22 @@ function eic_groups_theme($existing, $type, $theme, $path) {
 }
 
 /**
+ * Implements hook_eic_groups_group_feature_public_alter().
+ */
+function eic_groups_eic_groups_group_feature_public_alter(bool &$is_publicly_available, array $context) {
+  /** @var \Drupal\group\Entity\GroupInterface $group */
+  $group = $context['group'];
+
+  switch ($group->getGroupType()->id()) {
+    case 'event':
+      // None of the group feature for events should be publicly available for
+      // events.
+      $is_publicly_available = FALSE;
+      break;
+  }
+}
+
+/**
  * Implements hook_views_data().
  */
 function eic_groups_views_data() {

--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -115,6 +115,31 @@ function eic_groups_eic_groups_group_feature_public_alter(bool &$is_publicly_ava
 }
 
 /**
+ * Implements hook_oec_group_flex_plugin_permission_alter().
+ */
+function eic_groups_oec_group_flex_plugin_permission_alter(bool &$is_allowed, array $context) {
+  /** @var \Drupal\group\Entity\GroupInterface $group */
+  $group = $context['group'];
+  /** @var \Drupal\group\Entity\GroupRoleInterface $role */
+  $role = $context['role'];
+  $plugin = $context['plugin'];
+
+  switch ($group->getGroupType()->id()) {
+    case 'event':
+      switch ($plugin->getPluginDefinition()['id']) {
+        case 'group_node':
+          // We deny access to view content for anonymous/outsider roles.
+          if ($role->isOutsider() || $role->isAnonymous()) {
+            $is_allowed = FALSE;
+          }
+          break;
+
+      }
+      break;
+  }
+}
+
+/**
  * Implements hook_views_data().
  */
 function eic_groups_views_data() {

--- a/lib/modules/oec_group_flex/oec_group_flex.api.php
+++ b/lib/modules/oec_group_flex/oec_group_flex.api.php
@@ -38,5 +38,42 @@ function hook_group_flex_visibility_save(
 }
 
 /**
+ * Allows to deny a permission for a certain role in a certain context.
+ *
+ * This alter call is being used in Drupal\oec_group_flex\Plugin\GroupVisibility\PublicVisibility
+ * only for now.
+ *
+ * @param bool $is_allowed
+ *   Wether to allow the permission.
+ * @param array $context
+ *   Array containing:
+ *   - plugin: the plugin instance.
+ *   - group: the group entity.
+ *   - role: role being treated.
+ *   - permission: the permission being applied.
+ */
+function hook_oec_group_flex_plugin_permission_alter(bool &$is_allowed, array $context) {
+  /** @var \Drupal\group\Entity\GroupInterface $group */
+  $group = $context['group'];
+  /** @var \Drupal\group\Entity\GroupRoleInterface $role */
+  $role = $context['role'];
+  $plugin = $context['plugin'];
+
+  switch ($group->getGroupType()->id()) {
+    case 'event':
+      switch ($plugin->getPluginDefinition()['id']) {
+        case 'group_node':
+          // We deny access to view content for anonymous/outsider roles.
+          if ($role->isOutsider() || $role->isAnonymous()) {
+            $is_allowed = FALSE;
+          }
+          break;
+
+      }
+      break;
+  }
+}
+
+/**
  * @} End of "addtogroup hooks".
  */

--- a/lib/modules/oec_group_flex/src/Plugin/GroupVisibility/PublicVisibility.php
+++ b/lib/modules/oec_group_flex/src/Plugin/GroupVisibility/PublicVisibility.php
@@ -3,6 +3,7 @@
 namespace Drupal\oec_group_flex\Plugin\GroupVisibility;
 
 use Drupal\group\Entity\GroupInterface;
+use Drupal\group\Entity\GroupRoleInterface;
 use Drupal\group\Entity\GroupTypeInterface;
 use Drupal\group_flex\Plugin\GroupVisibility\PublicVisibility as PublicVisibilityBase;
 
@@ -16,34 +17,67 @@ class PublicVisibility extends PublicVisibilityBase {
    */
   public function getGroupPermissions(GroupInterface $group): array {
     $groupType = $group->getGroupType();
-    $group_view_permissions = ['view group'];
-
-    $installedContentPlugins = $groupType->getInstalledContentPlugins();
-    foreach ($installedContentPlugins->getIterator() as $pluginId => $plugin) {
-      /** @var \Drupal\group\Plugin\GroupContentEnablerInterface $plugin */
-      switch ($plugin->getPluginDefinition()['id']) {
-        case 'group_node':
-        case 'group_membership':
-        case 'group_content_menu':
-          $group_view_permissions[] = "view $pluginId entity";
-          break;
-
-      }
-    }
 
     // Add perm when anonymous role has permission to view group on group type.
     $anonymousPermissions = [];
     if ($groupType->getAnonymousRole()->hasPermission('view group')) {
-      $anonymousPermissions = [$groupType->getAnonymousRoleId() => $group_view_permissions];
+      $anonymousPermissions = [
+        $groupType->getAnonymousRoleId() => $this->getGroupPermissionsPerRole($group, $groupType->getAnonymousRole()),
+      ];
     }
 
     // Add view comments permission to outsiders and group members.
     $group_view_permissions[] = 'view comments';
 
     return array_merge($anonymousPermissions, [
-      $groupType->getOutsiderRoleId() => $group_view_permissions,
-      $groupType->getMemberRoleId() => $group_view_permissions,
+      $groupType->getOutsiderRoleId() => $this->getGroupPermissionsPerRole($group, $groupType->getOutsiderRole()),
+      $groupType->getMemberRoleId() => $this->getGroupPermissionsPerRole($group, $groupType->getMemberRole()),
     ]);
+  }
+
+  /**
+   * Returns the group permissions for the given group and role.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group entity.
+   * @param \Drupal\group\Entity\GroupRoleInterface $role
+   *   The role entity.
+   *
+   * @return string[]
+   *   An array of permissions.
+   */
+  protected function getGroupPermissionsPerRole(GroupInterface $group, GroupRoleInterface $role) {
+    $groupType = $group->getGroupType();
+    $group_view_permissions[] = 'view group';
+
+    /** @var \Drupal\group\Plugin\GroupContentEnablerInterface $plugin */
+    foreach ($groupType->getInstalledContentPlugins()->getIterator() as $pluginId => $plugin) {
+
+      switch ($plugin->getPluginDefinition()['id']) {
+        case 'group_node':
+        case 'group_membership':
+        case 'group_content_menu':
+          $permission = "view $pluginId entity";
+
+          // Check if this permission should be available for the given group
+          // and role.
+          $is_allowed = TRUE;
+          $context = [
+            'plugin' => $plugin,
+            'group' => $group,
+            'role' => $role,
+            'permission' => $permission,
+          ];
+          \Drupal::moduleHandler()->alter('oec_group_flex_plugin_permission', $is_allowed, $context);
+
+          if ($is_allowed) {
+            $group_view_permissions[] = $permission;
+          }
+          break;
+
+      }
+    }
+    return $group_view_permissions;
   }
 
   /**


### PR DESCRIPTION
### Improvements

- Created a new method to rebuild group feature permissions: `Drupal\oec_group_features\GroupFeatureHelper::rebuildPermissions()`

This could be used in the future to provide a drush command to rebuild permissions.

### Tests

- [x] Run `drush updb -y`
- [x] As SA, go to an event that has content in it (or create content) and enable all the group features
- [x] As TU (non GM), go to the Event homepage
- [x] As TU, make sure you don't see other menu tabs than _Overview_ and _About_
- [x] As TU, make sure you can't access the overviews by direct link: `/events/<group-name>/discussions`, `/events/<group-name>/library`, `/events/<group-name>/news`, `/events/<group-name>/people`, `/events/<group-name>/latest-activity`
- [x] As TU, make sure you can't access the contents of the group through direct link