### PR TITLE
EICNET-1138: Change the link to help and guidance.

### DIFF
--- a/lib/modules/eic_content/src/Constants/HelpAndGuidance.php
+++ b/lib/modules/eic_content/src/Constants/HelpAndGuidance.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Drupal\eic_content\Constants;
+
+/**
+ * Help and Guidance section related constants.
+ */
+final class HelpAndGuidance {
+
+  /**
+   * The node ID of the top first-level page.
+   *
+   * @var int
+   */
+  const GLOBAL_PAGE_NODE_ID = 4;
+
+}

--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupOverviewMessageBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupOverviewMessageBlock.php
@@ -8,6 +8,7 @@ use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Url;
+use Drupal\eic_content\Constants\HelpAndGuidance;
 use Drupal\eic_groups\EICGroupsHelper;
 use Drupal\eic_groups\GroupsModerationHelper;
 use Drupal\group\GroupMembership;
@@ -155,7 +156,7 @@ class EICGroupOverviewMessageBlock extends BlockBase implements ContainerFactory
           '#has_content' => $has_group_content,
           '#has_member' => count($group->getMembers()) > 1,
           '#actions' => $content_operations,
-          '#help_link' => Url::fromRoute('contact.site_page')->toString(),
+          '#help_link' => Url::fromRoute('entity.node.canonical', ['node' => HelpAndGuidance::GLOBAL_PAGE_NODE_ID])->toString(),
         ];
       }
     }


### PR DESCRIPTION
### Improvements

- Created a new `Drupal\eic_content\Constants\HelpAndGuidance` class for related constants

### Tests

- [x] As TU, create a new group
- [x] As SA, approve the group (draft)
- [x] As TU, check the group homepage and make sure the link goes to Help and Guidance section (node 4)