### PR TITLE
EICNET-2865: Change the "Send notification" checkbox label and add field description

### DIFF
--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Hooks/FormOperations.php
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Hooks/FormOperations.php
@@ -165,7 +165,7 @@ class FormOperations implements ContainerInjectionInterface {
       }
 
       $form['field_send_notification'] = [
-        '#title' => $this->t('Send notification'),
+        '#title' => $this->t('Send notification to members.'),
         '#type' => 'checkbox',
         '#default_value' => $is_new_content && !in_array($entity->bundle(), $field_disable_by_default_types),
       ];

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Hooks/FormOperations.php
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Hooks/FormOperations.php
@@ -165,9 +165,10 @@ class FormOperations implements ContainerInjectionInterface {
       }
 
       $form['field_send_notification'] = [
-        '#title' => $this->t('Send notification to members.'),
+        '#title' => $this->t('Send notifications to members.'),
         '#type' => 'checkbox',
         '#default_value' => $is_new_content && !in_array($entity->bundle(), $field_disable_by_default_types),
+        '#description' => t('Notifications will not be sent as long your content is in Draft state.'),
       ];
       $form['actions']['submit']['#submit'][] = [
         $this,


### PR DESCRIPTION
### Improvements

- Change label text of checkbox to send notification.
- Add description text to the checkbox to send notification.

### Test

- [x] As GM, try to create or edit content in the group
- [x] Make sure the checkbox label to send notification is "Send notification to members" and there is an helper text bellow "Notifications will not be sent as long your content is in Draft state."