### PR TITLE
EICNET-2875: mails from contact form are stuck in the queue

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/content/message.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/message.inc
@@ -57,7 +57,10 @@ function eic_community_preprocess_message(&$variables) {
       // If field_sender is empty, it means the global message was sent from an
       // anonymous user. Therefore, we remove the body message that is supposed
       // to be for authenticated users.
-      if ($message->get('field_sender')->isEmpty()) {
+      if (
+        $message->get('field_sender')->isEmpty() ||
+        $message->get('field_sender')->value == 0
+      ) {
         unset($variables['content']['partial_1']);
       }
       else {


### PR DESCRIPTION
### Fixes

- Add missing condition to check if field_sender references anonymous user when preprocessing global contact messages.

### Test

- [ ] Import DB from PROD
- [ ] Run drush cim and drush cr
- [ ] Run `drush queue:run eic_message_notify_queue`
- [ ] Make sure the stucked messages are sent