### PR TITLE
EICNET-2995: Fix layout bug

### DIFF
--- a/lib/themes/eic_community/templates/blocks/block--block-content--latest-news-stories.html.twig
+++ b/lib/themes/eic_community/templates/blocks/block--block-content--latest-news-stories.html.twig
@@ -1,0 +1,12 @@
+<div{{ attributes }}>
+  <div class="ecl-container">
+    {{ title_prefix }}
+    {% if label %}
+      <h2{{ title_attributes }}>{{ label }}</h2>
+    {% endif %}
+    {{ title_suffix }}
+    {% block content %}
+      {{ content }}
+    {% endblock %}
+  </div>
+</div>


### PR DESCRIPTION
Add template for latest-news-stories with missing container so the layout bug is fixed.