### PR TITLE
EICNET-2823: Don't assign roles upon cas user registration.

### DIFF
--- a/config/sync/cas.settings.yml
+++ b/config/sync/cas.settings.yml
@@ -29,8 +29,7 @@ user_accounts:
   email_assignment_strategy: 1
   email_hostname: localhost
   email_attribute: email
-  auto_assigned_roles:
-    - trusted_user
+  auto_assigned_roles: {  }
   restrict_password_management: true
   restrict_email_management: true
 error_handling:


### PR DESCRIPTION
### Tests

- [x] As SA, go to `/admin/config/eic/smed` and make sure **Allow users to register within Drupal** is checked
- [x] As SA, go to `/admin/config/eic/smed` and make sure **Check/sync user** is unchecked
- [x] As anonymous go to the site, click **Member access** and try to login
- [x] As SA, make sure a user has been created and the user doesn't have any role assigned