### PR TITLE
EICNET-2745: Closed joining method for events (Rework)

### DIFF
--- a/config/sync/group.type.event.yml
+++ b/config/sync/group.type.event.yml
@@ -11,6 +11,7 @@ third_party_settings:
     group_type_joining_method:
       tu_open_method: tu_open_method
       tu_group_membership_request: tu_group_membership_request
+      tu_close_method: tu_close_method
       group_invitation: '0'
     group_type_joining_method_override: true
 id: event

--- a/lib/modules/oec_group_flex/src/OECGroupFlexGroupSaverDecorator.php
+++ b/lib/modules/oec_group_flex/src/OECGroupFlexGroupSaverDecorator.php
@@ -368,14 +368,20 @@ class OECGroupFlexGroupSaverDecorator extends GroupFlexGroupSaver {
       ]);
     }
 
-    if ($item->getType() !== $enabled_plugin->getPluginId()) {
+    if (
+      $enabled_plugin &&
+      $item->getType() !== $enabled_plugin->getPluginId()
+    ) {
       $item->setType($enabled_plugin->getPluginId());
     }
 
     // Don't save group permissions if they didn't change.
     if (
-      $item->getType() === $enabled_plugin->getPluginId() &&
-      $groupPermission->getPermissions() == $original_permissions
+      $groupPermission->getPermissions() == $original_permissions &&
+      (
+        !$enabled_plugin ||
+        $item->getType() === $enabled_plugin->getPluginId()
+      )
     ) {
       return;
     }


### PR DESCRIPTION
### Improvements

- Enable closed joining method in Global events + Fix error when saving private groups.

### Test

- [x] As SA/SCM, edit an event
- [x] Make sure the joining method Closed can be selected
- [x] Set group visibility to private
- [x] Make sure there is no error when you save the group