### PR TITLE
EICNET-2729: Add drush command to update organisation owners.

### DIFF
--- a/lib/modules/eic_flags/src/Service/TransferOwnershipRequestHandler.php
+++ b/lib/modules/eic_flags/src/Service/TransferOwnershipRequestHandler.php
@@ -517,7 +517,7 @@ class TransferOwnershipRequestHandler extends AbstractRequestHandler {
    * @param \Drupal\group\Entity\GroupContentInterface $group_content
    *   The group content entity related to the new owner.
    */
-  private function transferGroupOwnership(GroupInterface $group, GroupContentInterface $group_content) {
+  public function transferGroupOwnership(GroupInterface $group, GroupContentInterface $group_content) {
     /** @var \Drupal\group\GroupMembership $old_owner_membership */
     $old_owner_membership = EICGroupsHelper::getGroupOwner($group, TRUE);
 

--- a/lib/modules/eic_groups/drush.services.yml
+++ b/lib/modules/eic_groups/drush.services.yml
@@ -4,3 +4,8 @@ services:
     arguments: ['@entity_type.manager', '@database']
     tags:
       - { name: drush.command }
+  eic_groups.commands.update_organisations_ownership:
+    class: Drupal\eic_groups\Commands\UpdateOrganisationsOwnership
+    arguments: ['@entity_type.manager', '@eic_flags.transfer_ownership_request_handler']
+    tags:
+      - { name: drush.command }

--- a/lib/modules/eic_groups/src/Commands/UpdateOrganisationsOwnership.php
+++ b/lib/modules/eic_groups/src/Commands/UpdateOrganisationsOwnership.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Drupal\eic_groups\Commands;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\eic_flags\Service\TransferOwnershipRequestHandler;
+use Drupal\eic_groups\EICGroupsHelper;
+use Drupal\group\Entity\GroupInterface;
+use Drush\Commands\DrushCommands;
+
+/**
+ * This class provides a drush command to transfer ownership of organisations.
+ *
+ * This will transfer ownership of organisations from Community Manager user
+ * (uid: 3) to the best suited member, in order of preference:
+ *   - CEO
+ *   - CFO
+ *   - Oldest member
+ */
+class UpdateOrganisationsOwnership extends DrushCommands {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The transfer ownership request handler.
+   *
+   * @var \Drupal\eic_flags\Service\TransferOwnershipRequestHandler
+   */
+  protected $transferOwnershipRequestHandler;
+
+  /**
+   * Class constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\eic_flags\Service\TransferOwnershipRequestHandler $transfer_ownership_request_handler
+   *   The transfer ownership request handler.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, TransferOwnershipRequestHandler $transfer_ownership_request_handler) {
+    parent::__construct();
+    $this->entityTypeManager = $entity_type_manager;
+    $this->transferOwnershipRequestHandler = $transfer_ownership_request_handler;
+  }
+
+  /**
+   * Transfers ownership of organisations.
+   *
+   * @usage eic_groups:update-organisations-ownership
+   *   Transfer ownership of organisations from Community Manager user (uid: 3)
+   *   to the best suited member.
+   *
+   * @command eic_groups:update-organisations-ownership
+   * @aliases eic-uporgown
+   */
+  public function actionTransferOrganisationsOwnership() {
+    // Get organisations IDs.
+    $ids = \Drupal::entityQuery('group')
+      ->condition('type', 'organisation')
+      ->accessCheck(FALSE)
+      ->execute();
+
+    $count = count($ids);
+    $updated_groups = 0;
+
+    if ($this->confirm("$count organisations will be checked/updated. Proceed?")) {
+      $this->io()->progressStart($count);
+      foreach ($ids as $id) {
+        $this->io()->progressAdvance();
+        $group = $this->entityTypeManager->getStorage('group')->load($id);
+
+        // Ignore groups that have a different owner from 'Community Manager'.
+        if (EICGroupsHelper::getGroupOwner($group)->id() != 3) {
+          continue;
+        }
+
+        if ($new_owner_membership = $this->determineNewOwner($group)) {
+          $this->transferOwnershipRequestHandler->transferGroupOwnership($group, $new_owner_membership);
+          $updated_groups++;
+        }
+      }
+      $this->io()->progressFinish();
+      $this->io()->success("Transferred ownership for $updated_groups organisations.");
+    }
+  }
+
+  /**
+   * Returns a suitable membership for the given organisation.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group entity.
+   *
+   * @return \Drupal\group\Entity\GroupContentInterface|false
+   *   The group membership of the new owner or FALSE if none could be found.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  protected function determineNewOwner(GroupInterface $group) {
+    // General management / CEO.
+    /** @var \Drupal\group\Entity\GroupContentInterface[] $ceos */
+    $ceos = $this->entityTypeManager->getStorage('group_content')
+      ->loadByProperties([
+        'type' => 'organisation-group_membership',
+        'gid' => $group->id(),
+        'field_vocab_job_title' => 20,
+      ]);
+
+    if (!empty($ceos)) {
+      return reset($ceos);
+    }
+    else {
+      // Accounting / Finance / CFO.
+      /** @var \Drupal\group\Entity\GroupContentInterface[] $cfos */
+      $cfos = $this->entityTypeManager->getStorage('group_content')
+        ->loadByProperties([
+          'type' => 'organisation-group_membership',
+          'gid' => $group->id(),
+          'field_vocab_job_title' => 21,
+        ]);
+      if (!empty($cfos)) {
+        return reset($cfos);
+      }
+      else {
+        /** @var \Drupal\group\Entity\GroupContentInterface[] $old_memberships */
+        $old_memberships = $this->entityTypeManager->getStorage('group_content')
+          ->getQuery()
+          ->condition('type', 'organisation-group_membership')
+          ->condition('gid', $group->id())
+          ->condition('entity_id', 3, '<>')
+          ->sort('created', 'ASC')
+          ->range(0, 1)
+          ->execute();
+        if (!empty($old_memberships)) {
+          /** @var \Drupal\group\Entity\GroupContentInterface $old_membership */
+          return $this->entityTypeManager->getStorage('group_content')->load(reset($old_memberships));
+        }
+      }
+      return FALSE;
+    }
+  }
+
+}


### PR DESCRIPTION
### Tests

- [ ] `drush cr`
- [ ] `drush eic_groups:update-organisations-ownership`
- [ ] `drush cr`
- [ ] `drush sapi-r`
- [ ] `drush sapi-i`
- [ ] Check that most of the organisations have now a new owner instead of "Community manager"

For search re-index, you don't need to wait till the end, luckily group entities are indexed in first place, so you just need to wait the first +/- 8000 items to be indexed.

### Monitoring

You can run the following SQL query before and after to have an overview of oragnisations and owners:
```sql
SELECT gfd.label, ufd.name FROM group_content_field_data gcfd 
INNER JOIN group_content__group_roles gcgr ON gcfd.id = gcgr.entity_id
INNER JOIN groups_field_data gfd ON gfd.id = gcfd.gid
INNER JOIN users_field_data ufd ON gcfd.entity_id = ufd.uid
WHERE gcfd.type = 'organisation-group_membership'
AND gcgr.group_roles_target_id = 'organisation-owner';
```