### PR TITLE
EICNET-2829: Add taxonomy overview page access permission.

### DIFF
--- a/config/sync/user.role.content_administrator.yml
+++ b/config/sync/user.role.content_administrator.yml
@@ -85,6 +85,7 @@ permissions:
   - 'access media overview'
   - 'access news_stories entity browser pages'
   - 'access overview page overview'
+  - 'access taxonomy overview'
   - 'access toolbar'
   - 'access topics activity stream'
   - 'access user profiles'

--- a/config/sync/user.role.site_admin.yml
+++ b/config/sync/user.role.site_admin.yml
@@ -87,6 +87,7 @@ permissions:
   - 'access media overview'
   - 'access news_stories entity browser pages'
   - 'access overview page overview'
+  - 'access taxonomy overview'
   - 'access toolbar'
   - 'access topics activity stream'
   - 'access user profiles'


### PR DESCRIPTION
### Tests

- [x] Log in as SA (not DA)
- [x] Make sure you can access the Taxonomy overview page (`/admin/structure/taxonomy`)
- [x] Log in as SA-CM (not DA)
- [x] Make sure you can access the Taxonomy overview page (`/admin/structure/taxonomy`)