### PR TITLE
EICNET-2667: I can still manage members/memberships/invitations of a blocked group

### DIFF
--- a/config/sync/views.view.eic_group_invitations.yml
+++ b/config/sync/views.view.eic_group_invitations.yml
@@ -1,19 +1,18 @@
-uuid: 7b940c0a-3ee6-4b34-98e5-0e1b43558a92
+uuid: d963a8e7-fc7f-477c-96f2-a79b061a5e81
 langcode: en
 status: true
 dependencies:
   config:
-    - block.block.eicpagecontextualactionblock
     - field.storage.group_content.group_roles
+    - field.storage.group_content.invitee_mail
   module:
-    - eic_group_membership
     - eic_groups
     - group
     - user
 _core:
-  default_config_hash: zIcnLmbW8inPRIQdPSVbKPuG2o5G5wHGJED4Jlgb2SY
-id: eic_group_members
-label: 'EIC - Group members'
+  default_config_hash: YZgK6tSmg1F3D4UuX7Jwp_bgFjIzIfJerHoMoIHY0GI
+id: eic_group_invitations
+label: 'EIC - Group invitations'
 module: group
 description: ''
 tag: ''
@@ -26,22 +25,21 @@ display:
     display_plugin: default
     position: 0
     display_options:
-      title: Members
+      title: Invitations
       fields:
-        transfer_ownership_status:
-          id: transfer_ownership_status
-          table: group_content
-          field: transfer_ownership_status
+        invitee_mail:
+          id: invitee_mail
+          table: group_content__invitee_mail
+          field: invitee_mail
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: group_content
-          plugin_id: eic_group_membership_transfer_ownership_status
-          label: 'Group transfer ownership status'
-          exclude: true
+          plugin_id: field
+          label: Email
+          exclude: false
           alter:
-            alter_text: true
-            text: '<br>({{ transfer_ownership_status }})'
+            alter_text: false
+            text: ''
             make_link: false
             path: ''
             absolute: false
@@ -75,9 +73,22 @@ display:
           element_wrapper_class: ''
           element_default_classes: true
           empty: ''
-          hide_empty: true
+          hide_empty: false
           empty_zero: false
           hide_alter_empty: true
+          click_sort_column: value
+          type: email_mailto
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         name:
           id: name
           table: users_field_data
@@ -88,11 +99,11 @@ display:
           entity_type: user
           entity_field: name
           plugin_id: field
-          label: User
+          label: Invitee
           exclude: false
           alter:
-            alter_text: true
-            text: '{{ name }} {{ transfer_ownership_status }}'
+            alter_text: false
+            text: ''
             make_link: false
             path: ''
             absolute: false
@@ -125,7 +136,7 @@ display:
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
-          empty: ''
+          empty: 'Not registered'
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
@@ -188,7 +199,7 @@ display:
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
-          empty: '<div class="item-list"><ul><li>Member</li></ul></div>'
+          empty: '<div class="item-list"><ul><li>&lt;none&gt;</li></ul></div>'
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
@@ -206,17 +217,17 @@ display:
           multi_type: ul
           separator: ', '
           field_api_classes: false
-        changed:
-          id: changed
+        uid:
+          id: uid
           table: group_content_field_data
-          field: changed
+          field: uid
           relationship: none
           group_type: group
           admin_label: ''
           entity_type: group_content
-          entity_field: changed
+          entity_field: uid
           plugin_id: field
-          label: Updated
+          label: 'Invited by'
           exclude: false
           alter:
             alter_text: false
@@ -257,13 +268,11 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          click_sort_column: value
-          type: timestamp
+          click_sort_column: target_id
+          type: entity_reference_label
           settings:
-            date_format: short
-            custom_date_format: ''
-            timezone: ''
-          group_column: value
+            link: true
+          group_column: target_id
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -283,7 +292,7 @@ display:
           entity_type: group_content
           entity_field: created
           plugin_id: field
-          label: Joined
+          label: 'Invited on'
           exclude: false
           alter:
             alter_text: false
@@ -340,15 +349,118 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-        operations:
-          id: operations
+        delete_group_content:
+          id: delete_group_content
           table: group_content
-          field: operations
+          field: delete_group_content
+          relationship: none
+          group_type: group
+          admin_label: 'Remove member link'
+          entity_type: group_content
+          plugin_id: entity_link_delete
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: 'Remove invitation'
+          output_url_as_text: false
+          absolute: false
+        resend_invitation:
+          id: resend_invitation
+          table: group_content
+          field: resend_invitation
           relationship: none
           group_type: group
           admin_label: ''
           entity_type: group_content
-          plugin_id: entity_operations
+          plugin_id: resend_invitation
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: 'Resend invitation'
+        dropbutton:
+          id: dropbutton
+          table: views
+          field: dropbutton
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: dropbutton
           label: Operations
           exclude: false
           alter:
@@ -379,7 +491,7 @@ display:
             preserve_tags: ''
             html: false
           element_type: ''
-          element_class: 'views-field views-field-dropbutton'
+          element_class: ''
           element_label_type: ''
           element_label_class: ''
           element_label_colon: true
@@ -390,7 +502,15 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          destination: false
+          destination: true
+          fields:
+            delete_group_content: delete_group_content
+            resend_invitation: resend_invitation
+            invitee_mail: '0'
+            name: '0'
+            group_roles: '0'
+            uid: '0'
+            created: '0'
       pager:
         type: full
         options:
@@ -399,10 +519,10 @@ display:
           total_pages: null
           id: 0
           tags:
-            next: ››
-            previous: ‹‹
-            first: '« First'
-            last: 'Last »'
+            next: â€ºâ€º
+            previous: â€¹â€¹
+            first: 'Â« First'
+            last: 'Last Â»'
           expose:
             items_per_page: false
             items_per_page_label: 'Items per page'
@@ -425,16 +545,16 @@ display:
       access:
         type: eic_group_moderation_state_permission
         options:
-          group_permission: 'access members management'
+          group_permission: 'view group invitations'
           moderation_states:
+            archived: archived
             draft: draft
             published: published
-            archived: 0
             blocked: 0
             pending: 0
             refused: 0
       cache:
-        type: none
+        type: tag
         options: {  }
       empty:
         area_text_custom:
@@ -446,7 +566,7 @@ display:
           admin_label: ''
           plugin_id: text_custom
           empty: true
-          content: 'No members available.'
+          content: 'No invitations available.'
           tokenize: false
       sorts: {  }
       arguments:
@@ -466,7 +586,7 @@ display:
             title_enable: false
             title: All
           title_enable: true
-          title: '{{ arguments.gid|placeholder }} members'
+          title: '{{ arguments.gid|placeholder }} invitations'
           default_argument_type: fixed
           default_argument_options:
             argument: ''
@@ -487,10 +607,51 @@ display:
           validate_options: {  }
           break_phrase: false
           not: false
-      filters: {  }
-      filter_groups:
-        operator: AND
-        groups: {  }
+      filters:
+        invitation_status_value:
+          id: invitation_status_value
+          table: group_content__invitation_status
+          field: invitation_status_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: numeric
+          operator: '='
+          value:
+            min: ''
+            max: ''
+            value: '0'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            min_placeholder: ''
+            max_placeholder: ''
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       style:
         type: table
         options:
@@ -595,22 +756,9 @@ display:
           plugin_id: group_content_to_entity
           required: true
           group_content_plugins:
-            group_membership: group_membership
-      group_by: false
-      header:
-        entity_block:
-          id: entity_block
-          table: views
-          field: entity_block
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: entity
-          empty: true
-          target: eicpagecontextualactionblock
-          view_mode: default
-          tokenize: false
-          bypass_access: false
+            group_invitation: group_invitation
+            group_membership: '0'
+      header: {  }
       footer: {  }
       display_extenders: {  }
     cache_metadata:
@@ -624,20 +772,20 @@ display:
         - user.group_permissions
       tags:
         - 'config:field.storage.group_content.group_roles'
-  page_group_members:
-    id: page_group_members
+        - 'config:field.storage.group_content.invitee_mail'
+  page_1:
+    id: page_1
     display_title: Page
     display_plugin: page
     position: 1
     display_options:
       display_extenders: {  }
-      path: group/%group/members
+      path: group/%group/invitations
       menu:
         type: tab
-        title: Members
-        description: ''
-        weight: 20
-        enabled: true
+        title: Invitations
+        description: 'Group invitations'
+        weight: 25
         expanded: false
         menu_name: main
         parent: ''
@@ -653,3 +801,4 @@ display:
         - user.group_permissions
       tags:
         - 'config:field.storage.group_content.group_roles'
+        - 'config:field.storage.group_content.invitee_mail'

--- a/config/sync/views.view.eic_group_pending_members.yml
+++ b/config/sync/views.view.eic_group_pending_members.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   module:
+    - eic_groups
     - grequest
     - group
     - state_machine
@@ -483,9 +484,16 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       access:
-        type: group_permission
+        type: eic_group_moderation_state_permission
         options:
           group_permission: 'administer membership requests'
+          moderation_states:
+            archived: archived
+            draft: draft
+            published: published
+            blocked: 0
+            pending: 0
+            refused: 0
       cache:
         type: none
         options: {  }

--- a/config/sync/views.view.group_invitations.yml
+++ b/config/sync/views.view.group_invitations.yml
@@ -1,6 +1,6 @@
 uuid: 6fc6b12b-b84e-4c23-9300-7f34a706dc87
 langcode: en
-status: true
+status: false
 dependencies:
   config:
     - field.storage.group_content.group_roles

--- a/lib/modules/eic_groups/eic_groups.services.yml
+++ b/lib/modules/eic_groups/eic_groups.services.yml
@@ -64,6 +64,11 @@ services:
     arguments: ['@?eic_webservices.ws_helper']
     tags:
       - { name: access_check, applies_to: _smed_group_permission_access_check }
+  eic_groups.group_views_moderation_state_permission_route_access_check:
+    class: Drupal\eic_groups\Access\GroupViewsModerationStatePermissionChecker
+    arguments: [ '@group_permission.checker.outsider_in', '@group_permission.chain_calculator' ]
+    tags:
+      - { name: access_check, applies_to: _group_views_moderation_state_permission_access_check }
   eic_groups.route_subscriber:
     class: Drupal\eic_groups\Routing\RouteSubscriber
     tags:

--- a/lib/modules/eic_groups/eic_groups.services.yml
+++ b/lib/modules/eic_groups/eic_groups.services.yml
@@ -66,7 +66,7 @@ services:
       - { name: access_check, applies_to: _smed_group_permission_access_check }
   eic_groups.group_views_moderation_state_permission_route_access_check:
     class: Drupal\eic_groups\Access\GroupViewsModerationStatePermissionChecker
-    arguments: [ '@group_permission.checker.outsider_in', '@group_permission.chain_calculator' ]
+    arguments: [ '@?group_permission.checker.outsider_in', '@?group_permission.chain_calculator' ]
     tags:
       - { name: access_check, applies_to: _group_views_moderation_state_permission_access_check }
   eic_groups.route_subscriber:

--- a/lib/modules/eic_groups/modules/eic_group_membership/eic_group_membership.module
+++ b/lib/modules/eic_groups/modules/eic_group_membership/eic_group_membership.module
@@ -497,6 +497,7 @@ function eic_group_membership_group_content_access(EntityInterface $entity, $ope
       $group = $entity->getGroup();
       $is_power_user = UserHelper::isPowerUser($account);
       $deny_moderation_states = [
+        GroupsModerationHelper::GROUP_ARCHIVED_STATE,
         GroupsModerationHelper::GROUP_BLOCKED_STATE,
         GroupsModerationHelper::GROUP_PENDING_STATE,
         GroupsModerationHelper::GROUP_REFUSED_STATE,
@@ -514,6 +515,7 @@ function eic_group_membership_group_content_access(EntityInterface $entity, $ope
       $group = $entity->getGroup();
       $is_power_user = UserHelper::isPowerUser($account);
       $deny_moderation_states = [
+        GroupsModerationHelper::GROUP_ARCHIVED_STATE,
         GroupsModerationHelper::GROUP_BLOCKED_STATE,
         GroupsModerationHelper::GROUP_PENDING_STATE,
         GroupsModerationHelper::GROUP_REFUSED_STATE,

--- a/lib/modules/eic_groups/modules/eic_group_membership/eic_group_membership.module
+++ b/lib/modules/eic_groups/modules/eic_group_membership/eic_group_membership.module
@@ -15,6 +15,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use Drupal\eic_flags\FlagType;
 use Drupal\eic_groups\EICGroupsHelper;
+use Drupal\eic_groups\GroupsModerationHelper;
 use Drupal\eic_group_membership\GroupMembershipHelper;
 use Drupal\eic_overviews\GlobalOverviewPages;
 use Drupal\eic_user\UserHelper;
@@ -492,8 +493,41 @@ function eic_group_membership_group_content_access(EntityInterface $entity, $ope
   }
 
   switch ($operation) {
+    case 'edit':
+      $group = $entity->getGroup();
+      $is_power_user = UserHelper::isPowerUser($account);
+      $deny_moderation_states = [
+        GroupsModerationHelper::GROUP_BLOCKED_STATE,
+        GroupsModerationHelper::GROUP_PENDING_STATE,
+        GroupsModerationHelper::GROUP_REFUSED_STATE,
+      ];
+      // Group is blocked or refused and therefore only power users can edit
+      // group memberships.
+      if (in_array($group->get('moderation_state')->value, $deny_moderation_states) && !$is_power_user) {
+        $access = GroupAccessResult::forbidden()
+          ->addCacheableDependency($account)
+          ->addCacheableDependency($entity)
+          ->addCacheableDependency($group);
+      }
+      break;
     case 'delete':
       $group = $entity->getGroup();
+      $is_power_user = UserHelper::isPowerUser($account);
+      $deny_moderation_states = [
+        GroupsModerationHelper::GROUP_BLOCKED_STATE,
+        GroupsModerationHelper::GROUP_PENDING_STATE,
+        GroupsModerationHelper::GROUP_REFUSED_STATE,
+      ];
+
+      // Group is blocked or refused and therefore only power users can delete
+      // group memberships.
+      if (in_array($group->get('moderation_state')->value, $deny_moderation_states) && !$is_power_user) {
+        $access = GroupAccessResult::forbidden()
+          ->addCacheableDependency($account)
+          ->addCacheableDependency($entity)
+          ->addCacheableDependency($group);
+        break;
+      }
 
       /** @var \Drupal\user\UserInterface $group_content_member */
       $group_content_member = $entity->getEntity();

--- a/lib/modules/eic_groups/src/Access/GroupViewsModerationStatePermissionChecker.php
+++ b/lib/modules/eic_groups/src/Access/GroupViewsModerationStatePermissionChecker.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Drupal\eic_groups\Access;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\group\Access\GroupPermissionAccessCheck;
+use Drupal\views\Views;
+use Symfony\Component\Routing\Route;
+
+/**
+ * Calculates group permissions + moderation state for an account.
+ */
+class GroupViewsModerationStatePermissionChecker extends GroupPermissionAccessCheck {
+
+  /**
+   * Checks access.
+   *
+   * @param \Symfony\Component\Routing\Route $route
+   *   The route to check against.
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The parametrized route.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The account to check access for.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The access result.
+   */
+  public function access(Route $route, RouteMatchInterface $route_match, AccountInterface $account) {
+    $route->setRequirement('_group_permission', $route->getRequirement('_group_views_moderation_state_permission_access_check'));
+
+    $has_access = parent::access($route, $route_match, $account);
+
+    $view_id = $route->getDefault('view_id');
+    $display_id = $route->getDefault('display_id');
+    if ($view_id && $display_id) {
+      $view = Views::getView($view_id);
+      if ($view) {
+        $view->setDisplay($display_id);
+        return $view->access($display_id) ? $has_access : AccessResult::forbidden();
+      }
+    }
+
+    return $has_access;
+  }
+
+}

--- a/lib/modules/eic_groups/src/Form/BulkGroupInvitationConfirm.php
+++ b/lib/modules/eic_groups/src/Form/BulkGroupInvitationConfirm.php
@@ -78,7 +78,7 @@ class BulkGroupInvitationConfirm extends BulkGroupInvitationConfirmBase implemen
     if ($success) {
       try {
         $tempstore = \Drupal::service('tempstore.private')->get('ginvite_bulk_invitation');
-        $destination = new Url('view.group_invitations.page_1', ['group' => $tempstore->get('params')['gid']]);
+        $destination = new Url('view.eic_group_invitations.page_1', ['group' => $tempstore->get('params')['gid']]);
         if (!$destination->access()) {
           $destination = new Url('entity.group.canonical', ['group' => $tempstore->get('params')['gid']]);
         }

--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
@@ -285,7 +285,7 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
     // Adds pending invitations URL to the group operation links.
     $group_operation_links['edit-invitations'] = [
       'title' => $this->t('Manage invitations'),
-      'url' => Url::fromRoute('view.group_invitations.page_1', ['group' => $group->id()]),
+      'url' => Url::fromRoute('view.eic_group_invitations.page_1', ['group' => $group->id()]),
     ];
 
     // We extract only the group edit/delete/publish operation links into a new

--- a/lib/modules/eic_groups/src/Plugin/views/access/EICGroupPermissionWithContentModeration.php
+++ b/lib/modules/eic_groups/src/Plugin/views/access/EICGroupPermissionWithContentModeration.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Drupal\eic_groups\Plugin\views\access;
+
+use Drupal\Core\Extension\ModuleHandler;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\Context\ContextProviderInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\eic_groups\GroupsModerationHelper;
+use Drupal\eic_user\UserHelper;
+use Drupal\group\Access\GroupPermissionHandlerInterface;
+use Drupal\group\Entity\GroupInterface;
+use Drupal\group\Plugin\views\access\GroupPermission;
+use Drupal\oec_group_features\GroupFeatureHelper;
+use Drupal\views\Annotation\ViewsAccess;
+use Drupal\views\Plugin\views\access\AccessPluginBase;
+use Drupal\workflows\WorkflowInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Routing\Route;
+
+/**
+ * Provides group moderation state + permission-based access control.
+ *
+ * @ingroup views_access_plugins
+ *
+ * @ViewsAccess(
+ *   id = "eic_group_moderation_state_permission",
+ *   title = @Translation("Group moderation state and permission"),
+ *   help = @Translation("Access will be granted if group permissions and group moderation state matched.")
+ * )
+ */
+class EICGroupPermissionWithContentModeration extends GroupPermission {
+
+  /**
+   * Constructs a Permission object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\group\Access\GroupPermissionHandlerInterface $permission_handler
+   *   The group permission handler.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler.
+   * @param \Drupal\Core\Plugin\Context\ContextProviderInterface $context_provider
+   *   The group route context.
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    GroupPermissionHandlerInterface $permission_handler,
+    ModuleHandlerInterface $module_handler,
+    ContextProviderInterface $context_provider
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $permission_handler, $module_handler, $context_provider);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('group.permissions'),
+      $container->get('module_handler'),
+      $container->get('group.group_route_context')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * Check if user has the correct permission in group and matches the allowed
+   * moderation states.
+   */
+  public function access(AccountInterface $account) {
+    if (!parent::access($account)) {
+      return FALSE;
+    }
+
+    $moderation_state = $this->group->get('moderation_state')->value;
+    return (
+      isset($this->options['moderation_states'][$moderation_state]) &&
+      $this->options['moderation_states'][$moderation_state]
+    ) || empty($this->options['moderation_states']) || UserHelper::isPowerUser($account);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterRouteDefinition(Route $route) {
+    $route->setRequirement('_group_views_moderation_state_permission_access_check', $this->options['group_permission']);
+
+    // Upcast any %group path key the user may have configured so the
+    // '_group_permission' access check will receive a properly loaded group.
+    $route->setOption('parameters', ['group' => ['type' => 'entity:group']]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildOptionsForm(&$form, FormStateInterface $form_state) {
+    parent::buildOptionsForm($form, $form_state);
+
+    /** @var WorkflowInterface $workflow */
+    $workflow = \Drupal::entityTypeManager()->getStorage('workflow')->load(GroupsModerationHelper::WORKFLOW_MACHINE_NAME);
+    $options = [];
+    foreach ($workflow->get('type_settings')['states'] as $key => $state) {
+      $options[$key] = $state['label'];
+    }
+    $form['moderation_states'] = [
+      '#type' => 'checkboxes',
+      '#options' => $options,
+      '#title' => $this->t('Allowed moderation states'),
+      '#default_value' => $this->options['moderation_states'],
+      '#description' => $this->t('The moderation states allowed to access this view.'),
+    ];
+  }
+}

--- a/lib/modules/eic_groups/src/Routing/RouteSubscriber.php
+++ b/lib/modules/eic_groups/src/Routing/RouteSubscriber.php
@@ -32,7 +32,6 @@ class RouteSubscriber extends RouteSubscriberBase {
       'entity.node.delete_form',
       'entity.group.leave',
       'entity.group.edit_form',
-      'view.eic_group_members.page_group_members',
       'ginvite.invitation.bulk',
       'entity.group.join',
       'entity.group.group_request_membership',


### PR DESCRIPTION
### Fixes

- Create custom views access plugin to restrict access to based on the group permission and moderation state;
- Apply views custom access plugin in manage members page and manage invitations page;
- Create custom view EIC Group Invitations and replace it with the default one provided by the group module.

### Test

- [x] As GO/GA, make sure you cannot access "Manage invitations" and "Manage members" pages when the group is blocked/pending/refused
- [x] Make sure you cannot edit/delete group members when the group is blocked/pending/refused/archived
- [x] Make sure you cannot access "Manage members" when the group is archived (the logic was already like this, I just improved it and used the custom views access plugin that I created)
- [x] As  SA/SCM, make sure you can always access "Manage invitations" and "Manage members" pages