### PR TITLE
Feature/eicnet 2928 block base64 images

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "drupal/block_field": "^1.0@RC",
         "drupal/book_link_weight": "^1.0@beta",
         "drupal/cas_mock_server": "^1.3",
+        "drupal/ckeditor_blockimagepaste": "^1.4",
         "drupal/ckeditor_div_manager": "^2.0",
         "drupal/ckeditor_find": "^1.0@beta",
         "drupal/ckeditor_font": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "82f30fa2f36a3c9471a89a5f78bcf0a9",
+    "content-hash": "aae2adc077d00821ddbec5e6f9015fc3",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1331,38 +1331,6 @@
             "time": "2022-02-19T04:09:55+00:00"
         },
         {
-            "name": "container-interop/container-interop",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/container-interop/container-interop.git",
-                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/79cbf1341c22ec75643d841642dd5d6acd83bdb8",
-                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8",
-                "shasum": ""
-            },
-            "require": {
-                "psr/container": "^1.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Interop\\Container\\": "src/Interop/Container/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
-            "homepage": "https://github.com/container-interop/container-interop",
-            "abandoned": "psr/container",
-            "time": "2017-02-14T19:40:03+00:00"
-        },
-        {
             "name": "cweagans/composer-patches",
             "version": "1.7.2",
             "source": {
@@ -2472,6 +2440,55 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/cas_mock_server",
                 "issues": "https://www.drupal.org/project/issues/cas_mock_server"
+            }
+        },
+        {
+            "name": "drupal/ckeditor_blockimagepaste",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/ckeditor_blockimagepaste.git",
+                "reference": "8.x-1.4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/ckeditor_blockimagepaste-8.x-1.4.zip",
+                "reference": "8.x-1.4",
+                "shasum": "bdcfc77bfc7bf3af0a17898e7633a3e209fd50b2"
+            },
+            "require": {
+                "drupal/ckeditor": "*",
+                "drupal/core": "^8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.4",
+                    "datestamp": "1608640688",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "askibinski",
+                    "homepage": "https://www.drupal.org/user/248999"
+                },
+                {
+                    "name": "seanB",
+                    "homepage": "https://www.drupal.org/user/545912"
+                }
+            ],
+            "description": "Adds a plugin which blocks image pasting.",
+            "homepage": "https://www.drupal.org/project/ckeditor_blockimagepaste",
+            "support": {
+                "source": "https://git.drupalcode.org/project/ckeditor_blockimagepaste"
             }
         },
         {
@@ -10035,6 +10052,89 @@
                 }
             ],
             "time": "2022-03-24T10:26:04+00:00"
+        },
+        {
+            "name": "laminas/laminas-servicemanager",
+            "version": "3.17.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-servicemanager.git",
+                "reference": "360be5f16955dd1edbcce1cfaa98ed82a17f02ec"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/360be5f16955dd1edbcce1cfaa98ed82a17f02ec",
+                "reference": "360be5f16955dd1edbcce1cfaa98ed82a17f02ec",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-stdlib": "^3.2.1",
+                "php": "~7.4.0 || ~8.0.0 || ~8.1.0",
+                "psr/container": "^1.0"
+            },
+            "conflict": {
+                "ext-psr": "*",
+                "laminas/laminas-code": "<3.3.1",
+                "zendframework/zend-code": "<3.3.1",
+                "zendframework/zend-servicemanager": "*"
+            },
+            "provide": {
+                "psr/container-implementation": "^1.0"
+            },
+            "replace": {
+                "container-interop/container-interop": "^1.2.0"
+            },
+            "require-dev": {
+                "composer/package-versions-deprecated": "^1.0",
+                "laminas/laminas-coding-standard": "~2.4.0",
+                "laminas/laminas-container-config-test": "^0.7",
+                "laminas/laminas-dependency-plugin": "^2.1.2",
+                "mikey179/vfsstream": "^1.6.10@alpha",
+                "ocramius/proxy-manager": "^2.11",
+                "phpbench/phpbench": "^1.1",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5.5",
+                "psalm/plugin-phpunit": "^0.17.0",
+                "vimeo/psalm": "^4.8"
+            },
+            "suggest": {
+                "ocramius/proxy-manager": "ProxyManager ^2.1.1 to handle lazy initialization of services"
+            },
+            "bin": [
+                "bin/generate-deps-for-config-factory",
+                "bin/generate-factory-for-class"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/autoload.php"
+                ],
+                "psr-4": {
+                    "Laminas\\ServiceManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Factory-Driven Dependency Injection Container",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "PSR-11",
+                "dependency-injection",
+                "di",
+                "dic",
+                "laminas",
+                "service-manager",
+                "servicemanager"
+            ],
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2022-09-22T11:33:46+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -20,6 +20,7 @@ module:
   cas: 0
   cas_mock_server: 0
   ckeditor: 0
+  ckeditor_blockimagepaste: 0
   ckeditor_div_manager: 0
   ckeditor_find: 0
   ckeditor_font: 0

--- a/config/sync/editor.editor.basic_text.yml
+++ b/config/sync/editor.editor.basic_text.yml
@@ -36,6 +36,8 @@ settings:
       styles: ''
     language:
       language_list: un
+    blockimagepaste:
+      block_image_paste_enabled: true
     font:
       font_names: ''
       font_sizes: ''

--- a/config/sync/editor.editor.filtered_html.yml
+++ b/config/sync/editor.editor.filtered_html.yml
@@ -64,6 +64,8 @@ settings:
       styles: ''
     language:
       language_list: un
+    blockimagepaste:
+      block_image_paste_enabled: true
     font:
       font_names: ''
       font_sizes: ''

--- a/config/sync/editor.editor.full_html.yml
+++ b/config/sync/editor.editor.full_html.yml
@@ -78,6 +78,8 @@ settings:
       styles: ''
     language:
       language_list: un
+    blockimagepaste:
+      block_image_paste_enabled: true
     font:
       font_names: ''
       font_sizes: ''


### PR DESCRIPTION
### Improvements

- Enabled a Ckeditor plugin to block direct copy/pasting of images

### Tests

- [x] As logged in user, create a content
- [x] Copy an image from your browser by right-clicking and copy image
- [x] Try to paste it in Ckeditor
- [x] Make sure you get an alter box preventing you to copy/paste the image