### PR TITLE
EICNET-1921: Activity stream shows undefined link for deleted content

### DIFF
--- a/lib/modules/eic_messages/eic_messages.install
+++ b/lib/modules/eic_messages/eic_messages.install
@@ -30,7 +30,7 @@ function eic_messages_update_9001(&$sandbox) {
   }
 
   $batch_builder = (new BatchBuilder())
-    ->setTitle(t('Processing Batch to modify group permissions.'))
+    ->setTitle(t('Processing Batch to delete messages with references to non-existing content.'))
     ->setFinishCallback('_eic_messages_batch_finished')
     ->setInitMessage(t('Batch is starting'))
     ->setProgressMessage(t('Processed @current out of @total.'))

--- a/lib/modules/eic_messages/eic_messages.install
+++ b/lib/modules/eic_messages/eic_messages.install
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for the EIC Messages module.
+ */
+
+module_load_include('inc', 'eic_messages', 'eic_messages.install');
+
+use Drupal\eic_messages\Util\ActivityStreamMessageTemplates;
+use Drupal\Core\Batch\BatchBuilder;
+
+/**
+ * Delete messages with references to non-existing content.
+ */
+function eic_messages_update_9001(&$sandbox) {
+  $message_storage = \Drupal::entityTypeManager()->getStorage('message');
+  $activity_stream_templates = ActivityStreamMessageTemplates::getAllowedTemplates();
+
+  $query = \Drupal::database()->select('message_field_data', 'mfd');
+  $query->fields('mfd', ['mid']);
+  $query->condition('template', $activity_stream_templates, 'IN');
+  $query->innerJoin('message__field_referenced_node', 'frn', 'frn.entity_id = mfd.mid');
+  $query->leftJoin('node', 'n', 'n.nid = frn.field_referenced_node_target_id');
+  $query->isNull('n.nid');
+  $results = $query->execute()->fetchAllAssoc('mid');
+
+  if (!$results) {
+    return;
+  }
+
+  $batch_builder = (new BatchBuilder())
+    ->setTitle(t('Processing Batch to modify group permissions.'))
+    ->setFinishCallback('_eic_messages_batch_finished')
+    ->setInitMessage(t('Batch is starting'))
+    ->setProgressMessage(t('Processed @current out of @total.'))
+    ->setErrorMessage(t('Batch has encountered an error'));
+
+  $max_messages = count($results);
+  $messages_per_batch = 100;
+  $message_chunks = array_chunk($results, $messages_per_batch, TRUE);
+  $progress = 0;
+
+  foreach ($message_chunks as $message_chunk) {
+    $batch_builder->addOperation(
+      '_eic_messages_batch_delete_messages_with_empty_references',
+      [
+        array_keys($message_chunk),
+        $progress,
+        $progress + count($message_chunk),
+        $max_messages,
+      ]
+    );
+    $progress += count($message_chunk);
+  }
+
+  batch_set($batch_builder->toArray());
+}

--- a/lib/modules/eic_messages/eic_messages.install.inc
+++ b/lib/modules/eic_messages/eic_messages.install.inc
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @file
+ * Helper install functions for the EIC Messages module.
+ */
+
+use Drupal\Core\Cache\Cache;
+use Drupal\group_permissions\Entity\GroupPermission;
+
+/**
+ * Operation batch to delete messages with references to non-existing content.
+ */
+function _eic_messages_batch_delete_messages_with_empty_references(array $message_ids, int $progress, int $max, int $total, &$context) {
+  $message_storage = \Drupal::entityTypeManager()->getStorage('message');
+  $messages = $message_storage->loadMultiple($message_ids);
+  $message_storage->delete($messages);
+
+  if ($max > $total) {
+    $max = $total;
+  }
+
+  $context['message'] = t('Removed @progress message of @total', [
+    '@progress' => $max,
+    '@total' => $total,
+  ]);
+}
+
+/**
+ * Generic function to use in batch processes.
+ */
+function _eic_messages_batch_finished($success, array $results, array $operations) {
+  if ($success) {
+    \Drupal::messenger()
+      ->addMessage(t('@count results processed.', [
+        '@count' => count($results),
+      ]));
+  }
+  else {
+    // An error occurred.
+    // $operations contains the operations that remained unprocessed.
+    $error_operation = reset($operations);
+    \Drupal::messenger()
+      ->addError(t('An error occurred while processing @operation with arguments : @args', [
+        '@operation' => $error_operation[0],
+        '@args' => print_r($error_operation[0], TRUE),
+      ]));
+  }
+}
+

--- a/lib/modules/eic_messages/eic_messages.module
+++ b/lib/modules/eic_messages/eic_messages.module
@@ -318,12 +318,3 @@ function eic_messages_eic_groups_group_predelete(array $entities) {
   $class = \Drupal::classResolver(GroupMessageCreator::class);
   $class->groupPredelete($entities);
 }
-
-/**
- * Implements hook_ENTITY_TYPE_update().
- */
-function eic_messages_node_delete(EntityInterface $entity) {
-  /** @var Drupal\eic_messages\Hooks\EntityOperations $class */
-  $class = \Drupal::classResolver(EntityOperations::class);
-  $class->nodeDelete($entity);
-}

--- a/lib/modules/eic_messages/eic_messages.module
+++ b/lib/modules/eic_messages/eic_messages.module
@@ -318,3 +318,12 @@ function eic_messages_eic_groups_group_predelete(array $entities) {
   $class = \Drupal::classResolver(GroupMessageCreator::class);
   $class->groupPredelete($entities);
 }
+
+/**
+ * Implements hook_ENTITY_TYPE_update().
+ */
+function eic_messages_node_delete(EntityInterface $entity) {
+  /** @var Drupal\eic_messages\Hooks\EntityOperations $class */
+  $class = \Drupal::classResolver(EntityOperations::class);
+  $class->nodeDelete($entity);
+}

--- a/lib/modules/eic_messages/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_messages/src/Hooks/EntityOperations.php
@@ -60,13 +60,6 @@ class EntityOperations implements ContainerInjectionInterface {
   private $currentUser;
 
   /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  private EntityTypeManagerInterface $entityTypeManager;
-
-  /**
    * Constructs a new EntityOperations object.
    *
    * @param \Drupal\content_moderation\ModerationInformationInterface $moderationInformation
@@ -75,8 +68,6 @@ class EntityOperations implements ContainerInjectionInterface {
    *   The message bus service.
    * @param \Drupal\Core\Session\AccountProxyInterface $current_user
    *   The current user.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
    */
   public function __construct(
     ModerationInformationInterface $moderationInformation,
@@ -87,7 +78,6 @@ class EntityOperations implements ContainerInjectionInterface {
     $this->moderationInformation = $moderationInformation;
     $this->messageBus = $message_bus;
     $this->currentUser = $current_user;
-    $this->entityTypeManager = $entity_type_manager;
   }
 
   /**
@@ -97,8 +87,7 @@ class EntityOperations implements ContainerInjectionInterface {
     return new static(
       $container->get('content_moderation.moderation_information'),
       $container->get('eic_messages.message_bus'),
-      $container->get('current_user'),
-      $container->get('entity_type.manager')
+      $container->get('current_user')
     );
   }
 
@@ -191,17 +180,6 @@ class EntityOperations implements ContainerInjectionInterface {
   }
 
   /**
-   * Implements hook_ENTITY_TYPE_update() for nodes.
-   */
-  public function nodeDelete(EntityInterface $entity) {
-    // Deletes related activity stream messages.
-    if ($messages = $this->getActivityStreamMessagesForNode($entity)) {
-      $this->entityTypeManager->getStorage('message')
-        ->delete($messages);
-    }
-  }
-
-  /**
    * Gets the user ID that will receive the notification about content status.
    *
    * @param \Drupal\Core\Entity\EntityInterface $entity
@@ -232,28 +210,6 @@ class EntityOperations implements ContainerInjectionInterface {
         break;
     }
     return $uid;
-  }
-
-  /**
-   * @param \Drupal\Core\Entity\EntityInterface $entity
-   *   The entity that we want to retrieve activity stream messages.
-   *
-   * @return array|\Drupal\Core\Entity\EntityInterface[]
-   *   Array of message entities.
-   */
-  private function getActivityStreamMessagesForNode(EntityInterface $entity) {
-    $messages = [];
-    if (ActivityStreamMessageTemplates::hasTemplate($entity)) {
-      $message_storage = $this->entityTypeManager->getStorage('message');
-      $activity_stream_template = ActivityStreamMessageTemplates::getTemplate($entity);
-      $query_messages = $message_storage->getQuery();
-      $query_messages->condition('template', $activity_stream_template);
-      $query_messages->condition('field_referenced_node', $entity->id());
-      if ($results = $query_messages->execute()) {
-        $messages = $message_storage->loadMultiple($results);
-      }
-    }
-    return $messages;
   }
 
 }

--- a/lib/modules/eic_messages/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_messages/src/Hooks/EntityOperations.php
@@ -72,8 +72,7 @@ class EntityOperations implements ContainerInjectionInterface {
   public function __construct(
     ModerationInformationInterface $moderationInformation,
     MessageBusInterface $message_bus,
-    AccountProxyInterface $current_user,
-    EntityTypeManagerInterface $entity_type_manager
+    AccountProxyInterface $current_user
   ) {
     $this->moderationInformation = $moderationInformation;
     $this->messageBus = $message_bus;


### PR DESCRIPTION
### Improvements

- Create hook_update to delete activity stream messages with references to non-existing content.

### Test

- [x] Import DB from PROD
- [x] Run hook_update
- [x] Make sure the activity stream messages that point to non-existing content were deleted
- [x] Try to create a discussion and post it in the activity stream
- [x] Try to update the discussion and post it in the activity stream
- [x] Go to the latest activity of the group
- [x] Make sure you have 2 items
- [x] Delete the discussion
- [x] Make sure any message related to the discussion is shown in the activity stream
- [x] Check the database table `message__field_referenced_node` to see if there is still 2 references to the deleted node
- [x] Run cron
- [x] Make sure the rows were removed from the database
