### PR TITLE
EICNET-2703: Add Archived user status option in the user form

### DIFF
--- a/lib/modules/eic_user/modules/eic_user_login/src/Constants/SmedUserStatuses.php
+++ b/lib/modules/eic_user/modules/eic_user_login/src/Constants/SmedUserStatuses.php
@@ -77,6 +77,13 @@ final class SmedUserStatuses {
   const USER_UNSUBSCRIBED = 'user_unsubscribed';
 
   /**
+   * User archived.
+   *
+   * @var string
+   */
+  const USER_ARCHIVED = 'user_archived';
+
+  /**
    * Returns a list of possible statuses with their labels.
    *
    * @return array
@@ -92,6 +99,7 @@ final class SmedUserStatuses {
       self::USER_NOT_BOOTSTRAPPED => t('User not boostrapped', [], ['context' => 'eic_user_login']),
       self::USER_BLOCKED => t('User blocked', [], ['context' => 'eic_user_login']),
       self::USER_UNSUBSCRIBED => t('User unsubscribed', [], ['context' => 'eic_user_login']),
+      self::USER_ARCHIVED => t('User archived', [], ['context' => 'eic_user_login']),
       self::USER_UNKNOWN => t('User unknown', [], ['context' => 'eic_user_login']),
     ];
   }

--- a/lib/modules/eic_user/modules/eic_user_login/src/Service/SmedUserManager.php
+++ b/lib/modules/eic_user/modules/eic_user_login/src/Service/SmedUserManager.php
@@ -161,7 +161,6 @@ class SmedUserManager {
 
       case SmedUserStatuses::USER_NOT_BOOTSTRAPPED:
       case SmedUserStatuses::USER_BLOCKED:
-      case SmedUserStatuses::USER_ARCHIVED:
         $message = $this->t('It looks like something went wrong, Please contact us via the <a href=":contact_form_url">contact form</a>.', [
           ':contact_form_url' => Url::fromRoute('contact.site_page')->toString(),
         ]);
@@ -169,6 +168,12 @@ class SmedUserManager {
 
       case SmedUserStatuses::USER_UNSUBSCRIBED:
         $message = $this->t('It looks like something went wrong, please contact us via the <a href=":contact_form_url">contact form</a>.', [
+          ':contact_form_url' => Url::fromRoute('contact.site_page')->toString(),
+        ]);
+        break;
+
+      case SmedUserStatuses::USER_ARCHIVED:
+        $message = $this->t('Your account has been archived and is no longer active. If you think this is a mistake, please contact us via the <a href=":contact_form_url">contact form</a>.', [
           ':contact_form_url' => Url::fromRoute('contact.site_page')->toString(),
         ]);
         break;

--- a/lib/modules/eic_user/modules/eic_user_login/src/Service/SmedUserManager.php
+++ b/lib/modules/eic_user/modules/eic_user_login/src/Service/SmedUserManager.php
@@ -76,6 +76,7 @@ class SmedUserManager {
       case SmedUserStatuses::USER_NOT_BOOTSTRAPPED:
       case SmedUserStatuses::USER_BLOCKED:
       case SmedUserStatuses::USER_UNSUBSCRIBED:
+      case SmedUserStatuses::USER_ARCHIVED:
       case SmedUserStatuses::USER_UNKNOWN:
         $account->block();
         break;
@@ -160,6 +161,7 @@ class SmedUserManager {
 
       case SmedUserStatuses::USER_NOT_BOOTSTRAPPED:
       case SmedUserStatuses::USER_BLOCKED:
+      case SmedUserStatuses::USER_ARCHIVED:
         $message = $this->t('It looks like something went wrong, Please contact us via the <a href=":contact_form_url">contact form</a>.', [
           ':contact_form_url' => Url::fromRoute('contact.site_page')->toString(),
         ]);
@@ -170,6 +172,7 @@ class SmedUserManager {
           ':contact_form_url' => Url::fromRoute('contact.site_page')->toString(),
         ]);
         break;
+
       case SmedUserStatuses::USER_UNKNOWN:
         $message = $this->t('<p>It looks like you are not a member yet. Interested? </p> Please <span class="register_button"><a class="ecl-link ecl-link--cta" href=":smed_url" target="_blank">register</a></span> <p>If you have any questions <a href=":contact_form_url">contact us</a>.</p>', [
           ':smed_url' => $smed_url,


### PR DESCRIPTION
### Improvements

- Add archived status to the SMED user status option in the user profile;
- block user when SMED status is set to archived.

### Todo

- The status that needs to be given by SMED should be called "user_archived" otherwise it won't work. - WAITING FOR CONFIRMATION
- ~Update archived message. Currently it uses the same as the user blocked.~ - DONE

### Test

- [ ] Login via EU Login with a user that is archived in SMED
- [ ] Make sure you see the message "It looks like something went wrong, Please contact us via the contact form"