### PR TITLE
EICNET-900: Fix endpoint URL in recommend content data attributes.

### DIFF
--- a/lib/modules/eic_recommend_content/src/Services/RecommendContentManager.php
+++ b/lib/modules/eic_recommend_content/src/Services/RecommendContentManager.php
@@ -152,9 +152,6 @@ class RecommendContentManager {
       [
         'entity_type' => $entity->getEntityTypeId(),
         'entity_id' => $entity->id(),
-      ],
-      [
-        'absolute' => TRUE,
       ]
     );
     $can_recommend = TRUE;
@@ -203,7 +200,7 @@ class RecommendContentManager {
       '#theme' => 'eic_recommend_content_link',
       '#entity_type' => $entity->getEntityTypeId(),
       '#entity_id' => $entity->id(),
-      '#endpoint' => '/' . $endpoint_url->getInternalPath(),
+      '#endpoint' => $endpoint_url->toString(),
       '#can_recommend' => $can_recommend,
       '#can_recommend_external_users' => $can_recommend_external_users,
       '#translations' => [


### PR DESCRIPTION
### Test

- [x] As GM, go to a group
- [x] Inspect element and make sure the data attribute endpoin of the recommend link is prefixed with /community