### PR TITLE
Feature/eicnet 2795 organisation required fields

### DIFF
--- a/config/sync/field.field.group.organisation.field_vocab_services_products.yml
+++ b/config/sync/field.field.group.organisation.field_vocab_services_products.yml
@@ -12,7 +12,7 @@ entity_type: group
 bundle: organisation
 label: 'Services and products'
 description: ''
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/config/sync/field.field.group.organisation.field_vocab_target_markets.yml
+++ b/config/sync/field.field.group.organisation.field_vocab_target_markets.yml
@@ -12,7 +12,7 @@ entity_type: group
 bundle: organisation
 label: 'Target markets'
 description: ''
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/config/sync/field.field.group.organisation.field_vocab_topics.yml
+++ b/config/sync/field.field.group.organisation.field_vocab_topics.yml
@@ -12,7 +12,7 @@ entity_type: group
 bundle: organisation
 label: Topics
 description: ''
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/lib/modules/eic_groups/modules/eic_organisations/eic_organisations.module
+++ b/lib/modules/eic_groups/modules/eic_organisations/eic_organisations.module
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @file
+ * Primary module hooks for EIC Organisations module.
+ */
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\eic_organisations\Hooks\FormOperations;
+
+/**
+ * Implements hook_form_BASE_FORM_ID_alter().
+ */
+function eic_organisations_form_group_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  \Drupal::classResolver(FormOperations::class)
+    ->formGroupFormAlter($form, $form_state, $form_id);
+}

--- a/lib/modules/eic_groups/modules/eic_organisations/src/Hooks/FormOperations.php
+++ b/lib/modules/eic_groups/modules/eic_organisations/src/Hooks/FormOperations.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\eic_organisations\Hooks;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
+/**
+ * Class FormAlter.
+ *
+ * Implementations for entity hooks.
+ */
+class FormOperations {
+
+  use StringTranslationTrait;
+
+  /**
+   * Implements hook_form_BASE_FORM_ID_alter().
+   */
+  public function formGroupFormAlter(&$form, FormStateInterface $form_state, $form_id) {
+    /** @var \Drupal\Core\Entity\EntityInterface $entity */
+    $entity = $form_state->getFormObject()->getEntity();
+
+    switch ($entity->bundle()) {
+      case 'organisation':
+        // Webservices don't always have information for this field. Normally we
+        // would create an exception for this field when organisation is being
+        // created/updated from Webservice.
+        // However it seems overly complicated to create this exception.
+        // Therefore we work the other way-round: the field is now non-required
+        // but we require it through the form.
+        $form['field_vocab_topics']['widget']['#required'] = TRUE;
+        break;
+    }
+  }
+
+}


### PR DESCRIPTION
### Tests

- [x] With Postman, remove following fields in the `Organisation - CREATE` request: `field_vocab_topics`, `field_vocab_target_markets `and `field_vocab_services_products`
- [x] Trigger the request and make sure the organisation is created correctly
- [x] With Postman, remove following fields in the `Organisation - UPDATE` request: `field_vocab_topics`, `field_vocab_target_markets `and `field_vocab_services_products`
- [x] Trigger the request and make sure the organisation is created correctly
- [x] As SA, edit the organisation and make sure the `field_vocab_topics` is required