### PR TITLE
Feature/eicnet 2920 cancel user account

### DIFF
--- a/lib/modules/eic_admin/eic_admin.module
+++ b/lib/modules/eic_admin/eic_admin.module
@@ -19,3 +19,18 @@ function eic_admin_preprocess_views_view_field(&$vars) {
     $vars['field']->last_render = $flag_label;
   }
 }
+
+/**
+ * Implements hook_module_implements_alter().
+ */
+function eic_admin_module_implements_alter(&$implementations, $hook) {
+  if (\Drupal::service('module_handler')->moduleExists('oe_authentication')) {
+    switch ($hook) {
+      // OE Authentication module is removing some cancel methods.
+      // Prevent this by removing this implementation.
+      case 'user_cancel_methods_alter':
+        unset($implementations['oe_authentication']);
+        break;
+    }
+  }
+}

--- a/lib/modules/eic_groups/src/Hooks/CronOperations.php
+++ b/lib/modules/eic_groups/src/Hooks/CronOperations.php
@@ -206,6 +206,7 @@ class CronOperations implements ContainerInjectionInterface {
 
           $query = $this->entityTypeManager->getStorage('group_content')->getQuery();
           $query->condition('type', $installedContentPluginIds, 'IN');
+          $query->condition('gid', $group->id());
           $results = $query->execute();
 
           if (!empty($results)) {

--- a/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorMessage.php
+++ b/lib/modules/eic_search/src/Search/DocumentProcessor/ProcessorMessage.php
@@ -201,7 +201,10 @@ class ProcessorMessage extends DocumentProcessor {
         $language instanceof TermInterface ? $language->label() : NULL
       );
 
-      $user_follows = $this->getFollowUidByFlag('follow_user', $message->getOwner());
+      $user_follows = [];
+      if ($message->getOwner()) {
+        $user_follows = $this->getFollowUidByFlag('follow_user', $message->getOwner());
+      }
       $node_follows = $this->getFollowUidByFlag('follow_content', $node);
       $group_follows = [];
       $node_group_id = array_key_exists('its_group_id', $fields) ? $fields['its_group_id'] : NULL;


### PR DESCRIPTION
### Improvements

- Added a condition to avoid re-indexing all group_content aliases when we should only do it for the given group

### Tests

- [x] Log in a SA/SCM (not DA)
- [x] Go to `/admin/people`
- [x] Select some users, select "Cancel the selected user accounts" option and click "Apply to selected items"
- [x] Make sure you have the 2 delete options on the form:
![EICNET-2920](https://user-images.githubusercontent.com/5821299/200322786-da176c2e-c8d4-47c2-a8f1-40295bf1fb9d.png)
