### PR TITLE
EICNET-2899: contact form - sent mails - the reply message from is missing some information

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8128,6 +8128,9 @@
                 },
                 "branch-alias": {
                     "dev-8.x-1.x": "1.x-dev"
+                },
+                "patches_applied": {
+                    "#3316049 - Some custom headers (Reply-To/Sender/Return-Path) are overriden by the module": "https://www.drupal.org/files/issues/2022-10-19/3316049-4-some-custom-headers-are-overriden.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -98,6 +98,9 @@
     "drupal/social_link_field": {
       "#3155628 - Limited values are randomised": "https://www.drupal.org/files/issues/2020-09-02/3155628-10.patch"
     },
+    "drupal/smtp": {
+      "#3316049 - Some custom headers (Reply-To/Sender/Return-Path) are overriden by the module": "https://www.drupal.org/files/issues/2022-10-19/3316049-4-some-custom-headers-are-overriden.patch"
+    },
     "drupal/subpathauto": {
       "3130139 - Group Content Add/Create Paths do not work": "https://www.drupal.org/files/issues/2022-02-04/group-content-add-create-3130139-11.patch"
     },

--- a/lib/modules/eic_contact/eic_contact.module
+++ b/lib/modules/eic_contact/eic_contact.module
@@ -197,3 +197,15 @@ function _eic_contact_alter_submit(
     t('Message sent with success.', [], ['context' => 'eic_contact'])
   );
 }
+
+/**
+ * Implements hook_mail_alter().
+ */
+function eic_contact_mail_alter(&$message) {
+  if ($message['id'] == 'contact_page_mail') {
+    /** @var \Drupal\user\UserInterface $sender */
+    $sender = $message['params']['sender'];
+    $message['headers']['Reply-To'] = $sender->getEmail();
+    $message['headers']['Sender'] = $sender->getEmail();
+  }
+}


### PR DESCRIPTION
### Fixes

- Apply patch to keep "Sender" and "Reply-To" headers when sending email via smtp module.

### Test

- [x] Edit the email of the contact categories and put your personal one -> `/admin/structure/taxonomy/manage/contact_category/overview`
- [x] Edit the site email and put your personal one -> `/admin/config/system/site-information`
- [x] Edit the smtp settings and add your personal email in the From email field -> `/admin/config/system/smtp`
- [x] As anonymous fill in the global contact form -> `/contact` 
- [x] Make sure the subject of the email is -> **contact-form-email-sender@...** on behalf of **Site-name** **<site-email@....>**