### PR TITLE
EICNET-2743: [Event] rename "Sign up" with "Register" and remove erronated text

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/events.inc
+++ b/lib/themes/eic_community/includes/preprocess/events.inc
@@ -117,11 +117,9 @@ function _eic_community_render_event_detail_page(array &$variables, EntityInterf
     $signup_link = $entity->get('field_link')->uri
   ) {
     $action = [
-      'title' => t('Sign up to this event', [], ['context' => 'eic_community']),
-      'text' => t('Get notified of the latest changes and take part in the discussion linked to this event.', [],
-        ['context' => 'eic_community']),
+      'title' => t('Register to this event', [], ['context' => 'eic_community']),
       'action' => [
-        'label' => t('Sign up now', [], ['context' => 'eic_community']),
+        'label' => t('Register now', [], ['context' => 'eic_community']),
         'url' => $signup_link,
       ],
     ];

--- a/lib/themes/eic_community/patterns/components/signup.html.twig
+++ b/lib/themes/eic_community/patterns/components/signup.html.twig
@@ -1,6 +1,12 @@
 <div class="ecl-signup">
-  <h3 class="ecl-signup_title">Sign up to this event</h3>
-  <p class="ecl-signup_text">Get notified of the latest changes and take part in the discussion linked to this event.</p>
+  {% if title %}
+    <h3 class="ecl-signup_title">{{ title }}</h3>
+  {% else %}
+    <h3 class="ecl-signup_title">Sign up to this event</h3>
+  {% endif %}
+  {% if text %}
+    <p class="ecl-signup_text">{{ text }}</p>
+  {% endif %}
   <a href="{{ action.url }}" class="ecl-link ecl-link--standalone ecl-link--button ecl-link--button-primary ecl-link--button--big">
     <span class="ecl-link__label">{{ action.label }}</span>
   </a>


### PR DESCRIPTION
### Fixes

- Replace event "Sign up" section texts with "Register" and remove extra text between the sidebar title and the registration link.

### Test

- [ ] As TU, go to a global event detail page
- [ ] Make sure the sidebar section to sign up has the title "Register to this event" and a link "Register now"