### PR TITLE
EICNET-2746: Relabel references to "group" with neutral labels

### DIFF
--- a/config/sync/eic_admin.action_forms.group_membership_leave.yml
+++ b/config/sync/eic_admin.action_forms.group_membership_leave.yml
@@ -3,5 +3,5 @@ paths: ''
 label: 'Group membership - Leave'
 title: 'Leave [group:title]'
 description:
-  value: "<p>You are about to leave <a href=\"[group:url]\">[group:title]</a>.</p>\r\n\r\n<p>Click the Leave group button to complete this action.</p>\r\n\r\n<p>&nbsp;</p>\r\n"
+  value: "<p>You are about to leave <a href=\"[group:url]\">[group:title]</a>.</p>\r\n\r\n<p>Click the Leave button to complete this action.</p>\r\n\r\n<p>&nbsp;</p>\r\n"
   format: full_html

--- a/lib/modules/eic_groups/modules/eic_group_membership/eic_group_membership.module
+++ b/lib/modules/eic_groups/modules/eic_group_membership/eic_group_membership.module
@@ -184,6 +184,8 @@ function eic_group_membership_form_alter(
       $new_url = Url::fromRoute('entity.group.canonical', ['group' => $group->id()]);
       $form['actions']['cancel']['#url'] = $new_url;
     }
+    // Change the title of the submit button.
+    $form['actions']['submit']['#value'] = t('Leave');
     return;
   }
 
@@ -248,6 +250,10 @@ function _eic_group_membership_handle_group_membership_form(&$form, FormStateInt
         $new_url->setOptions($old_url->getOptions());
         $form['actions']['delete']['#url'] = $new_url;
       }
+      break;
+
+    case "group_content_{$group_type}-group_membership_group-join_form":
+      $form['actions']['submit']['#value'] = t('Join');
       break;
   }
 }
@@ -580,4 +586,19 @@ function eic_group_membership_group_content_access(EntityInterface $entity, $ope
   }
 
   return $access;
+}
+
+/**
+ * Implements hook_group_operations_alter().
+ */
+function eic_group_membership_group_operations_alter(array &$operations, GroupInterface $group) {
+  if (isset($operations['group-join'])) {
+    $operations['group-join']['title'] = t('Join');
+  }
+  if (isset($operations['group-request-membership'])) {
+    $operations['group-request-membership']['title'] = t('Request membership');
+  }
+  if (isset($operations['group-leave'])) {
+    $operations['group-leave']['title'] = t('Leave');
+  }
 }

--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
@@ -313,7 +313,7 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
     if (!empty($visible_group_operation_links)) {
       $visible_group_operation_links = [
         [
-          'label' => $this->t('Group management'),
+          'label' => $this->t('Manage'),
           'links' => $visible_group_operation_links,
         ],
       ];
@@ -389,7 +389,7 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
         $link['url'] = Url::fromRoute('eic_user_login.member_access', [], $login_link_options);
         switch ($joining_methods[0]['plugin_id']) {
           case 'tu_open_method':
-            $link['title'] = $this->t('Log in to join group');
+            $link['title'] = $this->t('Log in to join');
             break;
 
           case 'tu_group_membership_request':

--- a/lib/themes/eic_community/includes/preprocess/blocks/block--eic-group-header-block.inc
+++ b/lib/themes/eic_community/includes/preprocess/blocks/block--eic-group-header-block.inc
@@ -69,7 +69,7 @@ function eic_community_preprocess_eic_group_header_block(array &$variables) {
     // Adds dropdown label if not presented.
     if (empty($variables['group_values']['group_operation_links'][0]['label'])) {
       $variables['group_values']['group_operation_links'][0]['label'] = t(
-        'Group management'
+        'Manage'
       );
     }
     // Adds dropdown icon.


### PR DESCRIPTION
### Fixes

- Update action form text for the group membership leave form;
- Update group operation label with neutral labels.

### Test

- [x] As anonymous, navigate to a public group overview page
- [x] Make sure the button to join has the label "Login to join"
- [x] As SA/SCM, change the joining method to request
- [x] As Anonymous, make sure the button to request has the label "Login to request membership"
- [x] Make sure the same labels for TUs (non-members) is "Login" and "Request membership"
- [x] As GM, make sure the group management dropdown label is "Manage"
- [x] As GM, make sure the leave button under the group management dropdown has the label "Leave"
- [x] Make sure all the previous behaviours are exactly the same in global events and organisations.