### PR TITLE
EICNET-2929: Duplicated item in news and stories in the email digest

### DIFF
--- a/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Hooks/FormOperations.php
+++ b/lib/modules/eic_messages/modules/eic_message_subscriptions/src/Hooks/FormOperations.php
@@ -147,8 +147,6 @@ class FormOperations implements ContainerInjectionInterface {
       $form_state->get('form_display')
         ->getComponent('field_send_notification')
     ) {
-      // We set the current publish status of the entity.
-      $form_state->set('entity_is_published', $entity->isPublished());
       $form_state->set('previous_state', $entity->get('moderation_state')->value);
 
       if (!$entity->isNew()) {
@@ -168,6 +166,9 @@ class FormOperations implements ContainerInjectionInterface {
       ) {
         $is_new_content = TRUE;
       }
+
+      // We set the current publish status of the entity.
+      $form_state->set('entity_is_published', $is_new_content ? FALSE : $entity->isPublished());
 
       $form['field_send_notification'] = [
         '#title' => $this->t('Send notifications to members.'),
@@ -248,7 +249,7 @@ class FormOperations implements ContainerInjectionInterface {
         $event = new MessageSubscriptionEvent($entity);
 
         // Dispatch the event to trigger message subscription notification
-        // about new content published when content changes from 
+        // about new content published when content changes from
         if (
           $form_state->get('entity_is_published') === FALSE &&
           $entity->isPublished() &&


### PR DESCRIPTION
### Fixes

- Avoid triggering duplicated notification message about content of interest.

### Test

- [x] As TU, follow a topic of interest
- [x] Also make sure you have enabled the notifications about terms of interest
- [x] As SA, create a new Story with that topic and publish it
- [x] Edit the story and create a new draft
- [x] Publish the draft
- [x] Go to weekly digest test UI -> `/admin/config/eic/digest`
- [x] Select the TU, set the date for 1 week from now and trigger the weekly diggest
- [x] Make sure the TU received a notification and the story is not shown as duplicated