### PR TITLE
EICNET-2673: Homepage statistics is not updated for organizations

### DIFF
--- a/lib/modules/eic_statistics/src/StatisticsStorage.php
+++ b/lib/modules/eic_statistics/src/StatisticsStorage.php
@@ -63,8 +63,11 @@ class StatisticsStorage implements StatisticsStorageInterface {
     if ($this->entityTypeManager->hasDefinition($entity_type)) {
       $entity_storage = $this->entityTypeManager->getStorage($entity_type);
       $query = $entity_storage->getQuery();
+      // Disable access check on this query.
+      $query->accessCheck(FALSE);
       // Add status condition for node and user entities.
       switch ($entity_type) {
+        case 'group':
         case 'node':
         case 'user':
           $query->condition('status', TRUE);

--- a/lib/themes/eic_community/includes/preprocess/blocks/block--facts-figures.inc
+++ b/lib/themes/eic_community/includes/preprocess/blocks/block--facts-figures.inc
@@ -45,26 +45,6 @@ function eic_community_preprocess_block__facts_figures(&$variables, &$cache_tags
           $cache_tags[] = $eic_statistics_storage->getEntityCounterCacheTag($entity_type);
           break;
 
-        case 'group':
-          switch ($bundle) {
-            case 'event':
-              $source = GlobalEventSourceType::class;
-              break;
-            case 'organisation':
-              $source = OrganisationSourceType::class;
-              break;
-            default:
-              $source = GroupSourceType::class;
-              break;
-          }
-          $solr_query = $solr_search_manager->init($source);
-          $results = $solr_query->search();
-          $results = json_decode($results, TRUE);
-
-          $counter = !empty($results) ? $results['response']['numFound'] : 0;
-          $cache_tags[] = $eic_statistics_storage->getEntityCounterCacheTag($entity_type);
-          break;
-
         default:
           $counter = $eic_statistics_storage->getEntityCounter($entity_type, $bundle);
           $cache_tags[] = $eic_statistics_storage->getEntityCounterCacheTag($entity_type, $bundle);


### PR DESCRIPTION
### Fixes

- Disable access check when querying statistics for facts and figures;
- Revert previous fix that was using search api to retrieve the counters.

### Test

- [x] Run cron
- [x] Go to the homepage and make sure the statistics in Facts and Figures block are updated
- [x] Try to add a new group and publish it
- [x] Run cron
- [x] Make sure the new group has been incremented to Facts and Figures statistics.