### PR TITLE
EICNET-2433: Empty state of [My settings][Email notifications][Your %group_type% notifications] missing

### DIFF
--- a/lib/themes/eic_community/react/components/Block/NotifManagement/index.js
+++ b/lib/themes/eic_community/react/components/Block/NotifManagement/index.js
@@ -240,7 +240,6 @@ class Overview extends React.Component {
               })}
 
             {this.state.loading === false &&
-              this.state.searchText !== '' &&
               visibleResults.length === 0 && (
                 <tr>
                   <td


### PR DESCRIPTION
### Fixes

- Show empty message in manage email notifications page if there are no results by default.

### Test

- [x] As Tu without groups, events and organisation memberships
- [x] Go to your Email notifications settings page -> `users/<user-name>/settings`
- [x] Make sure the empty text is shown when viewing the group, event and organisation notification tabs