### PR TITLE
EICNET-2739: [User profile] remove confusing text

### DIFF
--- a/config/sync/field.field.profile.member.field_vocab_topic_interest.yml
+++ b/config/sync/field.field.profile.member.field_vocab_topic_interest.yml
@@ -11,7 +11,7 @@ field_name: field_vocab_topic_interest
 entity_type: profile
 bundle: member
 label: 'Topics of Interest'
-description: ''
+description: "Select your area(s) of interest.\r\nYou can select maximum 3 topics and an unlimited number of subtopics."
 required: true
 translatable: false
 default_value: {  }

--- a/lib/modules/eic_user/eic_user.module
+++ b/lib/modules/eic_user/eic_user.module
@@ -203,6 +203,14 @@ function eic_user_tokens($type, $tokens, array $data, array $options, Bubbleable
 }
 
 /**
+ * Implements hook_field_widget_WIDGET_TYPE_form_alter().
+ */
+function eic_user_field_widget_entity_tree_form_alter(&$element, FormStateInterface $form_state, $context) {
+  \Drupal::classResolver(FieldWidgetOperations::class)
+    ->fieldWidgetEntityTreeFormAlter($element, $form_state, $context);
+}
+
+/**
  * Refreshes user data in Solr and invalidate relate cache tags.
  *
  * @param \Drupal\Core\Session\AccountInterface[] $accounts

--- a/lib/modules/eic_user/src/Hooks/FieldWidgetOperations.php
+++ b/lib/modules/eic_user/src/Hooks/FieldWidgetOperations.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\eic_user\Hooks;
 
+use Drupal\Component\Serialization\Json;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\eic_helper\SocialLinksFieldHelper;
@@ -78,6 +79,27 @@ class FieldWidgetOperations implements ContainerInjectionInterface {
     }
 
     $form_state->setValue($field_name, $form_state_values);
+  }
+
+  /**
+   * Implements hook_field_widget_entity_tree_form_alter().
+   */
+  public function fieldWidgetEntityTreeFormAlter(&$element, FormStateInterface $form_state, $context) {
+    $form_build_info = $form_state->getBuildInfo();
+
+    switch ($form_build_info['form_id']) {
+      case 'user_form':
+      case 'profile_member_edit_form':
+      case 'profile_member_add_form':
+        $translations = Json::decode($element['#attributes']['data-translations']);
+        // Removes match limit label for entity tree widgets in user profile
+        // form.
+        if ($translations['data-target-bundle'] !== 'user') {
+          $translations['match_limit'] = '';
+          $element['#attributes']['data-translations'] = Json::encode($translations);
+        }
+        break;
+    }
   }
 
 }

--- a/lib/modules/eic_user/src/Hooks/FieldWidgetOperations.php
+++ b/lib/modules/eic_user/src/Hooks/FieldWidgetOperations.php
@@ -94,7 +94,10 @@ class FieldWidgetOperations implements ContainerInjectionInterface {
         $translations = Json::decode($element['#attributes']['data-translations']);
         // Removes match limit label for entity tree widgets in user profile
         // form.
-        if ($translations['data-target-bundle'] !== 'user') {
+        if (
+          !isset($translations['data-target-bundle']) ||
+          $translations['data-target-bundle'] !== 'user'
+        ) {
           $translations['match_limit'] = '';
           $element['#attributes']['data-translations'] = Json::encode($translations);
         }


### PR DESCRIPTION
### Improvements

- Remove match limit label from entity tree widget fields in user profile form.

### Test

- [x] As TU, edit your profile
- [x] Make sure the label "you can select only 25 top-level items" is no longer shown in entity tree widget fieldss.