### PR TITLE
EICNET-2883: Also logged in users (trusted) should see the content of public and restricted groups

### DIFF
--- a/config/sync/group.role.group-outsider.yml
+++ b/config/sync/group.role.group-outsider.yml
@@ -14,3 +14,10 @@ permissions_ui: true
 permissions:
   - 'share content between groups'
   - 'view group'
+  - 'view group_node:book entity'
+  - 'view group_node:discussion entity'
+  - 'view group_node:document entity'
+  - 'view group_node:event entity'
+  - 'view group_node:gallery entity'
+  - 'view group_node:video entity'
+  - 'view group_node:wiki_page entity'


### PR DESCRIPTION
should see content of the group when visiting the group page (discussions, documents, events, gallery, video, wiki) in "Public" and "Restricted" groups.