### PR TITLE
Feature/eicnet 2786 exclude global news

### DIFF
--- a/config/sync/user.role.trusted_user.yml
+++ b/config/sync/user.role.trusted_user.yml
@@ -48,7 +48,6 @@ permissions:
   - 'create event group'
   - 'create group group'
   - 'create image media'
-  - 'create news content'
   - 'create remote_video media'
   - 'create story content'
   - 'create video media'

--- a/lib/modules/eic_search/src/Search/Sources/NewsStorySourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/NewsStorySourceType.php
@@ -26,7 +26,7 @@ class NewsStorySourceType extends SourceType {
    * @inheritDoc
    */
   public function getLabel(): string {
-    return $this->t('News & Stories', [], ['context' => 'eic_search']);
+    return $this->t('Stories', [], ['context' => 'eic_search']);
   }
 
   /**
@@ -41,7 +41,6 @@ class NewsStorySourceType extends SourceType {
    */
   public function getAvailableFacets(): array {
     return [
-      'ss_content_type' => $this->t('Type', [], ['context' => 'eic_search']),
       'sm_content_field_vocab_topics_string' => $this->t('Topic', [], ['context' => 'eic_search']),
       'sm_content_field_vocab_geo_string' => $this->t('Regions & countries', [], ['context' => 'eic_search']),
       'bs_content_is_private' => $this->t('Visibility', [], ['context' => 'eic_search']),
@@ -135,7 +134,7 @@ class NewsStorySourceType extends SourceType {
    * @inheritDoc
    */
   public function getPrefilteredContentType(): array {
-    return ['story', 'news'];
+    return ['story'];
   }
 
   /**


### PR DESCRIPTION
### Tests

- [x] As TU, go to the homepage and make sure you can create a News article from "Add content" dropdown
- [x] Go to `/articles`
- [x] Make sure you can't add News from the page banner, only Story
- [x] Make sure you don't see the Content type facet
- [x] Make sure you don't see News items in the overview
- [x] Make sure you get access denied on `/node/add/news`