### PR TITLE
[EICNET-2967]fix: allow trusted user if membership of group download sensitive

### DIFF
--- a/lib/modules/eic_media/modules/eic_media_statistics/src/Controller/MediaFileDownloadController.php
+++ b/lib/modules/eic_media/modules/eic_media_statistics/src/Controller/MediaFileDownloadController.php
@@ -108,7 +108,11 @@ class MediaFileDownloadController extends DownloadController {
     $user = User::load($this->currentUser()->id());
 
     // Do not allow downloading file if group sensitive and user no role sensitive.
-    if ($this->groupsHelper->isGroupSensitive($group) && !$user->hasRole(UserHelper::ROLE_SENSITIVE)) {
+    if (
+      $this->groupsHelper->isGroupSensitive($group) &&
+      !$user->hasRole(UserHelper::ROLE_SENSITIVE) &&
+      !$group->getMember($user)
+    ) {
       throw new AccessDeniedHttpException(t('You are not allowed to download a sensitive content.'));
     }
 


### PR DESCRIPTION
Allow membership of sensitive group downloading contents.