### PR TITLE
EICNET-2901: Views count in stories not working properly

### DIFF
--- a/lib/modules/eic_search/eic_search.module
+++ b/lib/modules/eic_search/eic_search.module
@@ -104,6 +104,7 @@ function eic_search_search_api_solr_documents_alter(
     foreach ($processors as $processor) {
       if ($processor->supports($fields)) {
         $processor->process($document, $fields, $items);
+        $processor->postProcess($document, $fields);
       }
     }
   }

--- a/lib/modules/eic_search/eic_search.services.yml
+++ b/lib/modules/eic_search/eic_search.services.yml
@@ -111,20 +111,27 @@ services:
     arguments: ['@eic_statistics.statistics.storage.node.decorator', '@file_url_generator', '@entity_type.manager']
     tags:
       - { name: eic_search.document_processor }
+    calls:
+      - [ setStateCache, [ '@?state' ] ]
   eic_search.document_processor_group_content:
     class: Drupal\eic_search\Search\DocumentProcessor\ProcessorGroupContent
     tags:
       - { name: eic_search.document_processor, priority: 12 }
+    calls:
+      - [ setStateCache, [ '@?state' ] ]
   eic_search.document_processor_message:
     class: Drupal\eic_search\Search\DocumentProcessor\ProcessorMessage
     arguments: ['@eic_media_statistics.entity_file_download_count', '@eic_statistics.statistics.storage.node.decorator', '@eic_comments.helper', '@flag', '@entity_type.manager', '@file_url_generator']
     tags:
       - { name: eic_search.document_processor, priority: 14 }
+    calls:
+      - [ setStateCache, [ '@?state' ] ]
   eic_search.document_processor_group:
     class: Drupal\eic_search\Search\DocumentProcessor\ProcessorGroup
     arguments: ['@eic_search.solr_search_manager', '@flag.count', '@entity_type.manager', '@file_url_generator']
     calls:
       - [ setGroupStatistics, [ '@?eic_group_statistics.helper' ] ]
+      - [ setStateCache, [ '@?state' ] ]
     tags:
       - { name: eic_search.document_processor, priority: 15 }
   eic_search.document_processor_news_story:
@@ -132,50 +139,70 @@ services:
     arguments: ['@entity_type.manager', '@file_url_generator']
     tags:
       - { name: eic_search.document_processor, priority: 16 }
+    calls:
+      - [ setStateCache, [ '@?state' ] ]
   eic_search.document_processor_discussion:
     class: Drupal\eic_search\Search\DocumentProcessor\ProcessorDiscussion
     arguments: ['@eic_statistics.helper', '@entity_type.manager', '@file_url_generator']
     tags:
       - { name: eic_search.document_processor, priority: 18 }
+    calls:
+      - [ setStateCache, [ '@?state' ] ]
   eic_search.document_processor_visibility:
     class: Drupal\eic_search\Search\DocumentProcessor\ProcessorVisibility
     arguments: ['@oec_group_flex.helper', '@eic_groups.helper']
     tags:
       - { name: eic_search.document_processor, priority: 24 }
+    calls:
+      - [ setStateCache, [ '@?state' ] ]
   eic_search.document_processor_user:
     class: Drupal\eic_search\Search\DocumentProcessor\ProcessorUser
     arguments: ['@group.membership_loader', '@eic_user.helper', '@entity_type.manager', '@database', '@eic_private_message.helper', '@file_url_generator']
     tags:
       - { name: eic_search.document_processor, priority: 26 }
+    calls:
+      - [ setStateCache, [ '@?state' ] ]
   eic_search.document_processor_document:
     class: Drupal\eic_search\Search\DocumentProcessor\ProcessorDocument
     arguments: ['@eic_media_statistics.entity_file_download_count']
     tags:
       - { name: eic_search.document_processor, priority: 20 }
+    calls:
+      - [ setStateCache, [ '@?state' ] ]
   eic_search.document_processor_flags:
     class: Drupal\eic_search\Search\DocumentProcessor\ProcessorFlags
     arguments: ['@database', '@flag.count']
     tags:
       - { name: eic_search.document_processor, priority: 22 }
+    calls:
+      - [ setStateCache, [ '@?state' ] ]
   eic_search.document_processor_group_event:
     class: Drupal\eic_search\Search\DocumentProcessor\ProcessorGroupEvent
     arguments: ['@file_url_generator']
     tags:
       - { name: eic_search.document_processor, priority: 28 }
+    calls:
+      - [ setStateCache, [ '@?state' ] ]
   eic_search.document_processor_global_event:
     class: Drupal\eic_search\Search\DocumentProcessor\ProcessorGlobalEvent
     arguments: ['@file_url_generator']
     tags:
       - { name: eic_search.document_processor, priority: 30 }
+    calls:
+      - [ setStateCache, [ '@?state' ] ]
   eic_search.document_processor_organisation:
     class: Drupal\eic_search\Search\DocumentProcessor\ProcessorOrganisation
     tags:
       - { name: eic_search.document_processor, priority: 32 }
+    calls:
+      - [ setStateCache, [ '@?state' ] ]
   eic_search.document_processor_video:
     class: Drupal\eic_search\Search\DocumentProcessor\ProcessorVideo
     arguments: ['@file_url_generator']
     tags:
       - { name: eic_search.document_processor, priority: 32 }
+    calls:
+      - [ setStateCache, [ '@?state' ] ]
   eic_search.solr_search_manager:
     class: Drupal\eic_search\Service\SolrSearchManager
     arguments: ['@current_user', '@eic_search.sources_collector', '@entity_type.manager', '@group.membership_loader', '@oec_group_flex.group_visibility.storage']

--- a/lib/modules/eic_search/src/Search/DocumentProcessor/DocumentProcessorInterface.php
+++ b/lib/modules/eic_search/src/Search/DocumentProcessor/DocumentProcessorInterface.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\eic_search\Search\DocumentProcessor;
 
+use Drupal\Core\State\StateInterface;
 use Solarium\QueryType\Update\Query\Document;
 
 /**
@@ -38,5 +39,18 @@ interface DocumentProcessorInterface {
    * @return bool
    */
   public function supports(array $fields): bool;
+
+  /**
+   * Logic that will be triggered after processing a document.
+   *
+   * @param \Solarium\QueryType\Update\Query\Document $document
+   *   The document.
+   * @param array $fields
+   *   Array of indexed fields.
+   *
+   * @return bool
+   *   TRUE if something has been processed.
+   */
+  public function postProcess(Document $document, array $fields) : bool;
 
 }

--- a/lib/modules/eic_statistics/src/Hooks/CronOperations.php
+++ b/lib/modules/eic_statistics/src/Hooks/CronOperations.php
@@ -3,6 +3,10 @@
 namespace Drupal\eic_statistics\Hooks;
 
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\State\StateInterface;
+use Drupal\eic_search\Service\SolrDocumentProcessor;
+use Drupal\eic_statistics\StatisticsHelper;
 use Drupal\eic_statistics\StatisticsStorageInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -21,13 +25,48 @@ class CronOperations implements ContainerInjectionInterface {
   protected $statisticsStorage;
 
   /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The state service.
+   *
+   * @var \Drupal\Core\State\StateInterface
+   */
+  protected $state;
+
+  /**
+   * The SOLR Document Processor service.
+   *
+   * @var \Drupal\eic_search\Service\SolrDocumentProcessor
+   */
+  protected $solrDocumentProcessor;
+
+  /**
    * Constructs a Cron object.
    *
    * @param \Drupal\eic_statistics\StatisticsStorageInterface $statistics_storage
    *   The EIC statistics storage service.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\State\StateInterface $state
+   *   The state service.
+   * @param \Drupal\eic_search\Service\SolrDocumentProcessor $solr_document_processor
+   *   The SOLR Document Processor service.
    */
-  public function __construct(StatisticsStorageInterface $statistics_storage) {
+  public function __construct(
+    StatisticsStorageInterface $statistics_storage,
+    EntityTypeManagerInterface $entity_type_manager,
+    StateInterface $state,
+    SolrDocumentProcessor $solr_document_processor
+  ) {
     $this->statisticsStorage = $statistics_storage;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->state = $state;
+    $this->solrDocumentProcessor = $solr_document_processor;
   }
 
   /**
@@ -35,7 +74,10 @@ class CronOperations implements ContainerInjectionInterface {
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('eic_statistics.storage')
+      $container->get('eic_statistics.storage'),
+      $container->get('entity_type.manager'),
+      $container->get('state'),
+      $container->get('eic_search.solr_document_processor')
     );
   }
 
@@ -44,6 +86,7 @@ class CronOperations implements ContainerInjectionInterface {
    */
   public function cron() {
     $this->updateEntityCountersStatistic();
+    $this->reindexNodeViewCountersStatistic();
   }
 
   /**
@@ -65,6 +108,22 @@ class CronOperations implements ContainerInjectionInterface {
         $this->statisticsStorage->updateEntityCounter($count, $entity_type);
       }
     }
+  }
+
+  /**
+   * Re-indexes node view counter statistics.
+   */
+  public function reindexNodeViewCountersStatistic() {
+    $node_view_counter_state_cache = $this->state->get(StatisticsHelper::NODE_VIEW_COUNTER_REINDEX_STATE_CACHE, []);
+    $this->state->delete(StatisticsHelper::NODE_VIEW_COUNTER_REINDEX_STATE_CACHE);
+    if (empty($node_view_counter_state_cache)) {
+      return;
+    }
+
+    $nodes = $this->entityTypeManager->getStorage('node')
+      ->loadMultiple($node_view_counter_state_cache);
+
+    $this->solrDocumentProcessor->reIndexEntities($nodes);
   }
 
 }

--- a/lib/modules/eic_statistics/src/NodeStatisticsDatabaseStorage.php
+++ b/lib/modules/eic_statistics/src/NodeStatisticsDatabaseStorage.php
@@ -63,6 +63,15 @@ class NodeStatisticsDatabaseStorage extends CoreNodeStatisticsDatabaseStorage {
     // Dispatch an event.
     $event = new PageViewCountUpdate($id, $page_views);
     $this->eventDispatcher->dispatch($event, PageViewCountUpdate::EVENT_NAME);
+    $node_view_counter_state_cache = $this->state->get(StatisticsHelper::NODE_VIEW_COUNTER_REINDEX_STATE_CACHE, []);
+    // The node view counter is not re-indexed everytime we view a node page.
+    // Therefore, there is a cron responsible for re-indexing the nodes at a
+    // later stage. Here we reset the state cache used in the cron so that we
+    // avoid re-indexing the entity multiple times.
+    if (!in_array($id, $node_view_counter_state_cache)) {
+      $node_view_counter_state_cache[] = $id;
+      $this->state->set(StatisticsHelper::NODE_VIEW_COUNTER_REINDEX_STATE_CACHE, $node_view_counter_state_cache);
+    }
     // On each stat update we invalidate the stat cache for the given node and all nodes (this one isn't used for the moment)
     Cache::invalidateTags(["eic_statistics:node:$id"]);
 

--- a/lib/modules/eic_statistics/src/StatisticsHelper.php
+++ b/lib/modules/eic_statistics/src/StatisticsHelper.php
@@ -19,6 +19,11 @@ use Drupal\statistics\NodeStatisticsDatabaseStorage;
 class StatisticsHelper {
 
   /**
+   * State cache name of node ids to update the view counter in SOLR.
+   */
+  const NODE_VIEW_COUNTER_REINDEX_STATE_CACHE =  'eic_statistics_reindex_node_view_counter';
+
+  /**
    * The eic_statistics.storage service.
    *
    * @var \Drupal\eic_statistics\StatisticsStorage


### PR DESCRIPTION
### Improvements

- Save node ID in a state cache whenever there is an update on the view counter so that we can re-index the node at a later stage with cron.

### Test

- [x] Create nodes News/Story/Event/Document/Gallery/Video
- [x] View the detail page of the nodes multiple times
- [x] Check that the view counter in the overview pages doesn't show the update number
- [x] Run cron
- [x] Check that the view counter in the overview pages is now showing the updated number