### PR TITLE
EICNET-2898: Validate user entity and send out custom message if not valid.

### DIFF
--- a/lib/modules/eic_webservices/src/Plugin/rest/resource/EicUserResource.php
+++ b/lib/modules/eic_webservices/src/Plugin/rest/resource/EicUserResource.php
@@ -34,6 +34,17 @@ class EicUserResource extends EicUserResourceBase {
     // Get the field name that contains the SMED ID.
     $smed_id_field = $this->configFactory->get('eic_webservices.settings')->get('smed_id_field');
 
+    // Check entity integrity.
+    $is_valid = $this->checkUserEntityIntegrity($entity);
+    if ($is_valid instanceof \Exception) {
+      // Send custom response.
+      $data = [
+        'message' => "Unprocessable Entity: validation failed. " . $is_valid->getMessage(),
+      ];
+
+      return new ResourceResponse($data, 422);
+    }
+
     // Check if user already exists.
     $user_exists = FALSE;
     if ($user = user_load_by_mail($entity->getEmail())) {

--- a/lib/modules/eic_webservices/src/Plugin/rest/resource/EicUserResourceBase.php
+++ b/lib/modules/eic_webservices/src/Plugin/rest/resource/EicUserResourceBase.php
@@ -2,7 +2,9 @@
 
 namespace Drupal\eic_webservices\Plugin\rest\resource;
 
+use Drupal\Component\Utility\EmailValidator;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\user\UserInterface;
 use Drupal\rest\Plugin\rest\resource\EntityResource;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -75,6 +77,38 @@ abstract class EicUserResourceBase extends EntityResource {
     $this->wsRestHelper->formatEntityFields($entity);
 
     return parent::patch($original_entity, $entity);
+  }
+
+  /**
+   * Check that the user entity has the required/valid information.
+   *
+   * @param \Drupal\user\UserInterface|null $entity
+   *   The user entity.
+   *
+   * @return bool|\Exception
+   *   TRUE if user entity is valid, Exception otherwise.
+   */
+  public function checkUserEntityIntegrity(UserInterface $entity = NULL) {
+    // Check if entity is null.
+    if (is_null($entity)) {
+      return new \Exception("Entity is null.");
+    }
+
+    // Check if account has an account name.
+    if (empty($entity->getAccountName())) {
+      return new \Exception("Account name is empty.");
+    }
+
+    // Check that there is email address.
+    if (empty($entity->getEmail())) {
+      return new \Exception("Email address is empty.");
+    }
+    // Check that the email address is valid.
+    elseif (!EmailValidator::isValid($entity->getEmail())) {
+      return new \Exception("Email address is not valid.");
+    }
+
+    return TRUE;
   }
 
 }


### PR DESCRIPTION
### Tests

With Postman.

- [x] Try to create a user with missing `name` value. You should get a message: `Unprocessable Entity: validation failed. Account name is empty.`
- [x] Try to create a user with missing `mail` value. You should get a message: `Unprocessable Entity: validation failed. Email address is empty.`