### PR TITLE
EICNET-900: Recommend content (small fixes)

### DIFF
--- a/lib/modules/eic_recommend_content/templates/eic-recommend-content-link.html.twig
+++ b/lib/modules/eic_recommend_content/templates/eic-recommend-content-link.html.twig
@@ -13,7 +13,7 @@
   data-modal-description="{{ translations.modal_description }}"
   data-modal-success-title="{{ translations.modal_success_title }}"
   data-modal-success-description="{{ translations.modal_success_description }}"
-  data-modal-translations="{{ translations }}"
+  data-modal-translations="{{ translations | json_encode }}"
 />
   {{ translations.link_label }}
 </div>


### PR DESCRIPTION
### Fixes

- Render data attribute translations in recommend content link as encoded json.

### Test

- [ ] Clear all cache
- [ ] Go to a group detail page
- [ ] Make sure you have no errors in the logs as such: `User error: "link_label" is an invalid render array key in Drupal\Core\Render\Element::children() (line 98 of core/lib/Drupal/Core/Render/Element.php).`