### PR TITLE
EICNET-2765: [Organsiation] inviting a user page replace reference to groups with "Organsiation"

### DIFF
--- a/config/sync/eic_admin.action_forms.ginvite.invitation.bulk.confirm.yml
+++ b/config/sync/eic_admin.action_forms.ginvite.invitation.bulk.confirm.yml
@@ -1,7 +1,7 @@
 route: ginvite.invitation.bulk.confirm
 paths: ''
-label: 'Invite members to group - Step 2/2'
-title: 'Invite users to the group (2 of 2)'
+label: 'Invite members to [group:type] - Step 2/2'
+title: 'Invite users to the [group:type] (2 of 2)'
 description:
   value: ''
   format: full_html

--- a/config/sync/eic_admin.action_forms.ginvite.invitation.bulk.yml
+++ b/config/sync/eic_admin.action_forms.ginvite.invitation.bulk.yml
@@ -1,7 +1,7 @@
 route: ginvite.invitation.bulk
 paths: ''
-label: 'Invite members to group - Step 1/2'
-title: 'Invite users to the group (1 of 2)'
+label: 'Invite members to [group:type] - Step 1/2'
+title: 'Invite users to the [group:type] (1 of 2)'
 description:
   value: "<p>You are about to invite users to <a href=\"[group:url]\">[group:title]</a>.<br />\r\n&nbsp;<br />\r\nIn order to complete the invitations process, please confirm the list of users below matches the users you wish to invite to the group. Click the confirm invitations button to complete this action.</p>\r\n"
   format: full_html


### PR DESCRIPTION
### Fixes

- Fix group type name in page title of group users invitation form.

### Test

- [x] As GM, go to a group, organisation and global event
- [x] Click on invite users
- [x] Make sure the page title for step 1 is "Invite users to the <group-type> (1 of 2)"
- [x] Make sure the page title for step 2 is "Invite users to the <group-type> (2 of 2)"