### PR TITLE
EICNET-2798: Filters on a the topics do not point to correct taxonomy

### DIFF
--- a/lib/modules/eic_search/src/Search/Sources/NewsStorySourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/NewsStorySourceType.php
@@ -134,7 +134,7 @@ class NewsStorySourceType extends SourceType {
    * @inheritDoc
    */
   public function getPrefilteredContentType(): array {
-    return ['news', 'story'];
+    return ['story'];
   }
 
   /**

--- a/lib/modules/eic_search/src/Search/Sources/NewsStorySourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/NewsStorySourceType.php
@@ -134,7 +134,7 @@ class NewsStorySourceType extends SourceType {
    * @inheritDoc
    */
   public function getPrefilteredContentType(): array {
-    return ['story'];
+    return ['news', 'story'];
   }
 
   /**

--- a/lib/modules/eic_topics/src/Plugin/Block/TopicStatisticsBlock.php
+++ b/lib/modules/eic_topics/src/Plugin/Block/TopicStatisticsBlock.php
@@ -4,6 +4,7 @@ namespace Drupal\eic_topics\Plugin\Block;
 
 use Drupal\Core\Block\Annotation\Block;
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\eic_topics\TopicsManager;
@@ -72,8 +73,20 @@ class TopicStatisticsBlock extends BlockBase implements ContainerFactoryPluginIn
     return [
       '#theme' => 'topics_statistics_block',
       '#stats' => $this->topicsManager->generateTopicsStats($term->id()),
-      '#cache' => ['tags' => ['taxonomy_term:' . $term->id()]],
+      '#cache' => [
+        'tags' => [
+          'taxonomy_term:' . $term->id(),
+        ],
+      ],
     ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheContexts() {
+    // Adds extra cache contexts to the block.
+    return Cache::mergeContexts(parent::getCacheContexts(), ['url.path']);
   }
 
 }


### PR DESCRIPTION
### Fixes

- Add cache url.path as cache context in topic statistics block.
- Fix issue where News content type was not shown in Stories overview page.

### Test

- [x] As any user, go to /topics
- [x] Select a topic
- [x] In the topic detail page check the statistics block and click in one of them
- [x] Make sure you get redirected to the overview page with the correct topic as a filter
- [x] Go to a different topic detail page
- [x] Make sure the statistics are different and correct according to the selected topic
- [x] Click in one of the statistics and make sure you get redirected to the overview page with the correct topic as a filter

### Test stories overview

- [x] As any user, go to /stories
- [x] Make sure you can see stories and news