### PR TITLE
EICNET-2438: Always display News and Events views in Organisation GT.

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/groups/organisation.inc
+++ b/lib/themes/eic_community/includes/preprocess/groups/organisation.inc
@@ -284,29 +284,15 @@ function _eic_community_render_organisation_detail_page(&$variables, $group) {
     ];
   }
 
-  $url_add_news = Url::fromRoute(
-    'entity.group_content.create_form',
-    ['group' => $group->id(), 'plugin_id' => 'group_node:news']
-  );
-
-  $url_add_event = Url::fromRoute(
-    'entity.group_content.create_form',
-    ['group' => $group->id(), 'plugin_id' => 'group_node:event']
-  );
-
-  $render_news = _eic_community_get_rendered_view(
+  // Display the render view.
+  $variables['news'] = _eic_community_get_rendered_view(
     'organisation_content',
     'organisation_news'
   );
-
-  $render_events = _eic_community_get_rendered_view(
+  $variables['events'] = _eic_community_get_rendered_view(
     'organisation_content',
     'organisation_events'
   );
-
-  // Display the render view for some roles even if there are 0 results (so CTA to add content is shown)
-  $variables['news'] = !$url_add_news->access() && empty($render_news['#rows']) ? [] : $render_news;
-  $variables['events'] = !$url_add_event->access() && empty($render_events['#rows']) ? [] : $render_events;
 
   $view_builder = Drupal::entityTypeManager()->getViewBuilder('paragraph');
   $variables['teams'] = [


### PR DESCRIPTION
### Tests

- [x] As TU, go to to an organisation without any News or Event (e.g. `/organisations/ict4water`)
- [x] Make sure you see the empty state for each of the News and Events block
- [x] Make sure the group menu items anchors leads you to the correct blocks when clicking on News or Events