### PR TITLE
EICNET-2697: Do not link users to their profile for anonymous users.

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/groups/group.inc
+++ b/lib/themes/eic_community/includes/preprocess/groups/group.inc
@@ -167,8 +167,8 @@ function _group_about_group_tab($variables, &$sections) {
     $user = $owner->getUser();
 
     return [
-      'title' => realname_load($user),
-      'path' => $user->toUrl(),
+      'title' => $user->getDisplayName(),
+      'path' => $user->toUrl()->access() ? $user->toUrl() : '',
     ];
   }, $owners);
 
@@ -184,13 +184,13 @@ function _group_about_group_tab($variables, &$sections) {
       $user = $admin->getUser();
 
       return [
-        'title' => realname_load($user),
-        'path' => $user->toUrl(),
+        'title' => $user->getDisplayName(),
+        'path' => $user->toUrl()->access() ? $user->toUrl() : '',
       ];
     }, $admins);
 
     $about_items[] = [
-      'title' => t('Administrator'),
+      'title' => t('Administrators'),
       'items' => $admins,
     ];
   }
@@ -230,9 +230,7 @@ function _group_about_group_tab($variables, &$sections) {
 
   $about_items[] = [
     'title' => t('Group description'),
-    'content' => $group->hasField('field_body') ?
-      $group->get('field_body')->value :
-      '',
+    'content' => $group->hasField('field_body') ? $group->get('field_body')->value : '',
   ];
 
   $sections[] = [


### PR DESCRIPTION
### Tests

- [x] As TU, go to a group's About page
- [x] Make sure Group owner and Administrators have a link to their profile
- [x] As Anonymous go to a group's About page
- [x] Make sure Group owner and Administrators don't have a link to their profile