### PR TITLE
EICNET-2461: Sharing content to another group should be filtered on the availability of that CT in that specific group

### DIFF
--- a/lib/modules/eic_groups/modules/eic_share_content/src/Service/ShareManager.php
+++ b/lib/modules/eic_groups/modules/eic_share_content/src/Service/ShareManager.php
@@ -42,6 +42,17 @@ class ShareManager {
   const GROUP_CONTENT_SHARED_PLUGIN_ID = 'group_shared_content';
 
   /**
+   * Node types excluded from being shared in certain group types.
+   *
+   * @var array
+   */
+  const GROUP_CONTENT_EXCLUDE_SHARE_GROUPS = [
+    'gallery' => [
+      'organisation',
+    ],
+  ];
+
+  /**
    * The EIC Groups helper.
    *
    * @var \Drupal\eic_groups\EICGroupsHelperInterface
@@ -343,6 +354,12 @@ class ShareManager {
     GroupInterface $target_group,
     array $target_group_visibility_types = [GroupVisibilityType::GROUP_VISIBILITY_PUBLIC]
   ) {
+    // Some content cannot be shared if defined in constant
+    // "GROUP_CONTENT_EXCLUDE_SHARE_GROUPS".
+    if (self::isGroupContentShareExcludedForGroupType($source_node, $target_group)) {
+      return FALSE;
+    }
+
     // Allow only published content.
     if (!$source_node->isPublished()) {
       return FALSE;
@@ -467,6 +484,30 @@ class ShareManager {
     ];
 
     $this->messageSubscribersService->sendMessage($node, $subscription, [], [], $context);
+  }
+
+  /**
+   * Checks if a node is excluded from being a group.
+   *
+   * @param \Drupal\node\NodeInterface $source_node
+   *   The node to be shared.
+   * @param \Drupal\group\Entity\GroupInterface $target_group
+   *   The target group.
+   *
+   * @return bool
+   *   TRUE if the group content cannot be shared in the group.
+   */
+  public static function isGroupContentShareExcludedForGroupType(
+    NodeInterface $source_node,
+    GroupInterface $target_group
+  ) {
+    if (
+      isset(self::GROUP_CONTENT_EXCLUDE_SHARE_GROUPS[$source_node->bundle()]) &&
+      in_array($target_group->bundle(), self::GROUP_CONTENT_EXCLUDE_SHARE_GROUPS[$source_node->bundle()])
+    ) {
+      return TRUE;
+    }
+    return FALSE;
   }
 
 }

--- a/lib/themes/eic_community/includes/preprocess/events.inc
+++ b/lib/themes/eic_community/includes/preprocess/events.inc
@@ -63,13 +63,15 @@ function _eic_community_render_event_detail_page(array &$variables, EntityInterf
 
   // Append paragraphs to the body. These paragraphs are legacy content coming
   // from the migration.
-  $full_body = $entity->field_body->value;
-  if ($entity->getEntityTypeId() == 'group' && $entity->hasField('field_additional_content')) {
-    $view_builder = \Drupal::entityTypeManager()->getViewBuilder($entity_type);
-    $additional_content = $view_builder->viewField($entity->field_additional_content);
-    $full_body .= \Drupal::service('renderer')->render($additional_content);
+  if ($entity->hasField('field_body')) {
+    $full_body = $entity->field_body->value;
+    if ($entity->getEntityTypeId() == 'group' && $entity->hasField('field_additional_content')) {
+      $view_builder = \Drupal::entityTypeManager()->getViewBuilder($entity_type);
+      $additional_content = $view_builder->viewField($entity->field_additional_content);
+      $full_body .= \Drupal::service('renderer')->render($additional_content);
+    }
+    $variables['full_body'] = $full_body;
   }
-  $variables['full_body'] = $full_body;
 
   if ($entity->bundle() !== 'event') {
     return;


### PR DESCRIPTION
### Fixes

- Exclude gallery nodes from being shared in organisations.

### Test

- [ ] As SA/SCM, go to a public group
- [ ] Make sure the group contains galleries
- [ ] Try to share a gallery with another group and make sure you cannot see/select any organisation from the dropdown list.