### PR TITLE
EICNET-2797: Disable visibility sorting.

### DIFF
--- a/config/sync/views.view.admin_groups.yml
+++ b/config/sync/views.view.admin_groups.yml
@@ -858,7 +858,7 @@ display:
               empty_column: false
               responsive: ''
             group_visibility:
-              sortable: true
+              sortable: false
               default_sort_order: asc
               align: ''
               separator: ''


### PR DESCRIPTION
### Tests

- [x] As SA, go to `/admin/community/groups/groups`, `/admin/community/groups/organisations` and `/admin/community/groups/events`
- [x] Make sure you can't sort on the visibility column in the table