### PR TITLE
EICNET-2857: [Organisation] created organisation miss of the default features

### DIFF
--- a/lib/modules/eic_groups/src/EICGroupsHelper.php
+++ b/lib/modules/eic_groups/src/EICGroupsHelper.php
@@ -1137,4 +1137,16 @@ class EICGroupsHelper implements EICGroupsHelperInterface {
     return $user_groups;
   }
 
+  /**
+   * Gets default features plugin IDs for a group.
+   *
+   * @param \Drupal\group\Entity\Group $group
+   *   The group entity.
+   */
+  public static function getGroupDefaultFeatures(Group $group) {
+    $group_type_id = $group->getGroupType()->id();
+    $config = \Drupal::configFactory()->get("eic_groups.group_features.default_features.$group_type_id");
+    return $config->get('default_features') ?? [];
+  }
+
 }

--- a/lib/modules/eic_webservices/src/Plugin/rest/resource/EventResource.php
+++ b/lib/modules/eic_webservices/src/Plugin/rest/resource/EventResource.php
@@ -59,6 +59,9 @@ class EventResource extends GroupResourceBase {
     // Initialise required fields if not provided.
     EventsHelper::setRequiredFieldsDefaultValues($entity);
 
+    // Sets default group features.
+    $this->setDefaultGroupFeatures($entity);
+
     return parent::post($entity);
   }
 

--- a/lib/modules/eic_webservices/src/Plugin/rest/resource/GroupResourceBase.php
+++ b/lib/modules/eic_webservices/src/Plugin/rest/resource/GroupResourceBase.php
@@ -4,7 +4,9 @@ namespace Drupal\eic_webservices\Plugin\rest\resource;
 
 use Drupal\Component\Serialization\Json;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\eic_groups\EICGroupsHelper;
 use Drupal\group\Entity\GroupInterface;
+use Drupal\oec_group_features\GroupFeatureHelper;
 use Drupal\rest\Plugin\rest\resource\EntityResource;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -96,6 +98,33 @@ abstract class GroupResourceBase extends EntityResource {
       $group->setOwnerId($author_uid);
     }
 
+  }
+
+  /**
+   * Sets group default features.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group entity.
+   */
+  protected function setDefaultGroupFeatures(GroupInterface &$group) {
+    // We don't set default group features if the group is being updated.
+    if (!$group->isNew()) {
+      return;
+    }
+
+    $default_features = EICGroupsHelper::getGroupDefaultFeatures($group);;
+
+    // Check if field exists.
+    if (!$group->hasField(GroupFeatureHelper::FEATURES_FIELD_NAME)) {
+      return;
+    }
+
+    // Check if field is empty.
+    if (!$group->get(GroupFeatureHelper::FEATURES_FIELD_NAME)->isEmpty()) {
+      return;
+    }
+
+    $group->set(GroupFeatureHelper::FEATURES_FIELD_NAME, $default_features);
   }
 
 }

--- a/lib/modules/eic_webservices/src/Plugin/rest/resource/OrganisationResource.php
+++ b/lib/modules/eic_webservices/src/Plugin/rest/resource/OrganisationResource.php
@@ -59,6 +59,9 @@ class OrganisationResource extends GroupResourceBase {
     // Initialise required fields if not provided.
     OrganisationsHelper::setRequiredFieldsDefaultValues($entity);
 
+    // Sets default group features.
+    $this->setDefaultGroupFeatures($entity);
+
     return parent::post($entity);
   }
 


### PR DESCRIPTION
### Fixes

- Set default group features when creating a global event or organisation via webservices.

### Test

- [x] Try to create an organisation and a global event via WS
- [x] Make sure the following features are enabled by default for organisation: "Members"
- [x] Make sure the following features are enabled by default for global event: "Members", "Discussions", "Files"