### PR TITLE
EICNET-2850: [Groups] TU cannot see created group in groups list

### DIFF
--- a/lib/modules/eic_search/src/Plugin/search_api/processor/GroupAccessContent.php
+++ b/lib/modules/eic_search/src/Plugin/search_api/processor/GroupAccessContent.php
@@ -149,6 +149,11 @@ class GroupAccessContent extends ProcessorPluginBase {
     OR (ss_group_visibility:' . GroupVisibilityType::GROUP_VISIBILITY_OPTION_ORGANISATION_TYPES . ' AND itm_' . GroupVisibilityType::GROUP_VISIBILITY_OPTION_ORGANISATION_TYPES . ':(' . $user_organisation_types_formatted . '))
     ';
 
+    // Group members can view their own groups regardless of the group visibility.
+    if ($user->isAuthenticated()) {
+      $query .= ' OR its_global_group_parent_id:(' . $group_ids_formatted . ')';
+    }
+
     // Restricted community group, only trusted_user role can view.
     if (!$user->isAnonymous() && ($user->hasRole(UserHelper::ROLE_TRUSTED_USER) || UserHelper::isPowerUser($this->getCurrentUser()))) {
       $query .= ' OR (ss_group_visibility:' . GroupVisibilityType::GROUP_VISIBILITY_COMMUNITY . ')';

--- a/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorGlobal.php
+++ b/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorGlobal.php
@@ -137,7 +137,9 @@ class ProcessorGlobal extends DocumentProcessor {
         // The node should not be accessible if the group is not published.
         if ($node_group_contents = GroupContent::loadByEntity($node)) {
           $node_group_content = reset($node_group_contents);
-          $status = $node_group_content->getGroup()->isPublished();
+          $status = $node_group_content->getGroup()->isPublished() ?
+            $fields['bs_content_status'] :
+            FALSE;
         }
         break;
       case 'entity:group':

--- a/lib/modules/eic_search/src/Service/SolrSearchManager.php
+++ b/lib/modules/eic_search/src/Service/SolrSearchManager.php
@@ -638,27 +638,29 @@ class SolrSearchManager {
       "its_group_owner_id:$user_id",
     ];
 
-    if (!$is_power_user) {
-      switch ($this->source->getEntityBundle()) {
-        case 'library':
-        case 'discussion':
-        case 'node_event':
-        case 'news':
-          // Show own content even if it's in draft, archived, ...
-          $query_bundle[] = "its_content_uid:$user_id";
-          break;
-        case 'group':
-          $query_bundle[] = 'its_global_group_parent_published:1';
-          break;
-        case 'activity_stream':
-          $query_bundle[] = "its_uid:$user_id";
-          break;
-        default:
-          break;
-      }
+    switch ($this->source->getEntityBundle()) {
+      case 'library':
+      case 'discussion':
+      case 'node_event':
+      case 'news':
+        // Show own content even if it's in draft, archived, ...
+        $query_bundle[] = "its_content_uid:$user_id";
+        break;
 
-      $status_query .= ' OR (' . implode(' OR ', $query_bundle) . ')';
+      case 'group':
+        $query_bundle[] = 'its_global_group_parent_published:1';
+        break;
+
+      case 'activity_stream':
+        $query_bundle[] = "its_uid:$user_id";
+        break;
+
+      case 'global':
+        $query_bundle[] = "its_content_uid:$user_id";
+        break;
     }
+
+    $status_query .= ' OR (' . implode(' OR ', $query_bundle) . ')';
 
     $status_query .= ')';
 


### PR DESCRIPTION
### Fixes

- Allow group members to view their own groups;
- Fix issue where draft content was shown for non authors in group overviews and global overview.

### Test

- [x] As TU, create a new custom restricted group/event using a domain email different from your email
- [x] Leave the group as pending
- [x] Go to /groups or /events
- [x] Make sure your pending group/event is shown in the list
- [x] As SA/SCM, publish the group/event
- [x] Create a new TU with the same email domain as the group/event
- [x] As the new TU, go to /groups or /events
- [x] Make sure you can view the restricted group/event

### Test draft content

- [x] As GM, create a draft discussion in a group
- [x] Make sure you can view the discussion in the group discussions overview and global search
- [x] Login as another GM and make sure you cannot view the draft discussion in the group discussions overview and global search
- [x] As SA/SCM, publish the discussion
- [x] Make sure all GMs can view the discussion in the group discussions overview and global search