### PR TITLE
EICNET-2715: [Stories] Manage content display wrong information for draft (Rework)

### DIFF
--- a/lib/modules/eic_flags/src/Service/ArchiveRequestHandler.php
+++ b/lib/modules/eic_flags/src/Service/ArchiveRequestHandler.php
@@ -222,6 +222,10 @@ class ArchiveRequestHandler extends AbstractRequestHandler {
           $is_published = $check_entity->isActive();
           break;
 
+        case 'group':
+          $is_published = (bool) $check_entity->get('status')->value;
+          break;
+
         default:
           $is_published = $check_entity->isPublished();
           break;

--- a/lib/modules/eic_flags/src/Service/ArchiveRequestHandler.php
+++ b/lib/modules/eic_flags/src/Service/ArchiveRequestHandler.php
@@ -210,7 +210,15 @@ class ArchiveRequestHandler extends AbstractRequestHandler {
       }
     }
     else {
-      $is_published = $entity->isPublished();
+      switch ($entity->getEntityTypeId()) {
+        case 'user':
+          $is_published = $entity->isActive();
+          break;
+
+        default:
+          $is_published = $entity->isPublished();
+          break;
+      }
     }
 
     return $is_published;

--- a/lib/modules/eic_flags/src/Service/ArchiveRequestHandler.php
+++ b/lib/modules/eic_flags/src/Service/ArchiveRequestHandler.php
@@ -14,6 +14,8 @@ use Drupal\eic_groups\GroupsModerationHelper;
 use Drupal\eic_moderation\Constants\EICContentModeration;
 use Drupal\eic_search\Service\SolrDocumentProcessor;
 use Drupal\flag\FlaggingInterface;
+use Drupal\group\Entity\GroupContent;
+use Drupal\group\Entity\GroupContentInterface;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
 
@@ -210,13 +212,18 @@ class ArchiveRequestHandler extends AbstractRequestHandler {
       }
     }
     else {
-      switch ($entity->getEntityTypeId()) {
+      $check_entity = $entity;
+      if ($entity instanceof GroupContentInterface) {
+        $check_entity = $entity->getEntity();
+      }
+
+      switch ($check_entity->getEntityTypeId()) {
         case 'user':
-          $is_published = $entity->isActive();
+          $is_published = $check_entity->isActive();
           break;
 
         default:
-          $is_published = $entity->isPublished();
+          $is_published = $check_entity->isPublished();
           break;
       }
     }


### PR DESCRIPTION
### Fixes

- Fix issue with method isPublished() from ArchiveRequestHandler when checking if user entity is published.

### Test

- [ ] As anonymous, go to the login page -> /user/login
- [ ] Try to login as a non CAS user
- [ ] Make sure there is no error and the homepage loads correctly -> `Error: Call to undefined method Drupal\group\Entity\GroupContent::isPublished() in Drupal\eic_flags\Service\ArchiveRequestHandler->isPublished()`