### PR TITLE
EICNET-2074: Improve method to get group content from entity

### DIFF
--- a/config/sync/context.context.book_pages.yml
+++ b/config/sync/context.context.book_pages.yml
@@ -15,10 +15,10 @@ description: ''
 requireAllConditions: false
 disabled: false
 conditions:
-  node_type:
-    id: node_type
+  'entity_bundle:node':
+    id: 'entity_bundle:node'
     negate: false
-    uuid: 6ece8dd6-40fc-4f4a-b4cc-87351d4cb228
+    uuid: 0408e437-a823-4ac3-99c3-c6f668599b36
     context_mapping:
       node: '@node.node_route_context:node'
     bundles:

--- a/config/sync/context.context.group_wiki_page.yml
+++ b/config/sync/context.context.group_wiki_page.yml
@@ -13,14 +13,6 @@ description: 'Context used when viewing group wiki pages'
 requireAllConditions: true
 disabled: false
 conditions:
-  node_type:
-    id: node_type
-    negate: false
-    uuid: 118a3ee8-d75a-43fa-8dc7-13e7c95a283f
-    context_mapping:
-      node: '@node.node_route_context:node'
-    bundles:
-      wiki_page: wiki_page
   group_type:
     id: group_type
     group_types:
@@ -30,6 +22,14 @@ conditions:
     uuid: 3fc5c7c9-452a-4dbc-be07-3532e63831ff
     context_mapping:
       group: '@group.group_route_context:group'
+  'entity_bundle:node':
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: 4d814838-6951-46b2-a5e9-8bfa0d6ea030
+    context_mapping:
+      node: '@node.node_route_context:node'
+    bundles:
+      wiki_page: wiki_page
 reactions:
   blocks:
     id: blocks

--- a/lib/modules/eic_content/modules/eic_content_book/src/Hooks/EntityOperations.php
+++ b/lib/modules/eic_content/modules/eic_content_book/src/Hooks/EntityOperations.php
@@ -78,7 +78,7 @@ class EntityOperations implements ContainerInjectionInterface {
       case 'entity.node.canonical':
         if ($entity->bundle() === 'book') {
           // Ignore book page that belongs to a group.
-          if ($this->eicContentHelper->getGroupContentByEntity($entity)) {
+          if ($this->eicContentHelper->getGroupContentByEntity($entity, [], ["group_node:{$entity->bundle()}"])) {
             return;
           }
           // Unsets book navigation since we already have that show in the

--- a/lib/modules/eic_content/modules/eic_content_book/src/Hooks/Preprocess.php
+++ b/lib/modules/eic_content/modules/eic_content_book/src/Hooks/Preprocess.php
@@ -62,7 +62,7 @@ class Preprocess implements ContainerInjectionInterface {
         if (($node = $this->routeMatch->getParameter('node'))
           && $node instanceof NodeInterface
           && $node->bundle() === 'book'
-          && !$this->eicContentHelper->getGroupContentByEntity($node)
+          && !$this->eicContentHelper->getGroupContentByEntity($node, [], ["group_node:{$node->bundle()}"])
         ) {
           unset($variables['links']['book_add_child']);
         }

--- a/lib/modules/eic_content/modules/eic_content_book/src/Plugin/Block/EICBookNavigationBlock.php
+++ b/lib/modules/eic_content/modules/eic_content_book/src/Plugin/Block/EICBookNavigationBlock.php
@@ -99,7 +99,7 @@ class EICBookNavigationBlock extends BookNavigationBlock {
     }
 
     // Ignore book page that belongs to a group.
-    if ($this->eicContentHelper->getGroupContentByEntity($node)) {
+    if ($this->eicContentHelper->getGroupContentByEntity($node, [], ["group_node:{$node->bundle()}"])) {
       return [];
     }
 

--- a/lib/modules/eic_content/src/EICContentHelperInterface.php
+++ b/lib/modules/eic_content/src/EICContentHelperInterface.php
@@ -16,10 +16,18 @@ interface EICContentHelperInterface {
    *
    * @param \Drupal\Core\Entity\ContentEntityInterface $entity
    *   An entity which may be within one or more groups.
+   * @param array $filter_group_types
+   *   Array of group types to be filtered by.
+   * @param array $filter_group_content_types
+   *   Array of group content types to be filtered by.
    *
    * @return bool|\Drupal\group\Entity\GroupContentInterface[]
    *   A list of GroupContent entities which refer to the given entity.
    */
-  public function getGroupContentByEntity(ContentEntityInterface $entity);
+  public function getGroupContentByEntity(
+    ContentEntityInterface $entity,
+    array $filter_group_types = [],
+    array $filter_group_content_types = []
+  );
 
 }

--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -278,7 +278,7 @@ function eic_groups_group_content_insert(EntityInterface $entity) {
  */
 function eic_groups_node_update(EntityInterface $entity) {
   /** @var \Drupal\group\Entity\GroupContentInterface[] $group_contents */
-  $group_contents = \Drupal::service('eic_content.helper')->getGroupContentByEntity($entity);
+  $group_contents = \Drupal::service('eic_content.helper')->getGroupContentByEntity($entity, [], ["group_node:{$entity->bundle()}"]);
 
   if (empty($group_contents)) {
     return;

--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Hooks/FormOperations.php
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Hooks/FormOperations.php
@@ -218,7 +218,7 @@ class FormOperations implements ContainerInjectionInterface {
           break;
         }
 
-        $group_contents = $this->eicContentHelper->getGroupContentByEntity($entity);
+        $group_contents = $this->eicContentHelper->getGroupContentByEntity($entity, [], ["group_node:{$entity->bundle()}"]);
         if (empty($group_contents)) {
           // If we are creating a new group content, we handle the notification
           // at a later stage because at this point we don't have the group

--- a/lib/modules/eic_messages/src/Hooks/EntityAdminUpdateNotifier.php
+++ b/lib/modules/eic_messages/src/Hooks/EntityAdminUpdateNotifier.php
@@ -90,8 +90,8 @@ class EntityAdminUpdateNotifier implements ContainerInjectionInterface {
       'field_event_executing_user' => $this->currentUser->id(),
       'field_referenced_node' => $entity,
     ];
-    
-    $group_content = $this->contentHelper->getGroupContentByEntity($entity);
+
+    $group_content = $this->contentHelper->getGroupContentByEntity($entity, [], ["group_node:{$entity->bundle()}"]);
     if (!empty($group_content)) {
       $group_content = reset($group_content);
       if ($group_content instanceof GroupContentInterface) {

--- a/lib/modules/eic_messages/src/Hooks/FormOperations.php
+++ b/lib/modules/eic_messages/src/Hooks/FormOperations.php
@@ -131,7 +131,10 @@ class FormOperations implements ContainerInjectionInterface {
     }
     // Check we are updating a node which has an associated GroupContent entity.
     if ($node = $form_state->getFormObject()->getEntity()) {
-      if (!$node->isNew() && $this->eicContentHelper->getGroupContentByEntity($node)) {
+      if (
+        !$node->isNew() &&
+        $this->eicContentHelper->getGroupContentByEntity($node, [], ["group_node:{$node->bundle()}"])
+      ) {
         $is_group_content = TRUE;
       }
     }
@@ -234,7 +237,7 @@ class FormOperations implements ContainerInjectionInterface {
 
     $group = $this->routeMatch->getParameter('group');
     if (!$group instanceof GroupInterface) {
-      $group_content = $this->eicContentHelper->getGroupContentByEntity($entity);
+      $group_content = $this->eicContentHelper->getGroupContentByEntity($entity, [], ["group_node:{$entity->bundle()}"]);
       if (empty($group_content)) {
         return;
       }

--- a/lib/modules/eic_messages/src/Service/CommentMessageCreator.php
+++ b/lib/modules/eic_messages/src/Service/CommentMessageCreator.php
@@ -115,7 +115,7 @@ class CommentMessageCreator implements ContainerInjectionInterface {
 
     /** @var \Drupal\Core\Entity\ContentEntityInterface $commented_entity */
     $commented_entity = $entity->getCommentedEntity();
-    $group_content = $this->contentHelper->getGroupContentByEntity($commented_entity);
+    $group_content = $this->contentHelper->getGroupContentByEntity($commented_entity, [], ["group_node:{$commented_entity->bundle()}"]);
     if (empty($group_content)) {
       return;
     }


### PR DESCRIPTION
### Improvements

- Refactor getGroupContentByEntity() method from EICContentHelper service.
- Refactor code using the method getGroupContentByEntity().

### Test

- [x] Create a comment in a discussion and make sure the activity stream message is generated
- [x] Make sure the message `SUBSCRIPTION :: MT18 :: New group content published` is still triggered on group content creation
- [x] Make sure the message `SUBSCRIPTION :: MT20 :: Group content updated` is still triggered on group content update
- [x] Make sure book navigation and book add links still work.