### PR TITLE
Feature/eicnet 2853 group permission revisions

### DIFF
--- a/composer.patches.json
+++ b/composer.patches.json
@@ -48,7 +48,8 @@
       "3302469 - Allow other modules to alter the calculated permissions": "https://www.drupal.org/files/issues/2022-08-09/group-calculated_permissions_alter-3302469-4.patch"
     },
     "drupal/group_permissions": {
-      "3302469 - Allow other modules to alter the calculated permissions": "https://www.drupal.org/files/issues/2022-08-12/group_permissions-cache_performance_issue-3301865-7.patch"
+      "3302469 - Allow other modules to alter the calculated permissions": "https://www.drupal.org/files/issues/2022-08-12/group_permissions-cache_performance_issue-3301865-7.patch",
+      "3210227 - Column not found: 1054 Unknown column 'revision_log'": "https://www.drupal.org/files/issues/2021-05-10/3210227-4-revision_log_problem.patch"
     },
     "drupal/group_content_menu": {
       "3209011 - Active trail is cached incorrectly": "https://www.drupal.org/files/issues/2021-04-21/group_content_menu-active_trail_cache_problem-3209011-10.patch"

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -49,7 +49,8 @@
     },
     "drupal/group_permissions": {
       "3302469 - Allow other modules to alter the calculated permissions": "https://www.drupal.org/files/issues/2022-08-12/group_permissions-cache_performance_issue-3301865-7.patch",
-      "3210227 - Column not found: 1054 Unknown column 'revision_log'": "https://www.drupal.org/files/issues/2021-05-10/3210227-4-revision_log_problem.patch"
+      "3210227 - Column not found: 1054 Unknown column 'revision_log'": "https://www.drupal.org/files/issues/2022-09-27/3210227-8-revision_log_problem.patch",
+      "3221828 - More than one group breaks permission tab in Drupal 9.2.0": "https://git.drupalcode.org/project/group_permissions/-/merge_requests/11.patch"
     },
     "drupal/group_content_menu": {
       "3209011 - Active trail is cached incorrectly": "https://www.drupal.org/files/issues/2021-04-21/group_content_menu-active_trail_cache_problem-3209011-10.patch"

--- a/lib/modules/eic_admin/src/Form/UpdateAllGroupPermissionsForm.php
+++ b/lib/modules/eic_admin/src/Form/UpdateAllGroupPermissionsForm.php
@@ -280,14 +280,9 @@ class UpdateAllGroupPermissionsForm extends FormBase {
         continue;
       }
 
-      // Saves the GroupPermission object with a new revision.
-      $groupPermissions->setNewRevision();
-      $groupPermissions->setRevisionUserId(1);
-      $groupPermissions->setRevisionCreationTime($this->datetime->getRequestTime());
-      $groupPermissions->setRevisionLogMessage('Group features enabled/disabled.');
       $groupPermissions->save();
 
-      // Saves group visibilit + joining methods if flex feature is enabled for
+      // Saves group visibility + joining methods if flex feature is enabled for
       // the group.
       if ($this->groupTypeFlex->hasFlexEnabled($group_type)) {
         $group_visibility = $this->oecGroupFlexHelper->getGroupVisibilitySettings($group);

--- a/lib/modules/eic_deploy/eic_deploy.module
+++ b/lib/modules/eic_deploy/eic_deploy.module
@@ -58,10 +58,6 @@ function eic_deploy_add_group_permissions_to_role(array $new_permissions = [], a
     }
 
     $group_permission->setPermissions($permissions);
-    $group_permission->setNewRevision();
-    $group_permission->setRevisionUserId(1);
-    $group_permission->setRevisionCreationTime(time());
-    $group_permission->setRevisionLogMessage(t('Update group permissions.'));
 
     if (count($group_permission->validate()) > 0) {
       continue;

--- a/lib/modules/eic_groups/eic_groups.install
+++ b/lib/modules/eic_groups/eic_groups.install
@@ -641,6 +641,13 @@ function eic_groups_update_9012(&$sandbox) {
 }
 
 /**
+ * Delete old group_permission revisions.
+ */
+function eic_groups_update_9013() {
+  _eic_groups_delete_old_group_permission_revisions();
+}
+
+/**
  * Operation batch for publishing group wiki section.
  */
 function _eic_groups_batch_publish_group_wiki(int $progress, int $max, int $total, &$context) {

--- a/lib/modules/eic_groups/eic_groups.install
+++ b/lib/modules/eic_groups/eic_groups.install
@@ -759,11 +759,6 @@ function _eic_groups_batch_remove_group_permission(string $permission_to_remove,
       );
     }
 
-    $group_permission->setNewRevision();
-    $group_permission->setRevisionUserId(1);
-    $group_permission->setRevisionCreationTime(time());
-    $group_permission->setRevisionLogMessage(t('Add "administer membership requests" permission to group owner and admin roles.'));
-
     if (count($group_permission->validate()) > 0) {
       continue;
     }

--- a/lib/modules/eic_groups/eic_groups.install.inc
+++ b/lib/modules/eic_groups/eic_groups.install.inc
@@ -89,3 +89,15 @@ function _eic_groups_batch_modify_group_permissions(array $permissions, array $i
     Cache::invalidateTags($group->getCacheTags());
   }
 }
+
+/**
+ * Deletes all the old group permissions and keep only the last one.
+ */
+function _eic_groups_delete_old_group_permission_revisions() {
+  /** @var \Drupal\Core\Database\StatementInterface $query */
+  $query = \Drupal::database()->query("DELETE group_permission_revision FROM group_permission_revision
+  LEFT JOIN group_permission ON group_permission_revision.revision_id = group_permission.revision_id
+  WHERE group_permission.revision_id IS NULL;");
+
+  return $query->execute();
+}

--- a/lib/modules/eic_groups/eic_groups.install.inc
+++ b/lib/modules/eic_groups/eic_groups.install.inc
@@ -80,11 +80,6 @@ function _eic_groups_batch_modify_group_permissions(array $permissions, array $i
       }
     }
 
-    $group_permission->setNewRevision();
-    $group_permission->setRevisionUserId(1);
-    $group_permission->setRevisionCreationTime(time());
-    $group_permission->setRevisionLogMessage("Modified permissions.");
-
     if (count($group_permission->validate()) > 0) {
       continue;
     }

--- a/lib/modules/eic_groups/src/EICGroupsHelper.php
+++ b/lib/modules/eic_groups/src/EICGroupsHelper.php
@@ -784,11 +784,6 @@ class EICGroupsHelper implements EICGroupsHelperInterface {
       throw new EntityStorageException('Group permissions were not saved correctly, because:' . $message);
     }
 
-    // Saves the GroupPermission object with a new revision.
-    $group_permissions->setNewRevision();
-    $group_permissions->setRevisionUserId($this->currentUser->id());
-    $group_permissions->setRevisionCreationTime($this->time->getRequestTime());
-    $group_permissions->setRevisionLogMessage('Group permissions updated successfully.');
     $group_permissions->save();
   }
 

--- a/lib/modules/oec_group_features/src/GroupFeatureHelper.php
+++ b/lib/modules/oec_group_features/src/GroupFeatureHelper.php
@@ -132,9 +132,6 @@ class GroupFeatureHelper {
         'status' => 1,
       ]);
     }
-    else {
-      $groupPermission->setNewRevision(TRUE);
-    }
 
     return $groupPermission;
   }

--- a/lib/modules/oec_group_features/src/GroupFeaturePluginBase.php
+++ b/lib/modules/oec_group_features/src/GroupFeaturePluginBase.php
@@ -203,12 +203,6 @@ abstract class GroupFeaturePluginBase extends PluginBase implements GroupFeature
       throw new EntityStorageException('Group permissions are not saved correctly, because:' . $message);
     }
 
-    // Saves the GroupPermission object with a new revision.
-    $group_permissions->setNewRevision();
-    $group_permissions->setRevisionUserId(\Drupal::currentUser()->id());
-    $group_permissions->setRevisionCreationTime(\Drupal::service('datetime.time')
-      ->getRequestTime());
-    $group_permissions->setRevisionLogMessage('Group features enabled/disabled.');
     $group_permissions->save();
   }
 
@@ -329,7 +323,7 @@ abstract class GroupFeaturePluginBase extends PluginBase implements GroupFeature
   protected function getExistingMenuItem(MenuLinkContentInterface $menu_item) {
     $url = $menu_item->getUrlObject();
 
-    /** @var MenuLinkContentInterface[] $items */
+    /** @var \Drupal\menu_link_content\MenuLinkContentInterface[] $items */
     $items = $this->menuLinkContentStorage->loadByProperties([
       'menu_name' => $menu_item->getMenuName(),
       'link__uri' => $url->toUriString(),

--- a/lib/modules/oec_group_flex/src/OECGroupFlexGroupSaverDecorator.php
+++ b/lib/modules/oec_group_flex/src/OECGroupFlexGroupSaverDecorator.php
@@ -232,9 +232,6 @@ class OECGroupFlexGroupSaverDecorator extends GroupFlexGroupSaver {
         'status' => 1,
       ]);
     }
-    else {
-      $groupPermission->setNewRevision(TRUE);
-    }
 
     return $groupPermission;
   }


### PR DESCRIPTION
### Tests

- [x] Install a dump from PROD
- [x] Get the result of `drush sqlq "SELECT count(*) FROM group_permission_revision;"`
- [x] Run `drush updb -y`
- [x] Get the result of `drush sqlq "SELECT count(*) FROM group_permission_revision;"` and make sure you have the exact same number as the number of existing groups (+/- 7000 items)
- [x] Edit a group and enable/disable some features
- [x] Get the result of `drush sqlq "SELECT count(*) FROM group_permission_revision;"` and make sure you have the exact same number as the number of existing groups (no new revision should be created)

### TODO

- Check if cache must be explictely cleared, or if it's already done upon the save() function.