### PR TITLE
Revert "EICNET-2915: Remove member profile related job title."

### DIFF
--- a/config/sync/core.entity_form_display.profile.member.default.yml
+++ b/config/sync/core.entity_form_display.profile.member.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.profile.member.field_location_address
     - field.field.profile.member.field_social_links
     - field.field.profile.member.field_vocab_geo
+    - field.field.profile.member.field_vocab_job_title
     - field.field.profile.member.field_vocab_language
     - field.field.profile.member.field_vocab_topic_expertise
     - field.field.profile.member.field_vocab_topic_interest
@@ -76,6 +77,12 @@ content:
       target_bundles: {  }
       is_required: false
       has_error: 0
+    third_party_settings: {  }
+  field_vocab_job_title:
+    type: options_buttons
+    weight: 9
+    region: content
+    settings: {  }
     third_party_settings: {  }
   field_vocab_language:
     type: options_buttons

--- a/config/sync/core.entity_view_display.profile.member.default.yml
+++ b/config/sync/core.entity_view_display.profile.member.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.profile.member.field_location_address
     - field.field.profile.member.field_social_links
     - field.field.profile.member.field_vocab_geo
+    - field.field.profile.member.field_vocab_job_title
     - field.field.profile.member.field_vocab_language
     - field.field.profile.member.field_vocab_topic_expertise
     - field.field.profile.member.field_vocab_topic_interest
@@ -69,6 +70,14 @@ content:
       link: true
     third_party_settings: {  }
     weight: 3
+    region: content
+  field_vocab_job_title:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 8
     region: content
   field_vocab_language:
     type: entity_reference_label

--- a/config/sync/field.field.profile.member.field_vocab_job_title.yml
+++ b/config/sync/field.field.profile.member.field_vocab_job_title.yml
@@ -1,0 +1,29 @@
+uuid: ae361fda-e4dc-43c3-827c-cf7f3173cf69
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.profile.field_vocab_job_title
+    - profile.type.member
+    - taxonomy.vocabulary.job_titles
+id: profile.member.field_vocab_job_title
+field_name: field_vocab_job_title
+entity_type: profile
+bundle: member
+label: 'Job title'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      job_titles: job_titles
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.storage.profile.field_vocab_job_title.yml
+++ b/config/sync/field.storage.profile.field_vocab_job_title.yml
@@ -1,0 +1,20 @@
+uuid: 0b9255d7-c8d0-4fcf-9f0f-090774f4254b
+langcode: en
+status: true
+dependencies:
+  module:
+    - profile
+    - taxonomy
+id: profile.field_vocab_job_title
+field_name: field_vocab_job_title
+entity_type: profile
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/search_api.index.global.yml
+++ b/config/sync/search_api.index.global.yml
@@ -53,6 +53,7 @@ dependencies:
     - field.storage.node.field_video_media
     - field.storage.profile.field_body
     - field.storage.profile.field_location_address
+    - field.storage.profile.field_vocab_job_title
     - field.storage.profile.field_vocab_language
     - field.storage.profile.field_social_links
     - field.storage.profile.field_vocab_geo

--- a/lib/themes/eic_community/includes/preprocess/users/user.inc
+++ b/lib/themes/eic_community/includes/preprocess/users/user.inc
@@ -75,6 +75,7 @@ function eic_community_preprocess_user(array &$variables) {
         'title' => \Drupal::service('eic_user.helper')->getFullName($user),
         'description' => _eic_community_get_user_profile_body($user, $member_profile),
         'type' => _eic_community_get_user_type($user, $member_profile),
+        'job_titles' => _eic_community_get_user_job_titles($user, $member_profile),
         'image' => _get_profile_image_array($user),
         'meta' => [],
       ];
@@ -493,6 +494,47 @@ function _eic_community_get_user_profile_body(UserInterface $account, ProfileInt
       'description' => $member_profile->get('field_body')->value,
     ],
   ];
+}
+
+/**
+ * Returns the 'render' array to use in templates for the user job titles.
+ *
+ * @param \Drupal\user\UserInterface $account
+ *   The user account for which we want to get the job titles.
+ * @param \Drupal\profile\Entity\ProfileInterface $member_profile
+ *   (optional) The user profile entity associated with user account.
+ *
+ * @return array
+ *   The render array for templates.
+ */
+function _eic_community_get_user_job_titles(UserInterface $account, ProfileInterface $member_profile = NULL) {
+  $member_profile = $member_profile ?? \Drupal::service('eic_user.helper')->getUserMemberProfile($account);
+
+  // If we don't have a member profile for this user, skip.
+  if (empty($member_profile)) {
+    return [];
+  }
+
+  // If the member profile doesn't have job titles, skip.
+  if ($member_profile->get('field_vocab_job_title')->isEmpty()) {
+    return [];
+  }
+
+  $job_titles = [];
+  /** @var \Drupal\taxonomy\Entity\Term[] $job_titles */
+  $job_titles_terms = $member_profile->get('field_vocab_job_title')->referencedEntities();
+  // Adds each fact and figure to the theme variables.
+  foreach ($job_titles_terms as $job_title) {
+    $job_title_translation = \Drupal::service('entity.repository')
+      ->getTranslationFromContext($job_title, $account->language()->getId());
+    // @todo Add missing organisations.
+    $job_titles[] = [
+      'label' => $job_title_translation->getName(),
+      'items' => [],
+    ];
+  }
+
+  return $job_titles;
 }
 
 /**


### PR DESCRIPTION
Reverts EIC-EA/EIC-community-D8#2047  
We need the "job title" field on the user level - because some users are not affiliated with an organisation / company.

after this , we probably need to make read only and visible only when filled via the webservice