### PR TITLE
EICNET-2729: Create a default custom ordering for Organisations members.

### DIFF
--- a/config/sync/context.context.group_members_overviews.yml
+++ b/config/sync/context.context.group_members_overviews.yml
@@ -23,13 +23,14 @@ reactions:
     id: blocks
     uuid: 52968c87-7333-4284-a1e0-68f19e8ed28d
     blocks:
-      6b8e8018-5a77-4a11-a3cc-3df82e28a314:
-        uuid: 6b8e8018-5a77-4a11-a3cc-3df82e28a314
+      89627531-455e-4e3c-87c1-09ee56341cb4:
+        uuid: 89627531-455e-4e3c-87c1-09ee56341cb4
         id: eic_search_overview
         label: ''
         provider: eic_search
         label_display: visible
         region: content
+        weight: '0'
         custom_id: eic_search_overview_group_members
         theme: eic_community
         css_class: ''
@@ -49,6 +50,7 @@ reactions:
           sm_roles_group: sm_roles_group
           sm_user_profile_job_string: 0
         sort_options:
+          team_default_sort: team_default_sort
           its_activity_score_group: its_activity_score_group
           ds_user_access: ds_user_access
           score: score

--- a/lib/modules/eic_search/src/Search/Sources/UserGallerySourceType.php
+++ b/lib/modules/eic_search/src/Search/Sources/UserGallerySourceType.php
@@ -15,6 +15,11 @@ class UserGallerySourceType extends SourceType {
   use StringTranslationTrait;
 
   /**
+   * This is used as a token for the team sort machine name.
+   */
+  const TEAM_DEFAULT_SORT = 'team_default_sort';
+
+  /**
    * @inheritDoc
    */
   public function getSourcesId(): array {
@@ -55,6 +60,10 @@ class UserGallerySourceType extends SourceType {
    */
   public function getAvailableSortOptions(): array {
     return [
+      self::TEAM_DEFAULT_SORT => [
+        'label' => $this->t('Organisation team default sort', [], ['context' => 'eic_search']),
+        'ASC' => $this->t('Default', [], ['context' => 'eic_search']),
+      ],
       DocumentProcessorInterface::SOLR_MOST_ACTIVE_ID => [
         'label' => $this->t('Most active', [], ['context' => 'eic_search']),
         'DESC' => $this->t('Most active', [], ['context' => 'eic_search']),
@@ -83,7 +92,7 @@ class UserGallerySourceType extends SourceType {
    * @inheritDoc
    */
   public function getDefaultSort(): array {
-    return [DocumentProcessorInterface::SOLR_MOST_ACTIVE_ID, 'DESC'];
+    return ['team_default_sort', 'ASC'];
   }
 
   /**

--- a/lib/modules/eic_search/src/Service/SolrSearchManager.php
+++ b/lib/modules/eic_search/src/Service/SolrSearchManager.php
@@ -242,6 +242,10 @@ class SolrSearchManager {
     if ($sort_value) {
       $sorts = explode('__', $sort_value);
 
+      if ($this->source instanceof UserGallerySourceType && $sorts[0] == $this->source::TEAM_DEFAULT_SORT) {
+        $sorts[0] = 'its_team_default_sort_' . $this->currentGroup;
+      }
+
       //Normally sort key have this structure 'FIELD__ASC' but add double check
       if (2 === count($sorts)) {
         // Check if sort needs a group injection before sending to solr.


### PR DESCRIPTION
### Tests

- [ ] Go to an organisation members page (_/organisations/<organisation-name>/members_)
- [ ] Edit member A and put it as CEO
- [ ] Edit member B and put as CFO
- [ ] Add a new member C
- [ ] Go to the organisation homepage (_/organisations/<organisation-name>_) and make sure that member A appears first, member in second place and member C appears in last position
