### PR TITLE
EICNET-2934: [Group access] Issue with groups access

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -128,7 +128,6 @@ module:
   group: 0
   group_content_menu: 0
   group_flex: 0
-  group_outsider_in: 0
   group_permissions: 0
   hal: 0
   image: 0


### PR DESCRIPTION
### Fixes

- Disable module group_outsider_in.

### Test

- [x] As TU (non-member), try to access a group detail page of a private group
- [x] Make sure you get access denied