### PR TITLE
EICNET-2793: Fix activity stream item URLs.

### DIFF
--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/ActivityStreamResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/ActivityStreamResultItem.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ResultItemWrapper from '../../../ActivityStream/partials/ResultItemWrapper';
 import svg from '../../../../../svg/svg';
+import {url} from "../../../../../Services/UrlHelper"
 import axios from "axios";
 
 class ActivityStreamResultItem extends React.Component {
@@ -96,6 +97,8 @@ class ActivityStreamResultItem extends React.Component {
 
     const message = `${this.props.result.tm_X3b_en_field_share_message && this.props.result.tm_X3b_en_field_share_message.length > 0 ? this.props.result.tm_X3b_en_field_share_message.shift() : ''}`;
     const entity_bundle = this.props.result.ss_type.replace(' ', '_').toLowerCase();
+    const itemUrl = url(this.props.result.ss_path);
+    const authorUrl = url(this.props.result.ss_global_user_url);
 
     return (<ResultItemWrapper
         showDeleteModal={this.props.showDeleteModal}
@@ -114,14 +117,14 @@ class ActivityStreamResultItem extends React.Component {
           <span
             className="ecl-activity-stream__item__description"
             dangerouslySetInnerHTML={{
-              __html: `<a href="${this.props.result.ss_global_user_url}">${fullname}</a> ${actionType[entity_bundle].label} <a href="${this.props.result.ss_path}">${this.props.result.ss_title}</a>`,
+              __html: `<a href="${authorUrl}">${fullname}</a> ${actionType[entity_bundle].label} <a href="${itemUrl}">${this.props.result.ss_title}</a>`,
             }}
           />
           ) : (
             <span
               className="ecl-activity-stream__item__description"
               dangerouslySetInnerHTML={{
-                __html: `${fullname} ${actionType[entity_bundle].label} <a href="${this.props.result.ss_path}">${this.props.result.ss_title}</a>`,
+                __html: `${fullname} ${actionType[entity_bundle].label} <a href="${itemUrl}">${this.props.result.ss_title}</a>`,
               }}
             />
           )


### PR DESCRIPTION
### Tests

- [ ] Browse the site with `/community` as prefix
- [ ] Go to a Topic page or a group page activity stream
- [ ] Make sure items point to the correct URL with a prefix