### PR TITLE
EICNET-2845: Relabel restricted stories to private.

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/layout/page.inc
+++ b/lib/themes/eic_community/includes/preprocess/layout/page.inc
@@ -147,15 +147,15 @@ function _preprocess_node_page(&$variables) {
         /* @todo Missing follow author flag when user is logged in. */
 
         $publish_date_format = 'd F Y';
-        $is_restricted = $node->private->value === '1';
+        $is_private = $node->private->value === '1';
         $tag = [
           'type' => 'display',
-          'label' => $is_restricted ? t('Restricted') : t('Public'),
+          'label' => $is_private ? t('Private') : t('Public'),
         ];
         $variables['editorial_header'] = [
           'tags' => [
             [
-              'extra_classes' => 'ecl-tag--is-' . ($is_restricted ? 'restricted' : 'public'),
+              'extra_classes' => 'ecl-tag--is-' . ($is_private ? 'private' : 'public'),
               'tag' => $tag,
             ],
           ],

--- a/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/StoryResultItem.js
+++ b/lib/themes/eic_community/react/components/Block/Overview/Search/ResultItem/StoryResultItem.js
@@ -8,7 +8,7 @@ export default function StoryResultItem(props) {
   const date = new Date(props.result.ss_global_created_date);
   const initials = props.result.ss_global_fullname.split(' ', 2);
   const itemUrl = url(props.result.ss_url)
-  const visibilityClass = props.result.bs_is_restricted ? 'restricted' : 'public';
+  const visibilityClass = props.result.bs_is_restricted ? 'private' : 'public';
   const visibilityLabel = props.translations[visibilityClass];
 
   return <div className="ecl-teaser-overview__item ">


### PR DESCRIPTION
### Tests

- [ ] Run `make build-front`
- [ ] `drush cr`
- [ ] Create a new story and check _"Only visible to community members"_
- [ ] Go to the Story detail page and make sure it is labelled "Private" with a red background
- [ ] Go to the Story overview page and make sure it is labelled "Private" with a red background