### PR TITLE
EICNET-2758: [Event] No one should be allowed to comment on a draft story

### DIFF
--- a/lib/modules/eic_groups/src/Controller/DiscussionController.php
+++ b/lib/modules/eic_groups/src/Controller/DiscussionController.php
@@ -82,7 +82,7 @@ class DiscussionController extends ControllerBase {
   private ?SolrDocumentProcessor $solrDocumentProcessor;
 
   /**
-   * The EIC Content Moderation Manager.
+   * The EIC Content Moderation Helper.
    *
    * @var \Drupal\eic_moderation\ModerationHelper
    */

--- a/lib/modules/eic_groups/src/Plugin/Block/CommentsFromDiscussionBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/CommentsFromDiscussionBlock.php
@@ -94,7 +94,7 @@ class CommentsFromDiscussionBlock extends BlockBase implements ContainerFactoryP
   /**
    * The entity type manager.
    *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   private $entityTypeManager;
 
@@ -142,21 +142,21 @@ class CommentsFromDiscussionBlock extends BlockBase implements ContainerFactoryP
    *   The plugin_id for the plugin instance.
    * @param mixed $plugin_definition
    *   The plugin definition.
-   * @param EICGroupsHelper $groups_helper
+   * @param \Drupal\eic_groups\EICGroupsHelper $groups_helper
    *   The EIC groups helper service.
-   * @param GroupPermissionChecker $group_permission_checker
+   * @param \Drupal\oec_group_comments\GroupPermissionChecker $group_permission_checker
    *   The group permission checker.
-   * @param Connection $database
+   * @param \Drupal\Core\Database\Connection $database
    *   The database connection service.
-   * @param RouteMatchInterface $route_match
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
    *   The route match service.
-   * @param RequestStack $request
+   * @param \Drupal\Core\Http\RequestStack $request
    *   The current request.
-   * @param FileUrlGeneratorInterface $file_url_generator
+   * @param \Drupal\Core\File\FileUrlGeneratorInterface $file_url_generator
    *   The file url generator service.
-   * @param EditorManager $editor_manager
+   * @param \Drupal\editor\Plugin\EditorManager $editor_manager
    *   The editor manager service.
-   * @param EntityTypeManagerInterface $entity_type_manager
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The Entity type manager.
    * @param \Drupal\eic_moderation\ModerationHelper $eic_moderation_helper
    *   The EIC Content Moderation Helper.

--- a/lib/modules/eic_groups/src/Plugin/Block/CommentsFromDiscussionBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/CommentsFromDiscussionBlock.php
@@ -19,12 +19,9 @@ use Drupal\eic_content\Constants\DefaultContentModerationStates;
 use Drupal\eic_content\Services\EntityTreeManager;
 use Drupal\eic_groups\EICGroupsHelper;
 use Drupal\eic_groups\Entity\Group;
-use Drupal\eic_groups\GroupsModerationHelper;
-use Drupal\eic_moderation\Constants\EICContentModeration;
-use Drupal\eic_moderation\Service\ContentModerationManager;
+use Drupal\eic_moderation\ModerationHelper;
 use Drupal\eic_search\Search\Sources\UserTaggingCommentsSourceType;
 use Drupal\eic_user\UserHelper;
-use Drupal\file\Entity\File;
 use Drupal\group\Entity\GroupContent;
 use Drupal\group\Entity\GroupInterface;
 use Drupal\group\GroupMembership;
@@ -102,11 +99,11 @@ class CommentsFromDiscussionBlock extends BlockBase implements ContainerFactoryP
   private $entityTypeManager;
 
   /**
-   * The EIC Content Moderation Manager.
+   * The EIC Content Moderation Helper.
    *
-   * @var \Drupal\eic_moderation\Service\ContentModerationManager
+   * @var \Drupal\eic_moderation\ModerationHelper
    */
-  private $eicContentModerationManager;
+  private $eicModerationHelper;
 
   /**
    * {@inheritdoc}
@@ -129,7 +126,7 @@ class CommentsFromDiscussionBlock extends BlockBase implements ContainerFactoryP
       $container->get('file_url_generator'),
       $container->get('plugin.manager.editor'),
       $container->get('entity_type.manager'),
-      $container->get('eic_moderation.content_moderation_manager')
+      $container->get('eic_moderation.helper')
     );
   }
 
@@ -161,8 +158,8 @@ class CommentsFromDiscussionBlock extends BlockBase implements ContainerFactoryP
    *   The editor manager service.
    * @param EntityTypeManagerInterface $entity_type_manager
    *   The Entity type manager.
-   * @param \Drupal\eic_moderation\Service\ContentModerationManager $eic_content_moderation_manager
-   *   The EIC Content Moderation Manager.
+   * @param \Drupal\eic_moderation\ModerationHelper $eic_moderation_helper
+   *   The EIC Content Moderation Helper.
    */
   public function __construct(
     array $configuration,
@@ -176,7 +173,7 @@ class CommentsFromDiscussionBlock extends BlockBase implements ContainerFactoryP
     FileUrlGeneratorInterface $file_url_generator,
     EditorManager $editor_manager,
     EntityTypeManagerInterface $entity_type_manager,
-    ContentModerationManager $eic_content_moderation_manager
+    ModerationHelper $eic_moderation_helper
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->groupsHelper = $groups_helper;
@@ -187,7 +184,7 @@ class CommentsFromDiscussionBlock extends BlockBase implements ContainerFactoryP
     $this->fileUrlGenerator = $file_url_generator;
     $this->editorManager = $editor_manager;
     $this->entityTypeManager = $entity_type_manager;
-    $this->eicContentModerationManager = $eic_content_moderation_manager;
+    $this->eicModerationHelper = $eic_moderation_helper;
   }
 
   /**
@@ -307,8 +304,8 @@ class CommentsFromDiscussionBlock extends BlockBase implements ContainerFactoryP
       !UserHelper::isPowerUser($account) &&
       $node->get('moderation_state')->value === DefaultContentModerationStates::ARCHIVED_STATE;
 
-    $is_content_draft = $this->eicContentModerationManager->isDraft($node);
-    $is_content_unpublished = $this->eicContentModerationManager->isUnpublished($node);
+    $is_content_draft = $this->eicModerationHelper->isDraft($node);
+    $is_content_unpublished = $this->eicModerationHelper->isUnpublished($node);
 
     $build['#attached']['drupalSettings']['overview'] = [
       'is_group_owner' => array_key_exists(

--- a/lib/modules/eic_moderation/src/ModerationHelper.php
+++ b/lib/modules/eic_moderation/src/ModerationHelper.php
@@ -125,4 +125,79 @@ class ModerationHelper {
     return $is_archived;
   }
 
+  /**
+   * Checks if the entity is moderated and unpublished.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity.
+   *
+   * @return bool
+   *   TRUE is entity is published.
+   */
+  public function isUnpublished(ContentEntityInterface $entity): bool {
+    $is_unpublished = FALSE;
+
+    if ($workflow = $this->moderationInformation->getWorkflowForEntity($entity)) {
+      switch ($workflow->id()) {
+        case EICContentModeration::MACHINE_NAME:
+          if ($entity->get('moderation_state')->value === EICContentModeration::STATE_UNPUBLISHED) {
+            $is_unpublished = TRUE;
+          }
+          break;
+      }
+    }
+    else {
+      $check_entity = $entity;
+      if ($entity instanceof GroupContentInterface) {
+        $check_entity = $entity->getEntity();
+      }
+
+      if ($check_entity instanceof UserInterface) {
+        $is_unpublished = $check_entity->isBlocked();
+      }
+      elseif ($check_entity instanceof EntityPublishedInterface) {
+        $is_unpublished = !$check_entity->isPublished();
+      }
+    }
+
+    return $is_unpublished;
+  }
+
+  /**
+   * Checks if the entity is moderated and draft.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The content entity.
+   *
+   * @return bool
+   *   TRUE if entity is archived.
+   */
+  public function isDraft(ContentEntityInterface $entity): bool {
+    $is_draft = FALSE;
+
+    if ($workflow = $this->moderationInformation->getWorkflowForEntity($entity)) {
+      switch ($workflow->id()) {
+        case DefaultContentModerationStates::WORKFLOW_MACHINE_NAME:
+          if ($entity->get('moderation_state')->value === DefaultContentModerationStates::DRAFT_STATE) {
+            $is_draft = TRUE;
+          }
+          break;
+
+        case GroupsModerationHelper::WORKFLOW_MACHINE_NAME:
+          if ($entity->get('moderation_state')->value === GroupsModerationHelper::GROUP_DRAFT_STATE) {
+            $is_draft = TRUE;
+          }
+          break;
+
+        case EICContentModeration::MACHINE_NAME:
+          if ($entity->get('moderation_state')->value === EICContentModeration::STATE_DRAFT) {
+            $is_draft = TRUE;
+          }
+          break;
+      }
+    }
+
+    return $is_draft;
+  }
+
 }

--- a/lib/modules/eic_moderation/src/Service/ContentModerationManager.php
+++ b/lib/modules/eic_moderation/src/Service/ContentModerationManager.php
@@ -4,16 +4,10 @@ namespace Drupal\eic_moderation\Service;
 
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Entity\EntityPublishedInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\content_moderation\ModerationInformationInterface;
-use Drupal\eic_content\Constants\DefaultContentModerationStates;
-use Drupal\eic_groups\GroupsModerationHelper;
-use Drupal\eic_moderation\Constants\EICContentModeration;
-use Drupal\group\Entity\GroupContentInterface;
 use Drupal\group\Entity\GroupInterface;
-use Drupal\user\UserInterface;
 use Drupal\workflows\Transition;
 
 /**
@@ -139,118 +133,6 @@ class ContentModerationManager {
         return TRUE;
       }
     });
-  }
-
-  /**
-   * Checks if the entity is moderated and unpublished.
-   *
-   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
-   *   The entity.
-   *
-   * @return bool
-   *   TRUE is entity is published.
-   */
-  public function isUnpublished(ContentEntityInterface $entity): bool {
-    $is_unpublished = FALSE;
-
-    if ($workflow = $this->moderationInformation->getWorkflowForEntity($entity)) {
-      switch ($workflow->id()) {
-        case EICContentModeration::MACHINE_NAME:
-          if ($entity->get('moderation_state')->value === EICContentModeration::STATE_UNPUBLISHED) {
-            $is_unpublished = TRUE;
-          }
-          break;
-      }
-    }
-    else {
-      $check_entity = $entity;
-      if ($entity instanceof GroupContentInterface) {
-        $check_entity = $entity->getEntity();
-      }
-
-      if ($check_entity instanceof UserInterface) {
-        $is_unpublished = $check_entity->isBlocked();
-      }
-      elseif ($check_entity instanceof EntityPublishedInterface) {
-        $is_unpublished = !$check_entity->isPublished();
-      }
-    }
-
-    return $is_unpublished;
-  }
-
-  /**
-   * Checks if the entity is moderated and archived.
-   *
-   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
-   *   The content entity.
-   *
-   * @return bool
-   *   TRUE if entity is archived.
-   */
-  public function isArchived(ContentEntityInterface $entity): bool {
-    $is_archived = FALSE;
-
-    if ($workflow = $this->moderationInformation->getWorkflowForEntity($entity)) {
-      switch ($workflow->id()) {
-        case DefaultContentModerationStates::WORKFLOW_MACHINE_NAME:
-          if ($entity->get('moderation_state')->value === DefaultContentModerationStates::ARCHIVED_STATE) {
-            $is_archived = TRUE;
-          }
-          break;
-
-        case GroupsModerationHelper::WORKFLOW_MACHINE_NAME:
-          if ($entity->get('moderation_state')->value === GroupsModerationHelper::GROUP_ARCHIVED_STATE) {
-            $is_archived = TRUE;
-          }
-          break;
-
-        case EICContentModeration::MACHINE_NAME:
-          if ($entity->get('moderation_state')->value === EICContentModeration::STATE_UNPUBLISHED) {
-            $is_archived = TRUE;
-          }
-          break;
-      }
-    }
-
-    return $is_archived;
-  }
-
-  /**
-   * Checks if the entity is moderated and draft.
-   *
-   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
-   *   The content entity.
-   *
-   * @return bool
-   *   TRUE if entity is archived.
-   */
-  public function isDraft(ContentEntityInterface $entity): bool {
-    $is_draft = FALSE;
-
-    if ($workflow = $this->moderationInformation->getWorkflowForEntity($entity)) {
-      switch ($workflow->id()) {
-        case DefaultContentModerationStates::WORKFLOW_MACHINE_NAME:
-          if ($entity->get('moderation_state')->value === DefaultContentModerationStates::DRAFT_STATE) {
-            $is_draft = TRUE;
-          }
-          break;
-
-        case GroupsModerationHelper::WORKFLOW_MACHINE_NAME:
-          if ($entity->get('moderation_state')->value === GroupsModerationHelper::GROUP_DRAFT_STATE) {
-            $is_draft = TRUE;
-          }
-          break;
-
-        case EICContentModeration::MACHINE_NAME:
-          if ($entity->get('moderation_state')->value === EICContentModeration::STATE_DRAFT) {
-            $is_draft = TRUE;
-          }
-          break;
-      }
-    }
-
-    return $is_draft;
   }
 
 }

--- a/lib/modules/eic_moderation/src/Service/ContentModerationManager.php
+++ b/lib/modules/eic_moderation/src/Service/ContentModerationManager.php
@@ -4,10 +4,16 @@ namespace Drupal\eic_moderation\Service;
 
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityPublishedInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\content_moderation\ModerationInformationInterface;
+use Drupal\eic_content\Constants\DefaultContentModerationStates;
+use Drupal\eic_groups\GroupsModerationHelper;
+use Drupal\eic_moderation\Constants\EICContentModeration;
+use Drupal\group\Entity\GroupContentInterface;
 use Drupal\group\Entity\GroupInterface;
+use Drupal\user\UserInterface;
 use Drupal\workflows\Transition;
 
 /**
@@ -45,7 +51,6 @@ class ContentModerationManager {
   ) {
     $this->entityTypeManager = $entity_type_manager;
     $this->moderationInformation = $moderation_information;
-
   }
 
   /**
@@ -134,6 +139,118 @@ class ContentModerationManager {
         return TRUE;
       }
     });
+  }
+
+  /**
+   * Checks if the entity is moderated and unpublished.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity.
+   *
+   * @return bool
+   *   TRUE is entity is published.
+   */
+  public function isUnpublished(ContentEntityInterface $entity): bool {
+    $is_unpublished = FALSE;
+
+    if ($workflow = $this->moderationInformation->getWorkflowForEntity($entity)) {
+      switch ($workflow->id()) {
+        case EICContentModeration::MACHINE_NAME:
+          if ($entity->get('moderation_state')->value === EICContentModeration::STATE_UNPUBLISHED) {
+            $is_unpublished = TRUE;
+          }
+          break;
+      }
+    }
+    else {
+      $check_entity = $entity;
+      if ($entity instanceof GroupContentInterface) {
+        $check_entity = $entity->getEntity();
+      }
+
+      if ($check_entity instanceof UserInterface) {
+        $is_unpublished = $check_entity->isBlocked();
+      }
+      elseif ($check_entity instanceof EntityPublishedInterface) {
+        $is_unpublished = !$check_entity->isPublished();
+      }
+    }
+
+    return $is_unpublished;
+  }
+
+  /**
+   * Checks if the entity is moderated and archived.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The content entity.
+   *
+   * @return bool
+   *   TRUE if entity is archived.
+   */
+  public function isArchived(ContentEntityInterface $entity): bool {
+    $is_archived = FALSE;
+
+    if ($workflow = $this->moderationInformation->getWorkflowForEntity($entity)) {
+      switch ($workflow->id()) {
+        case DefaultContentModerationStates::WORKFLOW_MACHINE_NAME:
+          if ($entity->get('moderation_state')->value === DefaultContentModerationStates::ARCHIVED_STATE) {
+            $is_archived = TRUE;
+          }
+          break;
+
+        case GroupsModerationHelper::WORKFLOW_MACHINE_NAME:
+          if ($entity->get('moderation_state')->value === GroupsModerationHelper::GROUP_ARCHIVED_STATE) {
+            $is_archived = TRUE;
+          }
+          break;
+
+        case EICContentModeration::MACHINE_NAME:
+          if ($entity->get('moderation_state')->value === EICContentModeration::STATE_UNPUBLISHED) {
+            $is_archived = TRUE;
+          }
+          break;
+      }
+    }
+
+    return $is_archived;
+  }
+
+  /**
+   * Checks if the entity is moderated and draft.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The content entity.
+   *
+   * @return bool
+   *   TRUE if entity is archived.
+   */
+  public function isDraft(ContentEntityInterface $entity): bool {
+    $is_draft = FALSE;
+
+    if ($workflow = $this->moderationInformation->getWorkflowForEntity($entity)) {
+      switch ($workflow->id()) {
+        case DefaultContentModerationStates::WORKFLOW_MACHINE_NAME:
+          if ($entity->get('moderation_state')->value === DefaultContentModerationStates::DRAFT_STATE) {
+            $is_draft = TRUE;
+          }
+          break;
+
+        case GroupsModerationHelper::WORKFLOW_MACHINE_NAME:
+          if ($entity->get('moderation_state')->value === GroupsModerationHelper::GROUP_DRAFT_STATE) {
+            $is_draft = TRUE;
+          }
+          break;
+
+        case EICContentModeration::MACHINE_NAME:
+          if ($entity->get('moderation_state')->value === EICContentModeration::STATE_DRAFT) {
+            $is_draft = TRUE;
+          }
+          break;
+      }
+    }
+
+    return $is_draft;
   }
 
 }


### PR DESCRIPTION
### Fixes

- Hide comments block and access to block api endpoints when content is in draft or unpublished state.

### Todo

- [x] Move methods from ContentModerationManager to EICModerationHelper after the following PR has been merged #2002

### Test

- [x] As SA/SCM, create a draft News in a global event
- [x] Make sure you cannot post or reply to comments
- [x] Publish the News and make sure you can post or reply to comments now
- [x] Unpublish the News and make sure you cannot post or reply to comments
- [x] Make sure the same behaviour happens with all group content. Whenever the content is in draft, users cannot post or reply to comments.