### PR TITLE
EICNET-2615: Add parent_group_title in the meta & OG title of nodes within a group

### DIFF
--- a/lib/modules/eic_groups/eic_groups.module
+++ b/lib/modules/eic_groups/eic_groups.module
@@ -995,3 +995,15 @@ function eic_groups_views_pre_render(ViewExecutable $view) {
 
   }
 }
+
+/**
+ * Implements hook_metatags_alter().
+ */
+function eic_groups_metatags_alter(array &$metatags, array &$context) {
+  // Includes group title in the node metatags.
+  if (\Drupal::routeMatch()->getRouteName() === 'entity.node.canonical') {
+    if($group = \Drupal::service('eic_groups.helper')->getOwnerGroupByEntity($context['entity'])) {
+      $metatags['title'] = $metatags['og_title'] = "[current-page:title] | {$group->label()} | [site:name]";
+    }
+  }
+}


### PR DESCRIPTION
### Improvements

- Include group title in node page metatags.

### Test

- [x] Go to a group content page
- [x] Make sure the metatags title and og:title contains -> `node title | group title | sitename`