### PR TITLE
EICNET-2745: Closed joining method for events

### DIFF
--- a/lib/modules/oec_group_flex/oec_group_flex.install
+++ b/lib/modules/oec_group_flex/oec_group_flex.install
@@ -5,6 +5,9 @@
  * Install, update and uninstall functions for the OEC Group Flex module.
  */
 
+use Drupal\group\Entity\Group;
+use Drupal\group\Entity\GroupType;
+
 /**
  * Implements hook_schema().
  */
@@ -46,6 +49,43 @@ function oec_group_flex_schema() {
     ],
   ];
 
+  $schema['oec_group_joining_method'] = [
+    'description' => 'Stores group joining method information.',
+    'fields' => [
+      'id' => [
+        'type' => 'serial',
+        'not null' => TRUE,
+        'description' => 'Primary Key: Unique record ID.',
+      ],
+      'gid' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'The group ID.',
+      ],
+      'type' => [
+        'type' => 'varchar_ascii',
+        'length' => 64,
+        'not null' => TRUE,
+        'default' => '',
+        'description' => 'The Group visibility plugin id.',
+      ],
+      'options' => [
+        'type' => 'blob',
+        'not null' => TRUE,
+        'size' => 'big',
+        'description' => 'The group joining method options of the item.',
+        'serialize' => TRUE,
+      ],
+    ],
+    'primary key' => ['id'],
+    'indexes' => [
+      'type' => ['type'],
+      'gid' => ['gid'],
+    ],
+  ];
+
   return $schema;
 }
 
@@ -75,6 +115,56 @@ function oec_group_flex_update_9001(&$sandbox) {
       $group_visibility->setOptions($newOptions);
 
       $group_visibility_storage->save($group_visibility);
+    }
+  }
+}
+
+/**
+ * Update OEC Group Flex Schema tables.
+ */
+function oec_group_flex_update_9002(&$sandbox) {
+  $tables = oec_group_flex_schema();
+  $database = \Drupal::database();
+  $schema = $database->schema();
+  foreach ($tables as $table_name => $table) {
+    // If table doesn't exist we create it.
+    if (!$schema->tableExists($table_name)) {
+      $schema->createTable($table_name, $table);
+    }
+  }
+}
+
+/**
+ * Update group visibility options to new data structure.
+ */
+function oec_group_flex_update_9003(&$sandbox) {
+  /** @var \Drupal\group_flex\GroupFlexGroupType $groupFlexType */
+  $groupFlexType = \Drupal::service('group_flex.group_type');
+  /** @var \Drupal\oec_group_flex\GroupJoiningMethodDatabaseStorage $groupJoiningMethodStorage */
+  $groupJoiningMethodStorage = \Drupal::service('oec_group_flex.group_joining_method.storage');
+  /** @var \Drupal\group_flex\GroupFlexGroup $groupFlex */
+  $groupFlex = \Drupal::service('group_flex.group');
+  $group_types = GroupType::loadMultiple();
+
+  foreach ($group_types as $group_type) {
+    if ($groupFlexType->hasFlexEnabled($group_type)) {
+      $query = \Drupal::entityQuery('group');
+      $query->condition('type', $group_type->id());
+      if ($results = $query->execute()) {
+        foreach ($results as $gid) {
+          $group = Group::load($gid);
+          $enabledMethods = $groupFlexType->getEnabledJoiningMethodPlugins($group_type);
+          $defaultOptions = $groupFlex->getDefaultJoiningMethods($group);
+          $joining_method_type = !empty($defaultOptions) ? reset($defaultOptions) : array_key_first($enabledMethods);
+
+          $joining_method_item = $groupJoiningMethodStorage->create([
+            'id' => 0,
+            'gid' => (int) $group->id(),
+            'type' => $joining_method_type,
+          ]);
+          $groupJoiningMethodStorage->save($joining_method_item);
+        }
+      }
     }
   }
 }

--- a/lib/modules/oec_group_flex/oec_group_flex.services.yml
+++ b/lib/modules/oec_group_flex/oec_group_flex.services.yml
@@ -4,7 +4,7 @@ services:
     decorates: group_flex.group
     decoration_priority: 1
     public: false
-    arguments: [ '@oec_group_flex.group_flex.group.decorator.inner', '@config.factory', '@oec_group_flex.group_visibility.storage', '@entity_type.manager', '@group_permission.group_permissions_manager', '@group_flex.group_type' ]
+    arguments: [ '@oec_group_flex.group_flex.group.decorator.inner', '@config.factory', '@oec_group_flex.group_visibility.storage', '@entity_type.manager', '@group_permission.group_permissions_manager', '@group_flex.group_type', '@oec_group_flex.group_joining_method.storage' ]
   oec_group_flex.group_flex.group_saver.decorator:
     class: Drupal\oec_group_flex\OECGroupFlexGroupSaverDecorator
     decorates: group_flex.group_saver
@@ -12,13 +12,16 @@ services:
     public: true
     calls:
       - [ setDocumentProcessor, [ '@?eic_search.solr_document_processor' ] ]
-    arguments: [ '@oec_group_flex.group_flex.group_saver.decorator.inner', '@oec_group_flex.group_visibility.storage', '@module_handler', '@entity_type.manager', '@group_permission.group_permissions_manager', '@plugin.manager.group_visibility', '@plugin.manager.group_joining_method', '@group_flex.group' ]
+    arguments: [ '@oec_group_flex.group_flex.group_saver.decorator.inner', '@oec_group_flex.group_visibility.storage', '@module_handler', '@entity_type.manager', '@group_permission.group_permissions_manager', '@plugin.manager.group_visibility', '@plugin.manager.group_joining_method', '@group_flex.group', '@oec_group_flex.group_joining_method.storage' ]
   oec_group_flex.group_visibility.storage:
     class: Drupal\oec_group_flex\GroupVisibilityDatabaseStorage
     arguments: [ '@entity_type.manager', '@database' ]
   plugin.manager.custom_restricted_visibility:
     class: Drupal\oec_group_flex\Plugin\CustomRestrictedVisibilityManager
     parent: default_plugin_manager
+  oec_group_flex.group_joining_method.storage:
+    class: Drupal\oec_group_flex\GroupJoiningMethodDatabaseStorage
+    arguments: [ '@entity_type.manager', '@database' ]
   oec_group_flex.helper:
     class: Drupal\oec_group_flex\OECGroupFlexHelper
     arguments: [ '@group_flex.group', '@plugin.manager.group_visibility', '@plugin.manager.group_joining_method', '@plugin.manager.custom_restricted_visibility', '@oec_group_flex.group_visibility.storage' ]

--- a/lib/modules/oec_group_flex/src/GroupJoiningMethodDatabaseStorage.php
+++ b/lib/modules/oec_group_flex/src/GroupJoiningMethodDatabaseStorage.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Drupal\oec_group_flex;
+
+use Drupal\Component\Serialization\Json;
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+
+/**
+ * Provides the default storage backend for Group Joining plugins.
+ */
+class GroupJoiningMethodDatabaseStorage implements GroupJoiningMethodDatabaseStorageInterface {
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The database connection used.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected $connection;
+
+  /**
+   * Constructs the statistics storage.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager service.
+   * @param \Drupal\Core\Database\Connection $connection
+   *   The database connection for the node view storage.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, Connection $connection) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->connection = $connection;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function load($gid) {
+    $result = $this->connection->select('oec_group_joining_method')
+      ->fields('oec_group_joining_method', ['id', 'gid', 'type', 'options'])
+      ->condition('gid', $gid)
+      ->range(0, 1)
+      ->execute()->fetchAssoc();
+
+    if (empty($result)) {
+      return FALSE;
+    }
+
+    return new GroupJoiningMethodRecord(
+      $result['id'],
+      $result['gid'],
+      $result['type'],
+      Json::decode($result['options']),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function create(array $values = []) {
+    $final_values = [];
+
+    // If the required parameters for GroupJoiningMethodItem are not set then we
+    // do nothing.
+    if (!isset($values['id']) || !isset($values['gid']) || !isset($values['type'])) {
+      return FALSE;
+    }
+
+    // Re-orders array $values into a final array that will contain the right
+    // parameters order when creating the GroupJoiningMethodItem object.
+    foreach (self::getGroupJoiningMethodRecordProperties() as $property) {
+      if (isset($values[$property])) {
+        $final_values[] = $values[$property];
+      }
+    }
+
+    // We don't always have a third element in the array, so test if first.
+    if (isset($final_values[3])) {
+      list($id, $gid, $type, $options) = $final_values;
+    }
+    else {
+      $options = [];
+      list($id, $gid, $type) = $final_values;
+    }
+
+    if (!is_array($options)) {
+      $options = [];
+    }
+
+    return new GroupJoiningMethodRecord($id, $gid, $type, $options);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function save(GroupJoiningMethodRecordInterface $entity) {
+    return (bool) $this->connection
+      ->merge('oec_group_joining_method')
+      ->key('id', $entity->getId())
+      ->fields([
+        'gid' => $entity->getGroupId(),
+        'type' => $entity->getType(),
+        'options' => Json::encode($entity->getOptions()),
+      ])
+      ->execute();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function delete(array $entities) {
+    $entity_ids = [];
+
+    foreach ($entities as $entity) {
+      $entity_ids[] = $entity->getId();
+    }
+
+    return (bool) $this->connection
+      ->delete('oec_group_joining_method')
+      ->condition('id', $entity_ids, 'IN')
+      ->execute();
+  }
+
+  /**
+   * Gets GroupJoiningMethodRecord properties.
+   *
+   * @return array
+   *   The array of properties.
+   */
+  public static function getGroupJoiningMethodRecordProperties() {
+    return [
+      'id',
+      'gid',
+      'type',
+      'options',
+    ];
+  }
+
+}

--- a/lib/modules/oec_group_flex/src/GroupJoiningMethodDatabaseStorageInterface.php
+++ b/lib/modules/oec_group_flex/src/GroupJoiningMethodDatabaseStorageInterface.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Drupal\oec_group_flex;
+
+/**
+ * Provides an interface defining Group Joining Databse Storage.
+ *
+ * Stores the group joining method in the database.
+ */
+interface GroupJoiningMethodDatabaseStorageInterface {
+
+  /**
+   * Loads a group joining method record from database.
+   *
+   * @param mixed $gid
+   *   The Group entity ID of the visibility record to load.
+   *
+   * @return \Drupal\oec_group_flex\GroupJoiningMethodRecordInterface|bool
+   *   A GroupJoiningMethodRecord object. FALSE if no matching records were
+   *   found.
+   */
+  public function load($gid);
+
+  /**
+   * Constructs a new GroupJoiningMethodRecord object, without saving it.
+   *
+   * @param array $values
+   *   (optional) An array of values to set, keyed by property name.
+   *
+   * @return \Drupal\oec_group_flex\GroupJoiningMethodRecordInterface|FALSE
+   *   A new GroupJoiningMethodRecord object.
+   */
+  public function create(array $values = []);
+
+  /**
+   * Saves the group joining method record permanently.
+   *
+   * @param \Drupal\oec_group_flex\GroupJoiningMethodRecordInterface $group_visibility_record
+   *   The group joining method record to save.
+   *
+   * @return bool
+   *   TRUE if the record was saved in the database.
+   */
+  public function save(GroupJoiningMethodRecordInterface $group_visibility_record);
+
+  /**
+   * Deletes permanently saved group joining method records.
+   *
+   * @param \Drupal\oec_group_flex\GroupJoiningMethodRecordInterface[] $entities
+   *   An array of entity objects to delete.
+   */
+  public function delete(array $entities);
+
+}

--- a/lib/modules/oec_group_flex/src/GroupJoiningMethodRecord.php
+++ b/lib/modules/oec_group_flex/src/GroupJoiningMethodRecord.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Drupal\oec_group_flex;
+
+/**
+ * Defines a class for oec_group_visibility database records.
+ */
+class GroupJoiningMethodRecord implements GroupJoiningMethodRecordInterface {
+
+  /**
+   * Group visibility record ID.
+   *
+   * @var int
+   */
+  public $id;
+
+  /**
+   * Group entity ID.
+   *
+   * @var int
+   */
+  private $gid;
+
+  /**
+   * Group visibility plugin id.
+   *
+   * @var string
+   */
+  private $type;
+
+  /**
+   * Group visibility plugin options.
+   *
+   * @var array
+   */
+  private $options;
+
+  /**
+   * Constructs a new GroupVisibilityRecord object.
+   *
+   * @param int $id
+   *   The Group visibility record ID.
+   * @param int $gid
+   *   The group entity ID.
+   * @param string $type
+   *   The group visibility plugin ID.
+   * @param array $options
+   *   The group visibility options.
+   */
+  public function __construct($id, $gid, $type, array $options = []) {
+    $this->id = $id;
+    $this->gid = $gid;
+    $this->type = $type;
+    $this->options = $options;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getId() {
+    return $this->id;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getGroupId() {
+    return $this->gid;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getType() {
+    return $this->type;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getOptions() {
+    return $this->options;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setId($id) {
+    $this->id = $id;
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setGroupId($gid) {
+    $this->gid = $gid;
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setType($type) {
+    $this->type = $type;
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setOptions(array $options = []) {
+    $this->options = $options;
+    return $this;
+  }
+
+}

--- a/lib/modules/oec_group_flex/src/GroupJoiningMethodRecordInterface.php
+++ b/lib/modules/oec_group_flex/src/GroupJoiningMethodRecordInterface.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Drupal\oec_group_flex;
+
+/**
+ * Interface for GroupJoiningMethodRecord objects.
+ */
+interface GroupJoiningMethodRecordInterface {
+
+  /**
+   * Gets the group joining method record ID.
+   *
+   * @return int
+   *   The group joining method record ID.
+   */
+  public function getId();
+
+  /**
+   * Gets the group entity ID.
+   *
+   * @return int
+   *   The group entity ID.
+   */
+  public function getGroupId();
+
+  /**
+   * Gets group joining method plugin ID.
+   *
+   * @return string
+   *   The group joining method plugin ID.
+   */
+  public function getType();
+
+  /**
+   * Gets group joining method options.
+   *
+   * @return array
+   *   The group joining method options array.
+   */
+  public function getOptions();
+
+  /**
+   * Sets the group joining method record ID.
+   *
+   * @return \Drupal\oec_group_flex\GroupJoiningMethodRecordInterface
+   *   The group joining method record object.
+   */
+  public function setId($id);
+
+  /**
+   * Sets the group entity ID.
+   *
+   * @param int $gid
+   *   The group entity ID.
+   *
+   * @return \Drupal\oec_group_flex\GroupJoiningMethodRecordInterface
+   *   The group joining method record object.
+   */
+  public function setGroupId($gid);
+
+  /**
+   * Sets the group joining method plugin ID.
+   *
+   * @param string $type
+   *   The group joining method plugin ID.
+   *
+   * @return \Drupal\oec_group_flex\GroupJoiningMethodRecordInterface
+   *   The group joining method record object.
+   */
+  public function setType($type);
+
+  /**
+   * Sets the group joining method options.
+   *
+   * @param array $options
+   *   The group joining method options array.
+   *
+   * @return \Drupal\oec_group_flex\GroupJoiningMethodRecordInterface
+   *   The group joining method record object.
+   */
+  public function setOptions(array $options = []);
+
+}

--- a/lib/modules/oec_group_flex/src/OECGroupFlexGroupDecorator.php
+++ b/lib/modules/oec_group_flex/src/OECGroupFlexGroupDecorator.php
@@ -40,6 +40,13 @@ class OECGroupFlexGroupDecorator extends GroupFlexGroup {
   protected $groupVisibilityStorage;
 
   /**
+   * The group joining method storage service.
+   *
+   * @var \Drupal\oec_group_flex\GroupJoiningMethodDatabaseStorageInterface
+   */
+  protected $groupJoiningMethodStorage;
+
+  /**
    * Constructs a new OECGroupFlexGroupDecorator.
    *
    * @param \Drupal\group_flex\GroupFlexGroup $groupFlexGroup
@@ -54,12 +61,23 @@ class OECGroupFlexGroupDecorator extends GroupFlexGroup {
    *   The group permissions manager.
    * @param \Drupal\group_flex\GroupFlexGroupType $flexGroupType
    *   The group type flex.
+   * @param \Drupal\oec_group_flex\GroupJoiningMethodDatabaseStorageInterface $groupVisibilityStorage
+   *   The group joining method storage service.
    */
-  public function __construct(GroupFlexGroup $groupFlexGroup, ConfigFactoryInterface $configFactory, GroupVisibilityDatabaseStorageInterface $groupVisibilityStorage, EntityTypeManagerInterface $entityTypeManager, GroupPermissionsManager $groupPermManager, GroupFlexGroupType $flexGroupType) {
+  public function __construct(
+    GroupFlexGroup $groupFlexGroup,
+    ConfigFactoryInterface $configFactory,
+    GroupVisibilityDatabaseStorageInterface $groupVisibilityStorage,
+    EntityTypeManagerInterface $entityTypeManager,
+    GroupPermissionsManager $groupPermManager,
+    GroupFlexGroupType $flexGroupType,
+    GroupJoiningMethodDatabaseStorageInterface $groupJoiningMethodStorage
+  ) {
     parent::__construct($entityTypeManager, $groupPermManager, $flexGroupType);
     $this->groupFlexGroup = $groupFlexGroup;
     $this->oecGroupFlexConfigSettings = $configFactory->get('oec_group_flex.settings');
     $this->groupVisibilityStorage = $groupVisibilityStorage;
+    $this->groupJoiningMethodStorage = $groupJoiningMethodStorage;
   }
 
   /**
@@ -76,6 +94,16 @@ class OECGroupFlexGroupDecorator extends GroupFlexGroup {
       return GroupVisibilityInterface::GROUP_FLEX_TYPE_VIS_PUBLIC;
     }
     return $group_visibility_record->getType();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDefaultJoiningMethods(GroupInterface $group): array {
+    if (!($item = $this->groupJoiningMethodStorage->load($group->id()))) {
+      return $this->groupFlexGroup->getDefaultJoiningMethods($group);
+    }
+    return [$item->getType()];
   }
 
   /**

--- a/lib/modules/oec_group_flex/src/OECGroupFlexGroupSaverDecorator.php
+++ b/lib/modules/oec_group_flex/src/OECGroupFlexGroupSaverDecorator.php
@@ -53,6 +53,13 @@ class OECGroupFlexGroupSaverDecorator extends GroupFlexGroupSaver {
   private $solrDocumentProcessor;
 
   /**
+   * The group joining method storage service.
+   *
+   * @var \Drupal\oec_group_flex\GroupJoiningMethodDatabaseStorageInterface
+   */
+  protected $groupJoiningMethodStorage;
+
+  /**
    * Constructs a new GroupFlexGroupSaver object.
    *
    * @param \Drupal\group_flex\GroupFlexGroupSaver $groupFlexSaver
@@ -71,6 +78,8 @@ class OECGroupFlexGroupSaverDecorator extends GroupFlexGroupSaver {
    *   The group joining method manager.
    * @param \Drupal\group_flex\GroupFlexGroup $groupFlex
    *   The group flex.
+   * @param \Drupal\oec_group_flex\GroupJoiningMethodDatabaseStorageInterface $groupVisibilityStorage
+   *   The group joining method storage service.
    */
   public function __construct(
     GroupFlexGroupSaver $groupFlexSaver,
@@ -80,12 +89,19 @@ class OECGroupFlexGroupSaverDecorator extends GroupFlexGroupSaver {
     GroupPermissionsManager $groupPermManager,
     GroupVisibilityManager $visibilityManager,
     GroupJoiningMethodManager $joiningMethodManager,
-    GroupFlexGroup $groupFlex
+    GroupFlexGroup $groupFlex,
+    GroupJoiningMethodDatabaseStorageInterface $groupJoiningMethodStorage
   ) {
-    parent::__construct($entityTypeManager, $groupPermManager,
-      $visibilityManager, $joiningMethodManager, $groupFlex);
+    parent::__construct(
+      $entityTypeManager,
+      $groupPermManager,
+      $visibilityManager,
+      $joiningMethodManager,
+      $groupFlex
+    );
     $this->groupFlexSaver = $groupFlexSaver;
     $this->groupVisibilityStorage = $groupVisibilityStorage;
+    $this->groupJoiningMethodStorage = $groupJoiningMethodStorage;
     $this->moduleHandler = $module_handler;
   }
 
@@ -318,6 +334,9 @@ class OECGroupFlexGroupSaverDecorator extends GroupFlexGroupSaver {
     // Save original permissions.
     $original_permissions = $groupPermission->getPermissions();
 
+    /** @var \Drupal\group_flex\Plugin\GroupJoiningMethodBase|null $enabled_plugin */
+    $enabled_plugin = NULL;
+
     /** @var \Drupal\group_flex\Plugin\GroupJoiningMethodBase $pluginInstance */
     foreach ($this->getAllJoiningMethods() as $id => $pluginInstance) {
       // Checks if the method is enabled.
@@ -326,9 +345,7 @@ class OECGroupFlexGroupSaverDecorator extends GroupFlexGroupSaver {
       $allowedVisibilities = $pluginInstance->getVisibilityOptions();
       $isAllowed = in_array($this->groupFlex->getGroupVisibility($group), $allowedVisibilities, TRUE);
       if ($isEnabled && $isAllowed) {
-        foreach ($pluginInstance->getGroupPermissions($group) as $role => $rolePermissions) {
-          $groupPermission = $this->addRolePermissionsToGroup($groupPermission, $role, $rolePermissions);
-        }
+        $enabled_plugin = $pluginInstance;
         continue;
       }
 
@@ -340,8 +357,29 @@ class OECGroupFlexGroupSaverDecorator extends GroupFlexGroupSaver {
       }
     }
 
+    if ($enabled_plugin) {
+      foreach ($enabled_plugin->getGroupPermissions($group) as $role => $rolePermissions) {
+        $groupPermission = $this->addRolePermissionsToGroup($groupPermission, $role, $rolePermissions);
+      }
+    }
+
+    if (!($item = $this->groupJoiningMethodStorage->load($group->id()))) {
+      $item = $this->groupJoiningMethodStorage->create([
+        'id' => 0,
+        'gid' => (int) $group->id(),
+        'type' => '',
+      ]);
+    }
+
+    if ($item->getType() !== $enabled_plugin->getPluginId()) {
+      $item->setType($enabled_plugin->getPluginId());
+    }
+
     // Don't save group permissions if they didn't change.
-    if ($groupPermission->getPermissions() == $original_permissions) {
+    if (
+      $item->getType() === $enabled_plugin->getPluginId() &&
+      $groupPermission->getPermissions() == $original_permissions
+    ) {
       return;
     }
 
@@ -354,6 +392,8 @@ class OECGroupFlexGroupSaverDecorator extends GroupFlexGroupSaver {
       throw new EntityStorageException('Group permissions are not saved correctly, because:' . $message);
     }
     $groupPermission->save();
+
+    $this->groupJoiningMethodStorage->save($item);
 
     // Invalidates group cache tags.
     Cache::invalidateTags($group->getCacheTagsToInvalidate());

--- a/lib/modules/oec_group_flex/src/Plugin/GroupJoiningMethod/TuCloseMethod.php
+++ b/lib/modules/oec_group_flex/src/Plugin/GroupJoiningMethod/TuCloseMethod.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Drupal\oec_group_flex\Plugin\GroupJoiningMethod;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\group\Entity\GroupInterface;
+use Drupal\group\Entity\GroupTypeInterface;
+use Drupal\group\GroupRoleSynchronizer;
+use Drupal\group_flex\Plugin\GroupJoiningMethodBase;
+use Drupal\oec_group_flex\OECGroupFlexHelper;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a 'tu_close_method' group joining method.
+ *
+ * @GroupJoiningMethod(
+ *  id = "tu_close_method",
+ *  label = @Translation("Close"),
+ *  weight = -80,
+ *  visibilityOptions = {
+ *   "public",
+ *   "flex",
+ *   "restricted_community_members",
+ *   "custom_restricted"
+ *  }
+ * )
+ */
+class TuCloseMethod extends GroupJoiningMethodBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The group role synchronizer.
+   *
+   * @var \Drupal\group\GroupRoleSynchronizer
+   */
+  protected $groupRoleSynchronizer;
+
+  /**
+   * Constructs a new RestrictedVisibility plugin object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\group\GroupRoleSynchronizer $groupRoleSynchronizer
+   *   The group role synchronizer.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, GroupRoleSynchronizer $groupRoleSynchronizer) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->groupRoleSynchronizer = $groupRoleSynchronizer;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('group_role.synchronizer')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function enableGroupType(GroupTypeInterface $groupType) {
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function disableGroupType(GroupTypeInterface $groupType) {
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getGroupPermissions(GroupInterface $group): array {
+    $ownerGroupRoleId = OECGroupFlexHelper::getGroupTypeRole($group->bundle(), 'owner');
+    return [
+      $ownerGroupRoleId => ['administer membership requests'],
+    ];
+  }
+
+  /**
+   * Get the trusted user role id for the given group type.
+   *
+   * @param \Drupal\group\Entity\GroupTypeInterface $groupType
+   *   The group type.
+   *
+   * @return string
+   *   The group role id.
+   */
+  private function getTrustedUserRoleId(GroupTypeInterface $groupType) {
+    $tuGroupRoleId = $this->groupRoleSynchronizer->getGroupRoleId($groupType->id(), 'trusted_user');
+    return $tuGroupRoleId;
+  }
+
+}


### PR DESCRIPTION
### Improvements

- Create new joining method plugin "tu_close_method";
- Create new table schema to save information about the group joining method;
- Create hook update to update joining method for existing groups.

### Test

Using PROD DB
- [ ] drush cr
- [ ] Run drush updb
- [ ] drush cim -y
- [ ] As GO, try to edit an event and make sure you have a new joining method "Close".
- [ ] Change it to close.
- [ ] As TU make sure you cannot request to join or join the event.
- [ ] Make sure the Open or Request to join methods still work if you change back