### PR TITLE
Release 1.51.2 - HF3 - fixing public access for groups / events + registration url

### DIFF
--- a/web/sites/default/default.settings.k8s.php
+++ b/web/sites/default/default.settings.k8s.php
@@ -164,6 +164,12 @@ $config['eic_user_login.settings']['endpoint_url'] = getenv('SMED_USERCHECK_URL'
 $config['eic_user_login.settings']['basic_auth_username'] = getenv('SMED_USERCHECK_USERNAME');
 $config['eic_user_login.settings']['basic_auth_password'] = getenv('SMED_USERCHECK_PASSWORD');
 $config['eic_user_login.settings']['api_key'] = getenv('SMED_USERCHECK_API_KEY');
+/**
+ * SMED User registration .
+ */
+if ($user_registration_url = getenv('SMED_USER_REGISTRATION_URL')) {
+  $config['eic_user_login.settings']['user_registration_url']  = $user_registration_url;
+}
 
 /**
  * SMED API connection information.


### PR DESCRIPTION
- [[EICINFRA-877](https://github.com/EIC-EA/EIC-community-D8/pull/2148/commits/b1c48685c12a7753c4aad09ab939d67cb9c4ade2)] - set registration url via environment parameter
- [[EICNET-2977](https://citnet.tech.ec.europa.eu/CITnet/jira/browse/EICNET-2977)] - newly created  events / groups are not accessible 
  [EIC-EA/hotfix/EICNET-readd-permissions](https://github.com/EIC-EA/EIC-community-D8/pull/2148/commits/3e1df06e80d0354f2858cac9f6dc7cde995be51f)