### PR TITLE
EICNET-2949: Enable 2FA with EUlogin - Do NOT merge before 20/12/2022

### DIFF
--- a/config/sync/oe_authentication.settings.yml
+++ b/config/sync/oe_authentication.settings.yml
@@ -5,3 +5,4 @@ register_path: eim/external/register.cgi
 validation_path: TicketValidationService
 assurance_level: TOP
 ticket_types: 'SERVICE,PROXY'
+force_2fa: true


### PR DESCRIPTION
we will enable 2FA for EU Login at that date!