### PR TITLE
EICNET-2924: Add missing 'edit memberships' permission.

### DIFF
--- a/lib/modules/eic_groups/eic_groups.install
+++ b/lib/modules/eic_groups/eic_groups.install
@@ -713,6 +713,56 @@ function eic_groups_update_9015() {
 }
 
 /**
+ * Add missing edit memberships permissions.
+ */
+function eic_groups_update_9016(&$sandbox) {
+  $batch_builder = (new BatchBuilder())
+    ->setTitle(t('Processing Batch to modify group permissions.'))
+    ->setFinishCallback('_eic_groups_batch_finished')
+    ->setInitMessage(t('Batch is starting'))
+    ->setProgressMessage(t('Processed @current out of @total.'))
+    ->setErrorMessage(t('Batch has encountered an error'));
+
+  $group_permissions = \Drupal::entityQuery('group_permission')
+    ->execute();
+
+  $max_groups = count($group_permissions);
+  $groups_per_batch = 100;
+
+  $internal_roles = [
+    'group-owner',
+    'group-admin',
+    'event-owner',
+    'event-admin',
+    'organisation-owner',
+    'organisation-admin',
+  ];
+  $external_roles = [
+    UserHelper::ROLE_DRUPAL_ADMINISTRATOR,
+    UserHelper::ROLE_SITE_ADMINISTRATOR,
+    UserHelper::ROLE_CONTENT_ADMINISTRATOR,
+  ];
+
+  for ($progress = 0; $progress < $max_groups; $progress += $groups_per_batch) {
+    $batch_builder->addOperation(
+      '_eic_groups_batch_modify_group_permissions',
+      [
+        ['edit memberships'],
+        $internal_roles,
+        $external_roles,
+        'add',
+        [],
+        $progress,
+        $progress + $groups_per_batch,
+        $max_groups,
+      ]
+    );
+  }
+
+  batch_set($batch_builder->toArray());
+}
+
+/**
  * Operation batch for publishing group wiki section.
  */
 function _eic_groups_batch_publish_group_wiki(int $progress, int $max, int $total, &$context) {


### PR DESCRIPTION
### Tests

- [ ] Run `drush updb -y`
- [ ] Go to `/groups/eic-community-training/permissions`
- [ ] Make sure following roles have the "Edit memberships" permission: Admin | Owner | Drupal admin (Outsider) | Content administrator (Outsider)