### PR TITLE
EICNET-2876: Group description header read more anchor is not working

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/groups/group.inc
+++ b/lib/themes/eic_community/includes/preprocess/groups/group.inc
@@ -231,6 +231,7 @@ function _group_about_group_tab($variables, &$sections) {
   }
 
   $about_items[] = [
+    'id' => 'group-description-full',
     'title' => t('Group description'),
     'content' => $group->hasField('field_body') ? $group->get('field_body')->value : '',
   ];

--- a/lib/themes/eic_community/patterns/compositions/extended-list/extended-list-item.html.twig
+++ b/lib/themes/eic_community/patterns/compositions/extended-list/extended-list-item.html.twig
@@ -1,6 +1,6 @@
 {% set item_title_element = item_title_element|default('span') %}
 
-<div class="ecl-extended-list__item {{ not items or items|length == 0 ? 'ecl-extended-list__item--has-full-layout' }} {{ extra_classes }}">
+<div class="ecl-extended-list__item {{ not items or items|length == 0 ? 'ecl-extended-list__item--has-full-layout' }} {{ extra_classes }}" {{ id ? 'id=' ~ id }}>
   {% if title %}
     <{{ item_title_element }} class="ecl-extended-list__item-title">
       {% if path is not empty %}


### PR DESCRIPTION
### Fixes

- Fix group header read more anchor.

### Test

- [x] As GM go to a group with a long description
- [x] Click on read more
- [x] Make sure you get redirected to the group about page and the page is scrolled down to the group description section