### PR TITLE
EICNET-2824: Remove duplicated status message

### DIFF
--- a/lib/modules/eic_user/modules/eic_user_login/src/EventSubscriber/CasEventSubscriber.php
+++ b/lib/modules/eic_user/modules/eic_user_login/src/EventSubscriber/CasEventSubscriber.php
@@ -145,7 +145,6 @@ class CasEventSubscriber implements EventSubscriberInterface {
     }
     catch (SmedUserLoginException $e) {
       $event->cancelLogin($e->getUserMessage());
-      $this->messenger()->addWarning($e->getUserMessage());
     }
   }
 


### PR DESCRIPTION
### Fixes

- Remove duplicated status message when invalid user logs in via CAS.

### Todo

- Hide the H3 tag in the status message and push the text next to the icon
![Screenshot 2022-09-27 172726 (1)](https://user-images.githubusercontent.com/9576940/192570121-b473b057-ffc5-435b-a8a6-c072227c8f91.png)

### Test

- [ ] As anonymous, try to Log in via EU Login
- [ ] After EU redirects you to the website, If your user is not valid make sure you can see an Error message (only 1 message should be displayed. Before it was duplicated)