### PR TITLE
[EICNET-2903]feat: Do not show blocked or removed user in email digest

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/content/message.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/message.inc
@@ -9,6 +9,7 @@ use Drupal\eic_user\UserHelper;
 use Drupal\message\MessageInterface;
 use Drupal\node\NodeInterface;
 use Drupal\user\Entity\User;
+use Drupal\user\UserInterface;
 
 /**
  * Implements hook_preprocess_message().
@@ -163,12 +164,21 @@ function _eic_community_preprocess_digest_message(&$variables) {
   $action = $action . ' ' . $suffix;
   $default_avatar = $variables['eic_mail_images_path'] . '/user_circle.png';
 
-  $variables['content'] = [
-    'user' => [
+  $user = NULL;
+
+  if (
+    $user instanceof UserInterface &&
+    !$user->isBlocked()
+  ) {
+    $user = [
       'full_name' => \Drupal::service('eic_user.helper')->getFullName($user),
       'profile_picture' => !$user->get('field_media')->isEmpty() ? UserHelper::getUserAvatar($user) : $default_avatar,
       'url' => $user->toUrl()->toString(),
-    ],
+    ];
+  }
+
+  $variables['content'] = [
+    'user' => $user,
     'group_suffix' => $group_suffix,
     'action' => t($action),
     'entity' => $entity,

--- a/lib/themes/eic_community/templates/message/message--notify-digest.html.twig
+++ b/lib/themes/eic_community/templates/message/message--notify-digest.html.twig
@@ -11,8 +11,9 @@
             <tbody>
             <tr>
               <td style="direction:ltr;font-size:0px;padding:15px 10px 15px;text-align:center;">
-                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="550px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:530px;" width="530" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-                <div style="margin:0px auto;max-width:530px;">
+                {% if content.user %}
+                    <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="550px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:530px;" width="530" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+                    <div style="margin:0px auto;max-width:530px;">
                   <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                     <tbody>
                     <tr>
@@ -86,6 +87,7 @@
                     </tbody>
                   </table>
                 </div>
+                {% endif %}
                 <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="550px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:530px;" width="530" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
                 <div style="margin:0px auto;max-width:530px;">
                   <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">


### PR DESCRIPTION
- [ ] Create a content in a group with a certain user
- [ ] Block this user
- [ ] Go to Test digest UI (/admin/config/eic/digest)
- [ ] Run digest for a user that is in the group and will receive the node created by a user
- [ ] Verify that you cannot see anymore the header with user on mail notification

![image](https://github.com/EIC-EA/EIC-community-D8/assets/11585507/be6bb750-41bc-4c60-ac82-3945e97388a4)
