### PR TITLE
EICNET-2882: Remove obsolete News group menu items.

### DIFF
--- a/lib/modules/eic_groups/eic_groups.install
+++ b/lib/modules/eic_groups/eic_groups.install
@@ -648,6 +648,25 @@ function eic_groups_update_9013() {
 }
 
 /**
+ * Remove obsolete News group menu items.
+ */
+function eic_groups_update_9014() {
+  /** @var \Drupal\Core\Entity\EntityTypeManagerInterface $em */
+  $em = \Drupal::service('entity_type.manager');
+
+  $menu_link_ids = \Drupal::entityQuery('menu_link_content')
+    ->condition('link__uri', 'internal:/group/%/news', 'LIKE')
+    ->condition('menu_name', 'group_menu_link_content-%', 'LIKE')
+    ->execute();
+
+  /** @var \Drupal\menu_link_content\MenuLinkContentInterface[] $menu_links */
+  $menu_links = $em->getStorage('menu_link_content')->loadMultiple($menu_link_ids);
+  $em->getStorage('menu_link_content')->delete($menu_links);
+
+  return t('Deleted @count menu items.', ['@count' => count($menu_links)]);
+}
+
+/**
  * Operation batch for publishing group wiki section.
  */
 function _eic_groups_batch_publish_group_wiki(int $progress, int $max, int $total, &$context) {

--- a/lib/modules/eic_groups/eic_groups.install
+++ b/lib/modules/eic_groups/eic_groups.install
@@ -650,7 +650,7 @@ function eic_groups_update_9013() {
 /**
  * Remove obsolete News group menu items.
  */
-function eic_groups_update_9014() {
+function eic_groups_update_9015() {
   /** @var \Drupal\Core\Entity\EntityTypeManagerInterface $em */
   $em = \Drupal::service('entity_type.manager');
 


### PR DESCRIPTION
### Tests

From a PROD dump:

- [x] As TU, go to `/events/17th-edition-eic-innovation-training` and check that you have 2 `News` group menu items
- [x] Run `drush updb -y`
- [x] Reload the event and make sure that there is only one `News` menu item left