### PR TITLE
EICNET-2749: As TU, I want a visual indication in a group I requested to join so that I can tell my request is pending

### DIFF
--- a/lib/modules/eic_groups/modules/eic_group_membership/eic_group_membership.module
+++ b/lib/modules/eic_groups/modules/eic_group_membership/eic_group_membership.module
@@ -612,10 +612,11 @@ function eic_group_membership_group_content_insert(EntityInterface $entity) {
     case 'group_membership_request':
       // Get the ID of the user that requested a membership.
       $uid = $entity->getEntity()->id();
+      $gid = $entity->getGroup()->id();
 
       // Clears the membership_request cache tag in order to update the
       // rendered output of the group header block.
-      Cache::invalidateTags(["membership_request:$uid"]);
+      Cache::invalidateTags(["membership_request:$uid:$gid"]);
       break;
 
   }

--- a/lib/modules/eic_groups/modules/eic_group_membership/eic_group_membership.module
+++ b/lib/modules/eic_groups/modules/eic_group_membership/eic_group_membership.module
@@ -610,11 +610,20 @@ function eic_group_membership_group_operations_alter(array &$operations, GroupIn
 function eic_group_membership_group_content_insert(EntityInterface $entity) {
   switch ($entity->getContentPlugin()->getPluginId()) {
     case 'group_membership_request':
-      $current_user = \Drupal::currentUser();
+      // Get the ID of the user that requested a membership.
+      $uid = $entity->getEntity()->id();
+
       // Clears the membership_request cache tag in order to update the
       // rendered output of the group header block.
-      Cache::invalidateTags(["membership_request:{$current_user->id()}"]);
+      Cache::invalidateTags(["membership_request:$uid"]);
       break;
 
   }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_update().
+ */
+function eic_group_membership_group_content_update(EntityInterface $entity) {
+  eic_group_membership_group_content_insert($entity);
 }

--- a/lib/modules/eic_groups/modules/eic_group_membership/eic_group_membership.module
+++ b/lib/modules/eic_groups/modules/eic_group_membership/eic_group_membership.module
@@ -7,6 +7,7 @@
 
 use Drupal\Component\Serialization\Json;
 use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
@@ -600,5 +601,20 @@ function eic_group_membership_group_operations_alter(array &$operations, GroupIn
   }
   if (isset($operations['group-leave'])) {
     $operations['group-leave']['title'] = t('Leave');
+  }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_insert().
+ */
+function eic_group_membership_group_content_insert(EntityInterface $entity) {
+  switch ($entity->getContentPlugin()->getPluginId()) {
+    case 'group_membership_request':
+      $current_user = \Drupal::currentUser();
+      // Clears the membership_request cache tag in order to update the
+      // rendered output of the group header block.
+      Cache::invalidateTags(["membership_request:{$current_user->id()}"]);
+      break;
+
   }
 }

--- a/lib/modules/eic_groups/src/EICGroupsHelper.php
+++ b/lib/modules/eic_groups/src/EICGroupsHelper.php
@@ -459,10 +459,7 @@ class EICGroupsHelper implements EICGroupsHelperInterface {
 
       // Retrieve the operations from the installed content plugins and merges
       // cacheable metadata.
-      if (
-        !is_null($cacheable_metadata) &&
-        $plugin->getEntityTypeId() === 'user'
-      ) {
+      if (!is_null($cacheable_metadata)) {
         // $cacheable_metadata = $cacheable_metadata->merge($plugin->getGroupOperationsCacheableMetadata());
       }
     }

--- a/lib/modules/eic_groups/src/EICGroupsHelper.php
+++ b/lib/modules/eic_groups/src/EICGroupsHelper.php
@@ -459,7 +459,10 @@ class EICGroupsHelper implements EICGroupsHelperInterface {
 
       // Retrieve the operations from the installed content plugins and merges
       // cacheable metadata.
-      if (!is_null($cacheable_metadata)) {
+      if (
+        !is_null($cacheable_metadata) &&
+        $plugin->getEntityTypeId() === 'user'
+      ) {
         // $cacheable_metadata = $cacheable_metadata->merge($plugin->getGroupOperationsCacheableMetadata());
       }
     }
@@ -1229,6 +1232,21 @@ class EICGroupsHelper implements EICGroupsHelperInterface {
     }
 
     return $label;
+  }
+
+  /**
+   * Gets the enabled joining method for a given group.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group entity.
+   *
+   * @return string
+   *   The joining method plugin id.
+   */
+  public function getGroupJoiningMethod(GroupInterface $group) {
+    $joining_methods = $this->oecGroupFlexHelper->getGroupJoiningMethod($group);
+    $joining_method = reset($joining_methods);
+    return $joining_method['plugin_id'];
   }
 
 }

--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
@@ -281,7 +281,6 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
             'value' => 'disabled',
             ],
           ],
-          'disabled' => TRUE,
         ];
       }
     }

--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
@@ -266,7 +266,7 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
 
     $joining_method = $this->eicGroupsHelper->getGroupJoiningMethod($group);
     if ($joining_method === 'tu_group_membership_request') {
-      $cacheable_metadata->addCacheTags(["membership_request:{$this->currentUser->id()}"]);
+      $cacheable_metadata->addCacheTags(["membership_request:{$this->currentUser->id()}:{$group->id()}"]);
 
       // Shows the "Request sent" button if the user already request group membership.
       if (!$membership && $has_sent_membership_request) {

--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
@@ -268,10 +268,10 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
     if ($joining_method === 'tu_group_membership_request') {
       $cacheable_metadata->addCacheTags(["membership_request:{$this->currentUser->id()}"]);
 
-      // Shows the "Request sent" button if the user already request group membership.
+      // Shows the "Pending approval" button if the user already request group membership.
       if (!$membership && $has_sent_membership_request) {
         $operation_links[] = [
-          'title' => $this->t('Request sent', [], ['context' => 'eic_groups']),
+          'title' => $this->t('Pending approval', [], ['context' => 'eic_groups']),
           'url' => Url::fromRoute('<nolink>'),
           'weight' => 0,
         ];

--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
@@ -274,6 +274,14 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
           'title' => $this->t('Pending approval', [], ['context' => 'eic_groups']),
           'url' => Url::fromRoute('<nolink>'),
           'weight' => 0,
+          'variant' => 'ghost',
+          'extra_attributes' => [
+            [
+            'name' => 'disabled',
+            'value' => 'disabled',
+            ],
+          ],
+          'disabled' => TRUE,
         ];
       }
     }

--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
@@ -264,17 +264,18 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
       }
     }
 
-    // Shows the "Request sent" button.
-    if (
-      !$membership &&
-      $this->eicGroupsHelper->getGroupJoiningMethod($group) &&
-      $has_sent_membership_request
-    ) {
-      $operation_links[] = [
-        'title' => $this->t('Request sent', [], ['context' => 'eic_groups']),
-        'url' => Url::fromRoute('<nolink>'),
-        'weight' => 0,
-      ];
+    $joining_method = $this->eicGroupsHelper->getGroupJoiningMethod($group);
+    if ($joining_method === 'tu_group_membership_request') {
+      $cacheable_metadata->addCacheTags(["membership_request:{$this->currentUser->id()}"]);
+
+      // Shows the "Request sent" button if the user already request group membership.
+      if (!$membership && $has_sent_membership_request) {
+        $operation_links[] = [
+          'title' => $this->t('Request sent', [], ['context' => 'eic_groups']),
+          'url' => Url::fromRoute('<nolink>'),
+          'weight' => 0,
+        ];
+      }
     }
 
     // Gather all the group content creation links to create a two dimensional

--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
@@ -236,6 +236,7 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
       ];
     }
 
+    $has_sent_membership_request = TRUE;
     // Moves group joining methods operations to the operation_links array.
     foreach ($user_operation_links as $key => $action) {
       if (in_array($action['url']->getRouteName(),
@@ -247,6 +248,9 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
         unset($user_operation_links[$key]);
         // We discard the operation link if user doesn't have access to it.
         if ($action['url']->access($this->currentUser)) {
+          if ($action['url']->getRouteName() === 'entity.group.group_request_membership') {
+            $has_sent_membership_request = FALSE;
+          }
           // We add the current page URL as destination so that the user will
           // be redirected back to the current page after joining the group.
           $action['url']->setOption('query',
@@ -258,6 +262,19 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
           $operation_links[$key] = $action;
         }
       }
+    }
+
+    // Shows the "Request sent" button.
+    if (
+      !$membership &&
+      $this->eicGroupsHelper->getGroupJoiningMethod($group) &&
+      $has_sent_membership_request
+    ) {
+      $operation_links[] = [
+        'title' => $this->t('Request sent', [], ['context' => 'eic_groups']),
+        'url' => Url::fromRoute('<nolink>'),
+        'weight' => 0,
+      ];
     }
 
     // Gather all the group content creation links to create a two dimensional

--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
@@ -271,7 +271,7 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
       // Shows the "Request sent" button if the user already request group membership.
       if (!$membership && $has_sent_membership_request) {
         $operation_links[] = [
-          'title' => $this->t('Request sent', [], ['context' => 'eic_groups']),
+          'title' => $this->t('Pending approval', [], ['context' => 'eic_groups']),
           'url' => Url::fromRoute('<nolink>'),
           'weight' => 0,
         ];

--- a/lib/modules/oec_group_flex/oec_group_flex.module
+++ b/lib/modules/oec_group_flex/oec_group_flex.module
@@ -176,6 +176,17 @@ function oec_group_flex_views_data() {
 }
 
 /**
+ * Implements hook_group_content_info_alter().
+ */
+function oec_group_flex_group_content_info_alter(array &$definitions) {
+  // Overrides the standard group invitation plugin class provided by
+  // ginvite module.
+  if (isset($definitions['group_membership_request'])) {
+    $definitions['group_membership_request']['class'] = '\Drupal\oec_group_flex\Plugin\GroupContentEnabler\GroupMembershipRequest';
+  }
+}
+
+/**
  * Implements hook_group_flex_visibility_save().
  */
 function oec_group_flex_group_flex_visibility_save(

--- a/lib/modules/oec_group_flex/oec_group_flex.services.yml
+++ b/lib/modules/oec_group_flex/oec_group_flex.services.yml
@@ -25,3 +25,14 @@ services:
   oec_group_flex.helper:
     class: Drupal\oec_group_flex\OECGroupFlexHelper
     arguments: [ '@group_flex.group', '@plugin.manager.group_visibility', '@plugin.manager.group_joining_method', '@plugin.manager.custom_restricted_visibility', '@oec_group_flex.group_visibility.storage' ]
+
+  access_check.oec_group_flex.group_membership_request_access_check:
+    class: Drupal\oec_group_flex\Access\GroupMembershipRequestAccessChecker
+    arguments: [ '@oec_group_flex.helper' ]
+    tags:
+      - { name: access_check, applies_to: _group_membership_request_access_check }
+
+  oec_group_flex.route_subscriber:
+    class: Drupal\oec_group_flex\Routing\RouteSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/lib/modules/oec_group_flex/src/Access/GroupMembershipRequestAccessChecker.php
+++ b/lib/modules/oec_group_flex/src/Access/GroupMembershipRequestAccessChecker.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Drupal\oec_group_flex\Access;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Routing\Access\AccessInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\group\Entity\GroupInterface;
+use Drupal\oec_group_flex\OECGroupFlexHelper;
+use Symfony\Component\Routing\Route;
+
+/**
+ * Checks if passed parameter matches the route configuration.
+ *
+ * @DCG
+ * To make use of this access checker add '_group_membership_request_access_check: Some value' entry to route
+ * definition under requirements section.
+ */
+class GroupMembershipRequestAccessChecker implements AccessInterface {
+
+  /**
+   * The OEC Group Flex Helper.
+   *
+   * @var \Drupal\oec_group_flex\OECGroupFlexHelper
+   */
+  protected $oecGroupFlexHelper;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(OECGroupFlexHelper $oec_group_flex_helper) {
+    $this->oecGroupFlexHelper = $oec_group_flex_helper;
+  }
+
+  /**
+   * Access callback.
+   *
+   * @param \Symfony\Component\Routing\Route $route
+   *   The route to check against.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The current user account.
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group entity.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The access result.
+   */
+  public function access(Route $route, AccountInterface $account, GroupInterface $group) {
+    return AccessResult::allowedIf(
+      $group->access('view', $account) &&
+      !$this->oecGroupFlexHelper->getMembershipRequest($account, $group)
+    )
+    ->addCacheableDependency($group)
+    ->addCacheableDependency($account);
+  }
+
+}

--- a/lib/modules/oec_group_flex/src/Plugin/GroupContentEnabler/GroupMembershipRequest.php
+++ b/lib/modules/oec_group_flex/src/Plugin/GroupContentEnabler/GroupMembershipRequest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Drupal\oec_group_flex\Plugin\GroupContentEnabler;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\group\Entity\GroupInterface;
+use Drupal\grequest\Plugin\GroupContentEnabler\GroupMembershipRequest as GroupMembershipRequestBase;
+use Drupal\oec_group_flex\OECGroupFlexHelper;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Overrides plugin 'group_membership_request'.
+ */
+class GroupMembershipRequest extends GroupMembershipRequestBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The OEC Group Flex Helper.
+   *
+   * @var \Drupal\oec_group_flex\OECGroupFlexHelper
+   */
+  protected $oecGroupFlexHelper;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    OECGroupFlexHelper $oec_group_flex_helper
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->oecGroupFlexHelper = $oec_group_flex_helper;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('oec_group_flex.helper')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getGroupOperations(GroupInterface $group) {
+    $account = \Drupal::currentUser();
+    $operations = [];
+    $url = $group->toUrl('group-request-membership');
+    if(
+      $url->access($account) &&
+      !$this->oecGroupFlexHelper->getMembershipRequest($account, $group)
+    ){
+      $operations['group-request-membership'] = [
+        'title' => $this->t('Request group membership'),
+        'url' => $url,
+        'weight' => 99,
+      ];
+    }
+
+    return $operations;
+  }
+
+}

--- a/lib/modules/oec_group_flex/src/Routing/RouteSubscriber.php
+++ b/lib/modules/oec_group_flex/src/Routing/RouteSubscriber.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Drupal\oec_group_flex\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Drupal\Core\Routing\RoutingEvents;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * OEC Group Flex route subscriber.
+ */
+class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+    if ($group_membership_route = $collection->get('entity.group.group_request_membership')) {
+      $group_membership_route->setRequirement('_group_membership_request_access_check', 'TRUE');
+    }
+  }
+
+}

--- a/lib/themes/eic_community/includes/preprocess/blocks/block--eic-group-header-block.inc
+++ b/lib/themes/eic_community/includes/preprocess/blocks/block--eic-group-header-block.inc
@@ -121,8 +121,12 @@ function eic_community_preprocess_eic_group_header_block(array &$variables) {
         'link' => [
           'label' => $link['title'],
           'path' => $link['url'],
+          'variant' => $link['variant'] ?? NULL,
+          'extra_attributes' => $link['extra_attributes'] ?? NULL,
         ],
       ];
+
+
 
       if (isset($link['action'])) {
         $tmp = array_merge($tmp, $link['action']);

--- a/lib/themes/eic_community/patterns/compositions/editorial-header.html.twig
+++ b/lib/themes/eic_community/patterns/compositions/editorial-header.html.twig
@@ -92,7 +92,8 @@
                               path: icon_file_path,
                               size: 's',
                             }) : {},
-                            extra_classes: (action.type == 'cta' ? 'ecl-link ecl-link--cta' : 'ecl-link--button ecl-link--' ~ (action.variant == 'secondary' ? 'button-secondary' : 'button-primary')) ~ (action.is_compact ? ' ecl-link--button-has-icon-layout ecl-link--action'),
+                            extra_attributes: extra_attributes|default(action.link.extra_attributes),
+                            extra_classes: (action.type == 'cta' ? 'ecl-link ecl-link--cta' : 'ecl-link--button ecl-link--' ~ (action.variant|default(action.link.variant) ? 'button-' ~ action.variant|default(action.link.variant) : 'button-primary')) ~ (action.is_compact ? ' ecl-link--button-has-icon-layout ecl-link--action' : ''),
                           }) only %}
 												{% elseif action is not empty %}
 													{% if action.link %}


### PR DESCRIPTION
### Improvements

- Prevent users from accessing group_membership_request group when there is already an opened or pending request.

### Todo

- We need to work on the Front end styles when the button changes from "Request membership" to "Request sent". Currently it has the same look and feel but we should show it as if it was disabled (grey background)

### Test

- [x] As SA, create a public group and set the joining method to "Request"
- [x] As TU, go to the group overview page
- [x] Make sure you see the button "Request membership"
- [x] Click on "Request membership" and confirm your request
- [x] Make sure you have been redirected to the group overview page and you see the button "Request sent"
- [x] As SA, go to the list of membership requests of the group -> `/groups/<group-name>/members-pending`
- [x] Reject the membership request from the TU
- [x] As the TU, make sure you can see the button "Request membership" and also make sure you are able to request group membership again