### PR TITLE
EICNET-2779: [Event] A none logged user should not see pending events

### DIFF
--- a/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorGlobal.php
+++ b/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorGlobal.php
@@ -12,6 +12,7 @@ use Drupal\eic_groups\EICGroupsHelper;
 use Drupal\eic_user\UserHelper;
 use Drupal\file\Entity\File;
 use Drupal\group\Entity\Group;
+use Drupal\group\Entity\GroupContent;
 use Drupal\group\Entity\GroupInterface;
 use Drupal\image\Entity\ImageStyle;
 use Drupal\node\Entity\Node;
@@ -131,6 +132,12 @@ class ProcessorGlobal extends DocumentProcessor {
             $date = \Drupal::service('date.formatter')
               ->format($node->get('published_at')->published_at_or_created, 'custom', DateTimeItemInterface::DATETIME_STORAGE_FORMAT);
           }
+        }
+
+        // The node should not be accessible if the group is not published.
+        if ($node_group_contents = GroupContent::loadByEntity($node)) {
+          $node_group_content = reset($node_group_contents);
+          $status = $node_group_content->getGroup()->isPublished();
         }
         break;
       case 'entity:group':

--- a/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorVisibility.php
+++ b/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorVisibility.php
@@ -95,14 +95,20 @@ class ProcessorVisibility extends DocumentProcessor {
     /** @var \Drupal\oec_group_flex\GroupVisibilityDatabaseStorage $group_visibility_storage */
     $group_visibility_storage = \Drupal::service('oec_group_flex.group_visibility.storage');
     $group_visibility_entity = $group_visibility_storage->load($group->id());
+    // If group type is organisation, only trusted users can access it.
+    // Therefore we assume the same visibility as GROUP_VISIBILITY_COMMUNITY"".
     $visibility_type = $group_visibility_entity ?
       $group_visibility_entity->getType() :
-      NULL;
+      (
+        $group->bundle() === 'organisation' ?
+        GroupVisibilityType::GROUP_VISIBILITY_COMMUNITY :
+        NULL
+      );
 
     switch ($visibility_type) {
       case GroupVisibilityType::GROUP_VISIBILITY_PRIVATE:
       case GroupVisibilityType::GROUP_VISIBILITY_COMMUNITY:
-        $group_visibility = $group_visibility_entity->getType();
+        $group_visibility = $group_visibility_entity ? $group_visibility_entity->getType() : GroupVisibilityType::GROUP_VISIBILITY_COMMUNITY;
         break;
 
       // In this case, when we have a custom restriction, we can have multiple restriction options like email domain, trusted users, organisation, ...


### PR DESCRIPTION
### Fixes

- Do not show group content of pending groups in global search (including content inside organisations).

### Test

- [x] As SA/SCM, create a public group and leave it as pending
- [x] Create content in the group
- [x] Make sure content is shown in the global search only for GO/GA/SA/SCM
- [x] As anonymous, make sure the content is not shown or any other user besides GO