### PR TITLE
[EICNET-2955]fix: If no joining method available for event, do not show empty box

### DIFF
--- a/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
+++ b/lib/modules/eic_groups/src/Plugin/Block/EICGroupHeaderBlock.php
@@ -399,7 +399,9 @@ class EICGroupHeaderBlock extends BlockBase implements ContainerFactoryPluginInt
         }
       }
     }
-    return $link;
+
+    // If no title has been set, that means no available join method.
+    return array_key_exists('title', $link) ? $link : [];
   }
 
   /**


### PR DESCRIPTION
- [ ] Set an event as closed joining method and "public" visibility
- [ ] Go on the event page as anonymous
- [ ] Be sure you do not have empty box in the header

![image](https://github.com/EIC-EA/EIC-community-D8/assets/11585507/eb9a68da-466a-4bfb-b739-0b6e65c22209)
