### PR TITLE
EICNET-2856: Take into account the user of group prefix in the alias migration

### DIFF
--- a/lib/modules/eic_migrate/src/Plugin/migrate/source/UrlAliasToPathRedirect.php
+++ b/lib/modules/eic_migrate/src/Plugin/migrate/source/UrlAliasToPathRedirect.php
@@ -89,7 +89,12 @@ class UrlAliasToPathRedirect extends PathRedirect {
     // runtime exceptions.
     $query = $row->getSourceProperty('source_options') ?? [];
     // We assume language is always 'en'.
-    $hash = Redirect::generateHash($row->getSourceProperty('source'), $query, 'en');
+    if ($this->includeGroupPrefix) {
+      $hash = Redirect::generateHash($row->getSourceProperty('source_with_group_prefix'), $query, 'en');
+    }
+    else {
+      $hash = Redirect::generateHash($row->getSourceProperty('source'), $query, 'en');
+    }
     $redirects = $this->entityTypeManager
       ->getStorage('redirect')
       ->loadByProperties(['hash' => $hash]);


### PR DESCRIPTION
### Tests

- [x] Run `drush mim upgrade_d7_node_with_group_url_alias_to_path_redirect`
- [x] Go to `/chemistry4eu/documents/eic-x-ceficbasf-challenges` and make sure you are redirected to `/events/chemistry4eu/library/eic-x-ceficbasf-challenges`

### Deployment procedure

- Run `drush mim upgrade_d7_node_with_group_url_alias_to_path_redirect`