### PR TITLE
EICNET-2802: Make sure to include the base_path in sub-requests.

### DIFF
--- a/lib/modules/eic_webservices/src/Utility/EicWsHelper.php
+++ b/lib/modules/eic_webservices/src/Utility/EicWsHelper.php
@@ -126,7 +126,8 @@ class EicWsHelper {
 
     // Get the profile resource endpoint URI.
     $profile_resource = $this->resourcePluginManager->getDefinition('eic_webservices_profile');
-    $uri = str_replace('{profile}', $profile->id(), $profile_resource['uri_paths']['canonical']);
+    $uri = $initial_request->getBasePath();
+    $uri .= str_replace('{profile}', $profile->id(), $profile_resource['uri_paths']['canonical']);
     $uri .= '?_format=hal_json';
 
     // Get the embedded profile content.


### PR DESCRIPTION
### Tests

- [ ] Try to create a user with a profile through the webservice, pointing to a site with `/community` (e.g. http://localhost/community)
- [ ] Make sure the user is created with the profile without errors