### PR TITLE
EICNET-3000: Rephrase username in teaser for anonymous user so we hav…

### DIFF
--- a/lib/themes/eic_community/includes/preprocess/content/node--discussion.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--discussion.inc
@@ -130,5 +130,10 @@ function _preprocess_discussion_teaser(&$variables, $discussion_type, $node) {
     ];
   }
 
+  // Privacy information, if current user is anonymous remove the author.
+  if (\Drupal::currentUser()->isAnonymous()) {
+    $teaser['author'] =  NULL;
+  }
+
   $variables['discussion_item'] = $teaser;
 }

--- a/lib/themes/eic_community/includes/preprocess/content/node--document.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--document.inc
@@ -43,6 +43,11 @@ function eic_community_preprocess_node__document(array &$variables) {
         $variables['#attached']['library'][] = 'flag/flag.link_ajax';
       }
 
+      // Privacy information, if current user is anonymous remove the author.
+      if (\Drupal::currentUser()->isAnonymous()) {
+        $teaser['author'] =  NULL;
+      }
+
       $variables['document_item'] = $teaser;
       break;
 

--- a/lib/themes/eic_community/includes/preprocess/content/node--event.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--event.inc
@@ -45,6 +45,11 @@ function eic_community_preprocess_node__event(array &$variables) {
         }
       }
 
+      // Privacy information, if current user is anonymous remove the author.
+      if (\Drupal::currentUser()->isAnonymous()) {
+        $teaser['author'] =  NULL;
+      }
+
       // Get the start date of the event.
       $start_date = 0;
       $end_date = 0;

--- a/lib/themes/eic_community/includes/preprocess/content/node--gallery.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--gallery.inc
@@ -152,6 +152,11 @@ function eic_community_preprocess_node__gallery(array &$variables) {
         $teaser['flags'] = [];
       }
 
+      // Privacy information, if current user is anonymous remove the author.
+      if (\Drupal::currentUser()->isAnonymous()) {
+        $teaser['author'] =  NULL;
+      }
+
       $teaser['images'] = $images;
       $teaser['type'] = [
         'label' => $node->type->entity->label(),

--- a/lib/themes/eic_community/includes/preprocess/content/node--news--story.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--news--story.inc
@@ -115,7 +115,7 @@ function _eic_community_preprocess_node_news_story(array &$variables) {
 
     // Privacy information, if current user is anonymous remove the author.
     if (\Drupal::currentUser()->isAnonymous()) {
-      $item['author'] =  NULL;
+      $item['author'] = NULL;
     }
   }
 

--- a/lib/themes/eic_community/includes/preprocess/content/node--news--story.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--news--story.inc
@@ -112,6 +112,11 @@ function _eic_community_preprocess_node_news_story(array &$variables) {
     }
 
     $variables['stats'] = $stats;
+
+    // Privacy information, if current user is anonymous remove the author.
+    if (\Drupal::currentUser()->isAnonymous()) {
+      $item['author'] =  NULL;
+    }
   }
 
   $variables['story_item'] = $item;

--- a/lib/themes/eic_community/includes/preprocess/content/node--video.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--video.inc
@@ -69,6 +69,11 @@ function eic_community_preprocess_node__video(array &$variables) {
         $teaser['flags'] = [];
       }
 
+      // Privacy information, if current user is anonymous remove the author.
+      if (\Drupal::currentUser()->isAnonymous()) {
+        $teaser['author'] =  NULL;
+      }
+
       // If we have flags, attach the js library.
       if (!empty($teaser['flags'])) {
         $variables['#attached']['library'][] = 'flag/flag.link_ajax';

--- a/lib/themes/eic_community/includes/preprocess/content/node--wiki.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--wiki.inc
@@ -38,7 +38,6 @@ function eic_community_preprocess_node__wiki_page(array &$variables) {
     case 'mail_teaser':
     case 'teaser':
       $teaser = _eic_community_prepare_node_teaser_array($node);
-      //  TODO:
       $teaser['description'] = Unicode::truncate(strip_tags($node->get('field_body')->value), 300, TRUE, TRUE);
       $teaser['type'] = [
         'label' => $node->type->entity->label(),
@@ -51,7 +50,7 @@ function eic_community_preprocess_node__wiki_page(array &$variables) {
       // Remove unwanted items.
       $teaser['stats'] = [];
 
-      // Privacy information. If current user is anonymous remove the author.
+      // Privacy information, if current user is anonymous remove the author.
       if (\Drupal::currentUser()->isAnonymous()) {
         $teaser['author'] =  NULL;
       }

--- a/lib/themes/eic_community/includes/preprocess/content/node--wiki.inc
+++ b/lib/themes/eic_community/includes/preprocess/content/node--wiki.inc
@@ -38,6 +38,7 @@ function eic_community_preprocess_node__wiki_page(array &$variables) {
     case 'mail_teaser':
     case 'teaser':
       $teaser = _eic_community_prepare_node_teaser_array($node);
+      //  TODO:
       $teaser['description'] = Unicode::truncate(strip_tags($node->get('field_body')->value), 300, TRUE, TRUE);
       $teaser['type'] = [
         'label' => $node->type->entity->label(),
@@ -49,6 +50,11 @@ function eic_community_preprocess_node__wiki_page(array &$variables) {
 
       // Remove unwanted items.
       $teaser['stats'] = [];
+
+      // Privacy information. If current user is anonymous remove the author.
+      if (\Drupal::currentUser()->isAnonymous()) {
+        $teaser['author'] =  NULL;
+      }
 
       $variables['story_item'] = $teaser;
       break;

--- a/lib/themes/eic_community/includes/preprocess/groups/group.inc
+++ b/lib/themes/eic_community/includes/preprocess/groups/group.inc
@@ -95,6 +95,11 @@ function eic_community_preprocess_group__group(array &$variables) {
       // @todo Get the real last activity.
       $item['timestamp']['label'] = eic_community_get_teaser_time_display($group->get('changed')->value);
 
+      // Privacy information, if current user is anonymous remove the author.
+      if (\Drupal::currentUser()->isAnonymous()) {
+        $item['owner'] =  NULL;
+      }
+
       // Get group statistics.
       $group_statistics = \Drupal::service('eic_group_statistics.helper')->loadGroupStatistics($group);
       $item['stats'] = [

--- a/lib/themes/eic_community/includes/preprocess/users/user.inc
+++ b/lib/themes/eic_community/includes/preprocess/users/user.inc
@@ -287,8 +287,11 @@ function _get_profile_image_array(EntityInterface $user, $relative_url = TRUE): 
  * @throws \Drupal\Core\TypedData\Exception\MissingDataException
  */
 function eic_community_get_teaser_user_display(UserInterface $user, $picture_image_style = 'crop_36x36') {
+  $current_user = \Drupal::currentUser();
+
+  // Privacy information. If current user is anonymous set user to 'Someone'.
   $author = [
-    'name' => $user->getDisplayName(),
+    'name' => $current_user->isAnonymous() ? t('Someone') : $user->getDisplayName(),
   ];
 
   // We add the user profile page URL if the current user has access to it.
@@ -296,7 +299,6 @@ function eic_community_get_teaser_user_display(UserInterface $user, $picture_ima
     $author['path'] = $user->toUrl()->toString();
   }
 
-  $current_user = \Drupal::currentUser();
   if (!$user->get('field_media')->isEmpty() && !$current_user->isAnonymous()) {
     $media_entity = $user->get('field_media')->entity;
     if ($media_entity) {

--- a/lib/themes/eic_community/includes/preprocess/views.inc
+++ b/lib/themes/eic_community/includes/preprocess/views.inc
@@ -327,6 +327,11 @@ function _eic_community_preprocess_views__latest_news_and_stories__homepage(&$va
       'stats' => $stats,
     ];
 
+    // Privacy information, if current user is anonymous remove the author.
+    if (\Drupal::currentUser()->isAnonymous()) {
+      $item['author'] =  NULL;
+    }
+
     if (!$node_translation->get('field_image')->isEmpty()) {
       /** @var \Drupal\media\Entity\Media $media */
       $media = \Drupal::service('entity.repository')->getTranslationFromContext($node_translation->get('field_image')->entity, $current_langcode);

--- a/lib/themes/eic_community/includes/preprocess/views.inc
+++ b/lib/themes/eic_community/includes/preprocess/views.inc
@@ -329,7 +329,7 @@ function _eic_community_preprocess_views__latest_news_and_stories__homepage(&$va
 
     // Privacy information, if current user is anonymous remove the author.
     if (\Drupal::currentUser()->isAnonymous()) {
-      $item['author'] =  NULL;
+      $item['author'] = NULL;
     }
 
     if (!$node_translation->get('field_image')->isEmpty()) {


### PR DESCRIPTION
Rephrase username to "Someone" for anonymous users so we have some elevated information privacy.

The topics pages had a full list of the following CTs in the teaser view-modes:

1. discussion
2. news & stories
3. group type: Group
4. Wiki
5. Documents
6. Video
7. Gallery
