### PR TITLE
Release/0.49.4 - HotFix - disable overwiting of smtp sender field.

### DIFF
--- a/lib/modules/eic_contact/eic_contact.module
+++ b/lib/modules/eic_contact/eic_contact.module
@@ -206,6 +206,7 @@ function eic_contact_mail_alter(&$message) {
     /** @var \Drupal\user\UserInterface $sender */
     $sender = $message['params']['sender'];
     $message['headers']['Reply-To'] = $sender->getEmail();
-    $message['headers']['Sender'] = $sender->getEmail();
+//  The sender cannot be from another domain than the domain/server sending the mail.
+//    $message['headers']['Sender'] = $sender->getEmail();
   }
 }


### PR DESCRIPTION
Issue EICNET-2899: AWS SES is now checking if it can send emails in name of the sender domain