### PR TITLE
Feature/eicnet 2807 invitee email access

### DIFF
--- a/config/sync/user.role.trusted_user.yml
+++ b/config/sync/user.role.trusted_user.yml
@@ -92,4 +92,3 @@ permissions:
   - 'view own unpublished media'
   - 'view private content'
   - 'view recommend_group'
-  - 'view user email addresses'

--- a/config/sync/views.view.group_invitations.yml
+++ b/config/sync/views.view.group_invitations.yml
@@ -545,7 +545,7 @@ display:
       access:
         type: group_permission
         options:
-          group_permission: 'administer members'
+          group_permission: 'view group invitations'
       cache:
         type: tag
         options: {  }

--- a/lib/modules/eic_groups/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_groups/src/Hooks/EntityOperations.php
@@ -486,83 +486,115 @@ class EntityOperations implements ContainerInjectionInterface {
 
     $entity = $items->getEntity();
 
-    if ($entity instanceof GroupInterface && $entity->bundle() === 'group') {
-      $group_restricted_fields = [
-        'field_related_groups',
-        'field_related_news_stories',
-      ];
-
-      // If field is non of the restricted ones, we do nothing.
-      if (!in_array($field_definition->getName(), $group_restricted_fields)) {
-        return $access;
-      }
-
-      switch ($operation) {
-        case 'edit':
-          // Deny access if it's a new group and the user doesn't have
-          // "site_admin" or "content_administrator" roles.
-          if ($entity->isNew()) {
-            $access = AccessResult::forbiddenIf(!UserHelper::isPowerUser($account))
-              ->addCacheableDependency($account);
-            break;
-          }
-          break;
-
-      }
+    if ($entity instanceof GroupInterface) {
+      $access = $this->groupFieldAccess($operation, $field_definition, $account, $items);
     }
     elseif ($entity instanceof NodeInterface) {
-      $access = AccessResult::neutral();
+      $access = $this->nodeFieldAccess($operation, $field_definition, $account, $items);
+    }
 
-      if ($operation !== 'edit') {
-        return $access;
-      }
+    return $access;
+  }
 
-      switch ($field_definition->getName()) {
-        case NodeProperty::MEMBER_CONTENT_EDIT_ACCESS:
+  /**
+   * Custom field access implementation for 'group' entity type.
+   *
+   * @see hook_entity_field_access()
+   * @see \Drupal\eic_groups\Hooks\EntityOperations::entityFieldAccess()
+   */
+  protected function groupFieldAccess($operation, FieldDefinitionInterface $field_definition, AccountInterface $account, FieldItemListInterface $items = NULL) {
+    $access = AccessResult::neutral();
+    $entity = $items->getEntity();
 
-          if ($entity->isNew()) {
-            $group = $this->eicGroupsHelper->getGroupFromRoute();
+    switch ($entity->bundle() === 'group') {
+      case 'group':
+        $group_restricted_fields = [
+          'field_related_groups',
+          'field_related_news_stories',
+        ];
 
-            if (!$group) {
-              return AccessResult::forbidden();
+        // If field is none of the restricted ones, we do nothing.
+        if (!in_array($field_definition->getName(), $group_restricted_fields)) {
+          return $access;
+        }
+
+        switch ($operation) {
+          case 'edit':
+            // Deny access if it's a new group and the user doesn't have
+            // "site_admin" or "content_administrator" roles.
+            if ($entity->isNew()) {
+              $access = AccessResult::forbiddenIf(!UserHelper::isPowerUser($account))
+                ->addCacheableDependency($account);
+              break;
             }
+            break;
 
-            return $access;
-          }
+        }
+        break;
+    }
 
-          /** @var \Drupal\group\Entity\Storage\GroupContentStorageInterface $storage */
-          $storage = $this->entityTypeManager->getStorage('group_content');
-          $group_contents = $storage->loadByEntity($entity);
+    return $access;
+  }
 
-          // Wiki page is not part of a group, so we always hide the field.
-          if (empty($group_contents)) {
+  /**
+   * Custom field access implementation for 'node' entity type.
+   *
+   * @see hook_entity_field_access()
+   * @see \Drupal\eic_groups\Hooks\EntityOperations::entityFieldAccess()
+   */
+  protected function nodeFieldAccess($operation, FieldDefinitionInterface $field_definition, AccountInterface $account, FieldItemListInterface $items = NULL) {
+    $access = AccessResult::neutral();
+    $entity = $items->getEntity();
+
+    if ($operation !== 'edit') {
+      return $access;
+    }
+
+    switch ($field_definition->getName()) {
+      case NodeProperty::MEMBER_CONTENT_EDIT_ACCESS:
+
+        if ($entity->isNew()) {
+          $group = $this->eicGroupsHelper->getGroupFromRoute();
+
+          if (!$group) {
             return AccessResult::forbidden();
           }
 
-          // If user is the group author, we allow access.
-          if ($entity->getOwnerId() === $account->id()) {
-            break;
-          }
+          return $access;
+        }
 
-          // If user is a power user, we allow access.
-          if (UserHelper::isPowerUser($account)) {
-            break;
-          }
+        /** @var \Drupal\group\Entity\Storage\GroupContentStorageInterface $storage */
+        $storage = $this->entityTypeManager->getStorage('group_content');
+        $group_contents = $storage->loadByEntity($entity);
 
-          $group_content = reset($group_contents);
-          $group = $group_content->getGroup();
+        // Wiki page is not part of a group, so we always hide the field.
+        if (empty($group_contents)) {
+          return AccessResult::forbidden();
+        }
 
-          // If user is a group admin, we allow access.
-          if (EICGroupsHelper::userIsGroupAdmin($group, $account)) {
-            break;
-          }
-
-          // At this point it means the user is just a group member and
-          // therefore we deny access to edit the field.
-          $access = AccessResult::forbidden();
+        // If user is the group author, we allow access.
+        if ($entity->getOwnerId() === $account->id()) {
           break;
+        }
 
-      }
+        // If user is a power user, we allow access.
+        if (UserHelper::isPowerUser($account)) {
+          break;
+        }
+
+        $group_content = reset($group_contents);
+        $group = $group_content->getGroup();
+
+        // If user is a group admin, we allow access.
+        if (EICGroupsHelper::userIsGroupAdmin($group, $account)) {
+          break;
+        }
+
+        // At this point it means the user is just a group member and
+        // therefore we deny access to edit the field.
+        $access = AccessResult::forbidden();
+        break;
+
     }
 
     return $access;


### PR DESCRIPTION
### Tests

- [x]  As GO/GA, go to your group
- [x] Invite an existing platform user and an external user
- [x] Make sure you don't see the platform user email in the invitations list
- [x] Make sure you do see the external user email in the invitations list
- [x] As SA/SCM, go to the same group
- [x] Make sure you see email address for both users