### PR TITLE
Feature/eicnet 2894 fix notification links

### DIFF
--- a/lib/modules/eic_user/eic_user.routing.yml
+++ b/lib/modules/eic_user/eic_user.routing.yml
@@ -102,3 +102,10 @@ eic_user.get_notification_settings:
   requirements:
     notification_type: 'groups|events|organisations'
     _user_is_logged_in: 'TRUE'
+
+eic_user.anonymous.my_settings:
+  path: '/user/settings'
+  defaults:
+    _controller: '\Drupal\eic_user\Controller\UserMySettingsRedirectController::build'
+  requirements:
+    _user_is_logged_in: 'TRUE'

--- a/lib/modules/eic_user/src/Controller/UserMySettingsRedirectController.php
+++ b/lib/modules/eic_user/src/Controller/UserMySettingsRedirectController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\eic_user\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+
+/**
+ * Provides a redirect to the user settings page.
+ *
+ * @package Drupal\eic_user\Controller
+ */
+class UserMySettingsRedirectController extends ControllerBase {
+
+  /**
+   * Redirects the user to the 'My settings' page.
+   *
+   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   *   A redirect response object.
+   */
+  public function build() {
+    return $this->redirect('eic_user.my_settings', ['user' => $this->currentUser()->id()]);
+  }
+
+}

--- a/lib/themes/eic_community/includes/preprocess/mail/mail.inc
+++ b/lib/themes/eic_community/includes/preprocess/mail/mail.inc
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @file
+ * Contains mail related functions.
+ */
+
+use Drupal\Core\Url;
+
+/**
+ * Implements template_preprocess_mimemail_message().
+ */
+function eic_community_preprocess_mimemail_message(&$variables) {
+  $link = Url::fromRoute('eic_user.anonymous.my_settings', [], ['absolute' => TRUE])->toString();
+  $variables['my_settings_link'] = $link;
+}

--- a/lib/themes/eic_community/mails/mail-dist/digest.html
+++ b/lib/themes/eic_community/mails/mail-dist/digest.html
@@ -1173,7 +1173,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                        <div style="font-family:Arial;font-size:16px;line-height:1.4;text-align:center;color:#404040;"><a href="#" target="_blank" style="color:#404040; font-size: 14px">Manage notifications</a> &nbsp; | &nbsp; <a href="#" target="_blank" style="color:#404040; font-size: 14px">Unsubscribe</a></div>
+                        <div style="font-family:Arial;font-size:16px;line-height:1.4;text-align:center;color:#404040;"><a href="{{ my_settings_link }}" target="_blank" style="color:#404040; font-size: 14px">Manage notifications</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/lib/themes/eic_community/mails/mail-dist/header_footer.html
+++ b/lib/themes/eic_community/mails/mail-dist/header_footer.html
@@ -284,7 +284,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                        <div style="font-family:Arial;font-size:16px;line-height:1.4;text-align:center;color:#404040;"><a href="#" target="_blank" style="color:#404040; font-size: 14px">Manage notifications</a> &nbsp; | &nbsp; <a href="#" target="_blank" style="color:#404040; font-size: 14px">Unsubscribe</a></div>
+                        <div style="font-family:Arial;font-size:16px;line-height:1.4;text-align:center;color:#404040;"><a href="{{ my_settings_link }}" target="_blank" style="color:#404040; font-size: 14px">Manage notifications</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/lib/themes/eic_community/mails/mail-dist/layout.html
+++ b/lib/themes/eic_community/mails/mail-dist/layout.html
@@ -293,7 +293,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                        <div style="font-family:Arial;font-size:16px;line-height:1.4;text-align:center;color:#404040;"><a href="#" target="_blank" style="color:#404040; font-size: 14px">Manage notifications</a> &nbsp; | &nbsp; <a href="#" target="_blank" style="color:#404040; font-size: 14px">Unsubscribe</a></div>
+                        <div style="font-family:Arial;font-size:16px;line-height:1.4;text-align:center;color:#404040;"><a href="{{ my_settings_link }}" target="_blank" style="color:#404040; font-size: 14px">Manage notifications</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/lib/themes/eic_community/templates/mimemail/mimemail-message.html.twig
+++ b/lib/themes/eic_community/templates/mimemail/mimemail-message.html.twig
@@ -440,7 +440,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                        <div style="font-family:Arial;font-size:16px;line-height:1.4;text-align:center;color:#404040;"><a href="#" target="_blank" style="color:#404040; font-size: 14px">Manage notifications</a> &nbsp; | &nbsp; <a href="#" target="_blank" style="color:#404040; font-size: 14px">Unsubscribe</a></div>
+                        <div style="font-family:Arial;font-size:16px;line-height:1.4;text-align:center;color:#404040;"><a href="{{ my_settings_link }}" target="_blank" style="color:#404040; font-size: 14px">Manage notifications</a></div>
                       </td>
                     </tr>
                   </tbody>


### PR DESCRIPTION
### Improvements

- Created a default redirect route to My Settings page (useful when we don't know the user ID)

### Tests

- [x] As TU, make sure you have some topics of interest and that your interest notifications are enabled (/user/<uid>/settings)
- [x] As SA, create a Story with the same topic and publish it
- [x] Run cron
- [x] Make sure you receive a notification of this type sub_content_interest_published and that has a link to `<domain-name>/user/settings` when clicking on `Manage subscriptions`