### PR TITLE
EICNET-3445: Uninstall oembed ckeditor module.

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -26,7 +26,6 @@ module:
   ckeditor_find: 0
   ckeditor_font: 0
   ckeditor_iframe: 0
-  ckeditor_oembed: 0
   ckeditor_selectall: 0
   colorbutton: 0
   comment: 0


### PR DESCRIPTION
Once merged, the follow up pull request that removes composer dependency can also be merged

Follow up PR: https://github.com/EIC-EA/EIC-community-D8/pull/2397