### PR TITLE
EICNET-2637: When going to the wiki tab inside a global event the breadcrumbs say group

### DIFF
--- a/lib/modules/eic_groups/src/Breadcrumb/GroupBreadcrumbBuilder.php
+++ b/lib/modules/eic_groups/src/Breadcrumb/GroupBreadcrumbBuilder.php
@@ -228,7 +228,7 @@ class GroupBreadcrumbBuilder implements BreadcrumbBuilderInterface {
                     Link::fromTextAndUrl(
                       $this->eicGroupsHelper->getGroupBundleLabel($group, TRUE),
                       GlobalOverviewPages::getGlobalOverviewPageLink(
-                        GlobalOverviewPages::GROUPS
+                        GlobalOverviewPages::getOverviewPageIdFromGroupType($group_type)
                       )->getUrl()
                     ),
                   ]

--- a/lib/modules/eic_groups/src/Breadcrumb/GroupBreadcrumbBuilder.php
+++ b/lib/modules/eic_groups/src/Breadcrumb/GroupBreadcrumbBuilder.php
@@ -226,7 +226,7 @@ class GroupBreadcrumbBuilder implements BreadcrumbBuilderInterface {
                   0,
                   [
                     Link::fromTextAndUrl(
-                      $this->t('Groups'),
+                      $this->eicGroupsHelper->getGroupBundleLabel($group, TRUE),
                       GlobalOverviewPages::getGlobalOverviewPageLink(
                         GlobalOverviewPages::GROUPS
                       )->getUrl()

--- a/lib/modules/eic_groups/src/EICGroupsHelper.php
+++ b/lib/modules/eic_groups/src/EICGroupsHelper.php
@@ -1144,4 +1144,37 @@ class EICGroupsHelper implements EICGroupsHelperInterface {
     return $config->get('default_features') ?? [];
   }
 
+  /**
+   * Gets group bundle label.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group entity.
+   * @param bool $return_plural
+   *   Return as plural.
+   *
+   * @return string
+   *   The group label.
+   */
+  public function getGroupBundleLabel(GroupInterface $group, bool $return_plural = FALSE) {
+    $label = $group->type->entity->label();
+
+    if ($return_plural) {
+      switch ($group->bundle()) {
+        case 'group':
+          $label = $this->t('Groups');
+          break;
+
+        case 'event':
+          $label = $this->t('Events');
+          break;
+
+        case 'organisation':
+          $label = $this->t('Organisations');
+          break;
+      }
+    }
+
+    return $label;
+  }
+
 }


### PR DESCRIPTION
### Fixes

- Fix breadcrumb when viewing wiki page of a global event.

### Test

- [x] As GM, go to a wiki page of a global event
- [x] Make sure the breadcrumb shows `Home > ... > Events >` and not `Home > ... > Groups >`