### PR TITLE
EICNET-2715: [Stories] Manage content display wrong information for draft

### DIFF
--- a/lib/modules/eic_content/eic_content.module
+++ b/lib/modules/eic_content/eic_content.module
@@ -9,6 +9,7 @@
  * @see https://www.drupal.org/node/2217931
  */
 
+use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Url;
@@ -128,4 +129,30 @@ function eic_content_metatags_attachments_alter(array &$metatag_attachments) {
     ],
     'og_image_0',
   ];
+}
+
+/**
+ * Implements hook_menu_local_tasks_alter().
+ */
+function eic_content_menu_local_tasks_alter(&$data, $route_name) {
+  $remove_route_links = [
+    'entity.node.canonical' => [
+      'entity.node.canonical',
+    ],
+    'entity.node.latest_version' => [
+      'content_moderation.workflows:node.latest_version_tab',
+    ],
+  ];
+
+  if (
+    isset($remove_route_links[$route_name]) &&
+    isset($data['tabs'][0])
+  ) {
+    foreach ($remove_route_links[$route_name] as $local_task_link_key) {
+      // Removes the local task link from the local tasks for the current route.
+      if (array_key_exists($local_task_link_key, $data['tabs'][0])) {
+        unset($data['tabs'][0][$local_task_link_key]);
+      }
+    }
+  }
 }

--- a/lib/modules/eic_flags/src/Service/DeleteRequestHandler.php
+++ b/lib/modules/eic_flags/src/Service/DeleteRequestHandler.php
@@ -2,9 +2,11 @@
 
 namespace Drupal\eic_flags\Service;
 
+use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Batch\BatchBuilder;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\eic_content\Constants\DefaultContentModerationStates;
 use Drupal\eic_flags\RequestStatus;
@@ -58,6 +60,21 @@ class DeleteRequestHandler extends AbstractRequestHandler {
       RequestStatus::ACCEPTED => 'notify_delete_request_accepted',
       RequestStatus::ARCHIVED => 'notify_delete_request_archived',
     ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function canRequest(
+    AccountInterface $account,
+    ContentEntityInterface $entity
+  ) {
+    // If user can delete the entity, there is no need to allow deletion request.
+    if ($entity->access('delete', $account)) {
+      return AccessResult::forbidden();
+    }
+
+    return parent::canRequest($account, $entity);
   }
 
   /**


### PR DESCRIPTION
### Fixes

- Removes certain local tasks links depending on the current route and moderation status.

### Test

- [x] As SA/SCM, create a new group
- [x] Make sure Request archival link is **only** shown in the group managent dropdown when the group is published. This should work the same for events and organisations.
- [x] Make sure the Request delete link is **only** shown in the group managent dropdown if the user doesn't have permission to delete the group
- [x] Test if the same rules apply to Manage content dropdown links in group content nodes.