### PR TITLE
[EICNET-2368]chore: Display visibility label for events

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/blocks/block--eic-group-header-block.inc
+++ b/lib/themes/eic_community/includes/preprocess/blocks/block--eic-group-header-block.inc
@@ -257,6 +257,7 @@ function eic_community_preprocess_eic_group_header_block(array &$variables) {
   $tags = [];
   switch ($group->getGroupType()->id()) {
     case 'group':
+    case 'event':
       $visibility = \Drupal::service('oec_group_flex.helper')->getGroupVisibilityTagLabel($group);
       $tags[] = [
         'type' => 'display',

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/GlobalEventResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/GlobalEventResultItem.js
@@ -46,6 +46,13 @@ const GlobalEventResultItem = ({isAnonymous, result}) => {
     }];
   }
 
+  if (result.ss_group_visibility_label && result.ss_group_visibility_label.toLowerCase() !== 'public') {
+    tags = [...tags, {
+      label: result.ss_group_visibility_label,
+      id: result.ss_group_visibility_label && result.ss_group_visibility_label.toLowerCase(),
+    }];
+  }
+
   return (
     <div className={"ecl-teaser-overview__item"}>
       <div className="ecl-teaser ecl-teaser--event">


### PR DESCRIPTION
- [x] Update a global event and make it restricted
- [x] The restricted label should be display on the event's teaser in the event overview
- [x] The restricted label should be display on the group header