### PR TITLE
EICNET-3250: D10 - update required configuration before upgrade

### DIFF
--- a/config/sync/block.block.eic_community_socialshare.yml
+++ b/config/sync/block.block.eic_community_socialshare.yml
@@ -19,8 +19,8 @@ settings:
   label_display: '0'
   provider: oe_webtools_social_share
 visibility:
-  node_type:
-    id: node_type
+  'entity_bundle:node':
+    id: 'entity_bundle:node'
     negate: false
     context_mapping:
       node: '@node.node_route_context:node'

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -244,4 +244,5 @@ theme:
   classy: 0
   seven: 0
   eic_community: 0
+  stable9: 0
 profile: minimal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,15 +37,18 @@ services:
         condition: service_healthy
     env_file:
       - .env
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   mysql:
-    image: percona/percona-server:5.7
+    image: mariadb:10.6
     container_name: ${APP_NAME}_mysql
     ports:
       - ${DATABASE_PORT}:3306
-    command: --innodb-log-file-size=1G --max_allowed_packet=1G --innodb-buffer-pool-size=512M --wait_timeout=3000 --net_write_timeout=3000 --log_error_verbosity=3
+    command: --transaction-isolation=READ-COMMITTED --innodb-log-file-size=1G --max_allowed_packet=1G --innodb-buffer-pool-size=512M --wait_timeout=3000 --net_write_timeout=3000
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+      MYSQL_DATABASE: ${DRUPAL_DATABASE_NAME}
     volumes:
       - mysql_data:/var/lib/mysql
     healthcheck:


### PR DESCRIPTION
1. Enabling `stable9` theme, that will be set as base theme for `eic_community` theme
2. Changing the condition plugin for block "Social Share" from the deprecated `node_type` to `entity_bundle:node`
